### PR TITLE
Add Skills Compare Next.js MVP with mock courses and 2-course comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,62 @@
+# Skills Compare (MVP)
+
+MVP funcional para validar la web app **Skills Compare**. Permite buscar una skill, explorar cursos mock, ver detalles y comparar exactamente 2 cursos.
+
+## 🚀 Cómo instalar y correr
+
+```bash
+npm install
+npm run dev
+```
+
+La app corre en `http://localhost:3000`.
+
+## 📁 Estructura del proyecto
+
+```
+next-env.d.ts
+next.config.js
+package.json
+postcss.config.js
+tailwind.config.js
+tsconfig.json
+.gitkeep
+app/
+  compare/page.tsx
+  courses/[courseId]/page.tsx
+  skills/[skillSlug]/page.tsx
+  globals.css
+  layout.tsx
+  page.tsx
+src/
+  components/
+    CompareBar.tsx
+    CourseCard.tsx
+    Filters.tsx
+    SearchBar.tsx
+  data/
+    courses.ts
+  hooks/
+    useCompareSelection.ts
+  types/
+    course.ts
+  utils/
+    slugify.ts
+```
+
+## ✅ Qué incluye el MVP
+
+- Búsqueda de skills con sugerencias rápidas.
+- Listado de cursos con filtros client-side.
+- Detalle de curso con objetivos, requisitos y temario.
+- Comparativa de 2 cursos usando query string.
+- Datos mock locales (sin APIs externas).
+
+## ❗ Qué falta para producción
+
+- Integración con APIs reales (Coursera/Udemy/edX/Microsoft Learn).
+- Sistema de afiliados y tracking de conversiones.
+- SEO avanzado (metadatos dinámicos, Open Graph, sitemap).
+- Analítica de producto (eventos, funnels, métricas).
+- Autenticación y perfiles (si fuese necesario).
+- Tests automatizados y CI/CD.

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useMemo } from "react";
+import { courses } from "@/data/courses";
+
+const LAST_SKILL_KEY = "skills-compare-last-skill";
+
+export default function ComparePage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const idsParam = searchParams.get("ids") ?? "";
+
+  const ids = useMemo(() => idsParam.split(",").filter(Boolean), [idsParam]);
+  const [leftId, rightId] = ids;
+  const leftCourse = courses.find((course) => course.id === leftId);
+  const rightCourse = courses.find((course) => course.id === rightId);
+
+  const hasTwoCourses = ids.length === 2 && leftCourse && rightCourse;
+
+  const handleChangeCourses = () => {
+    if (typeof window === "undefined") {
+      router.push("/");
+      return;
+    }
+    const lastSkill = window.localStorage.getItem(LAST_SKILL_KEY);
+    if (lastSkill) {
+      router.push(`/skills/${lastSkill}`);
+    } else {
+      router.push("/");
+    }
+  };
+
+  if (!hasTwoCourses) {
+    return (
+      <section className="flex flex-col items-center gap-4 rounded-2xl border border-dashed border-slate-300 bg-white p-10 text-center">
+        <h2 className="text-2xl font-semibold text-slate-900">
+          Selecciona 2 cursos para comparar
+        </h2>
+        <p className="text-slate-600">
+          Vuelve al listado y selecciona exactamente dos cursos.
+        </p>
+        <Link
+          href="/"
+          className="rounded-lg bg-slate-900 px-5 py-2 text-sm font-semibold text-white"
+        >
+          Ir al Home
+        </Link>
+      </section>
+    );
+  }
+
+  const rows = [
+    { label: "Plataforma", left: leftCourse.platform, right: rightCourse.platform },
+    { label: "Precio", left: leftCourse.priceText, right: rightCourse.priceText },
+    { label: "Duración", left: leftCourse.durationText, right: rightCourse.durationText },
+    { label: "Nivel", left: leftCourse.level, right: rightCourse.level },
+    {
+      label: "Rating",
+      left: leftCourse.rating ? leftCourse.rating.toFixed(1) : "Sin rating",
+      right: rightCourse.rating ? rightCourse.rating.toFixed(1) : "Sin rating"
+    },
+    { label: "Idioma", left: leftCourse.language, right: rightCourse.language },
+    {
+      label: "Certificado",
+      left: leftCourse.certificate ? "Sí" : "No",
+      right: rightCourse.certificate ? "Sí" : "No"
+    },
+    {
+      label: "Puntos clave",
+      left: leftCourse.syllabusBullets.slice(0, 3).join(" · "),
+      right: rightCourse.syllabusBullets.slice(0, 3).join(" · ")
+    }
+  ];
+
+  return (
+    <section className="flex flex-col gap-8">
+      <div className="flex flex-col gap-3">
+        <h2 className="text-3xl font-semibold text-slate-900">
+          Comparativa de cursos
+        </h2>
+        <p className="text-slate-600">
+          Revisa rápidamente las diferencias clave entre ambos cursos.
+        </p>
+      </div>
+
+      <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <div className="grid grid-cols-3 gap-4 border-b border-slate-200 bg-slate-50 px-6 py-4 text-sm font-semibold text-slate-700">
+          <span>Detalle</span>
+          <span>{leftCourse.title}</span>
+          <span>{rightCourse.title}</span>
+        </div>
+        <div className="divide-y divide-slate-200">
+          {rows.map((row) => (
+            <div
+              key={row.label}
+              className="grid grid-cols-3 gap-4 px-6 py-4 text-sm text-slate-600"
+            >
+              <span className="font-semibold text-slate-700">{row.label}</span>
+              <span>{row.left}</span>
+              <span>{row.right}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={handleChangeCourses}
+        className="w-fit rounded-lg border border-slate-200 px-5 py-2 text-sm font-semibold text-slate-700 hover:border-slate-300"
+      >
+        Cambiar cursos
+      </button>
+    </section>
+  );
+}

--- a/app/courses/[courseId]/page.tsx
+++ b/app/courses/[courseId]/page.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useMemo } from "react";
+import { courses } from "@/data/courses";
+import { useCompareSelection } from "@/hooks/useCompareSelection";
+
+export default function CourseDetailPage() {
+  const params = useParams();
+  const courseId = Array.isArray(params.courseId)
+    ? params.courseId[0]
+    : params.courseId;
+
+  const course = useMemo(
+    () => courses.find((item) => item.id === courseId),
+    [courseId]
+  );
+
+  const { toggle, isSelected, selectedIds } = useCompareSelection();
+  const objectives = course ? course.syllabusBullets.slice(0, 3) : [];
+
+  if (!course) {
+    return (
+      <section className="flex flex-col items-center gap-4 rounded-2xl border border-dashed border-slate-300 bg-white p-10 text-center">
+        <h2 className="text-2xl font-semibold text-slate-900">
+          Curso no encontrado
+        </h2>
+        <p className="text-slate-600">
+          Revisa el ID del curso o vuelve al inicio.
+        </p>
+        <Link
+          href="/"
+          className="rounded-lg bg-slate-900 px-5 py-2 text-sm font-semibold text-white"
+        >
+          Ir al Home
+        </Link>
+      </section>
+    );
+  }
+
+  const selected = isSelected(course.id);
+  const disabled = !selected && selectedIds.length >= 2;
+
+  return (
+    <section className="flex flex-col gap-8">
+      <div className="space-y-3">
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">
+          Curso
+        </p>
+        <h2 className="text-3xl font-semibold text-slate-900">{course.title}</h2>
+        <p className="text-slate-600">{course.shortDescription}</p>
+        <div className="flex flex-wrap gap-2 text-sm text-slate-600">
+          <span className="rounded-full bg-slate-100 px-3 py-1">
+            {course.platform}
+          </span>
+          <span className="rounded-full bg-slate-100 px-3 py-1">
+            {course.level}
+          </span>
+          <span className="rounded-full bg-slate-100 px-3 py-1">
+            {course.durationText}
+          </span>
+          <span className="rounded-full bg-slate-100 px-3 py-1">
+            {course.priceText}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={() => toggle(course.id)}
+          disabled={disabled}
+          className={`w-fit rounded-lg px-5 py-2 text-sm font-semibold text-white transition ${
+            selected ? "bg-emerald-600 hover:bg-emerald-500" : "bg-slate-900 hover:bg-slate-800"
+          } ${disabled ? "bg-slate-300" : ""}`}
+        >
+          {selected ? "Seleccionado para comparar" : "Agregar a comparación"}
+        </button>
+        {disabled ? (
+          <p className="text-xs text-amber-600">
+            Ya tienes 2 cursos seleccionados.
+          </p>
+        ) : null}
+      </div>
+
+      <div className="grid gap-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm md:grid-cols-2">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900">Objetivos</h3>
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-600">
+            {objectives.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900">Requisitos</h3>
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-600">
+            {course.prerequisitesBullets.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900">Temario resumido</h3>
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-600">
+            {course.syllabusBullets.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900">Detalles</h3>
+          <div className="mt-3 space-y-2 text-sm text-slate-600">
+            <p>
+              <span className="font-semibold text-slate-800">Idioma:</span> {course.language}
+            </p>
+            <p>
+              <span className="font-semibold text-slate-800">Certificado:</span>{" "}
+              {course.certificate ? "Sí" : "No"}
+            </p>
+            {course.rating ? (
+              <p>
+                <span className="font-semibold text-slate-800">Rating:</span> {course.rating.toFixed(1)}
+              </p>
+            ) : null}
+            <p>
+              <span className="font-semibold text-slate-800">Link externo:</span>{" "}
+              <a
+                href={course.externalUrl}
+                className="text-slate-900 underline"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Ver curso
+              </a>
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <Link
+        href="/"
+        className="text-sm font-semibold text-slate-600 hover:text-slate-900"
+      >
+        ← Volver al Home
+      </Link>
+    </section>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-slate-50 text-slate-900;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Skills Compare",
+  description: "Compara cursos y aprende nuevas skills de forma rápida"
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="es">
+      <body className="min-h-screen">
+        <div className="mx-auto flex min-h-screen max-w-6xl flex-col px-6">
+          <header className="flex items-center justify-between border-b border-slate-200 py-6">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-500">
+                Skills Compare
+              </p>
+              <h1 className="text-xl font-semibold">Encuentra el curso ideal</h1>
+            </div>
+            <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
+              MVP
+            </span>
+          </header>
+          <main className="flex-1 py-8">{children}</main>
+          <footer className="border-t border-slate-200 py-6 text-sm text-slate-500">
+            MVP para validar Skills Compare. Sin afiliados ni datos externos.
+          </footer>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { SearchBar } from "@/components/SearchBar";
+import { slugify } from "@/utils/slugify";
+
+const suggestions = [
+  "AI Fundamentals",
+  "Prompt Engineering",
+  "LLMs",
+  "Machine Learning"
+];
+
+export default function HomePage() {
+  const router = useRouter();
+
+  const handleSearch = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return;
+    }
+    router.push(`/skills/${slugify(trimmed)}`);
+  };
+
+  return (
+    <section className="flex flex-col gap-8">
+      <div className="space-y-3">
+        <h2 className="text-3xl font-semibold text-slate-900">
+          ¿Qué skill quieres aprender?
+        </h2>
+        <p className="text-slate-600">
+          Busca una skill para ver cursos recomendados y compararlos rápidamente.
+        </p>
+      </div>
+
+      <SearchBar
+        placeholder="Ej: Prompt Engineering"
+        onSearch={handleSearch}
+      />
+
+      <div className="flex flex-wrap gap-2">
+        {suggestions.map((skill) => (
+          <button
+            key={skill}
+            type="button"
+            onClick={() => router.push(`/skills/${slugify(skill)}`)}
+            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300"
+          >
+            {skill}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/skills/[skillSlug]/page.tsx
+++ b/app/skills/[skillSlug]/page.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import { CourseCard } from "@/components/CourseCard";
+import { Filters } from "@/components/Filters";
+import { CompareBar } from "@/components/CompareBar";
+import { courses } from "@/data/courses";
+import { slugify, titleFromSlug } from "@/utils/slugify";
+
+const LAST_SKILL_KEY = "skills-compare-last-skill";
+
+type FiltersState = {
+  platform: string;
+  level: string;
+  priceType: string;
+};
+
+export default function SkillPage() {
+  const params = useParams();
+  const skillSlug = Array.isArray(params.skillSlug)
+    ? params.skillSlug[0]
+    : params.skillSlug;
+  const [filters, setFilters] = useState<FiltersState>({
+    platform: "All",
+    level: "All",
+    priceType: "All"
+  });
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && skillSlug) {
+      window.localStorage.setItem(LAST_SKILL_KEY, skillSlug);
+    }
+  }, [skillSlug]);
+
+  const skillTitle = titleFromSlug(skillSlug ?? "");
+
+  const filteredCourses = useMemo(() => {
+    if (!skillSlug) {
+      return [];
+    }
+    return courses
+      .filter((course) =>
+        course.skillTags.some((tag) => slugify(tag) === skillSlug)
+      )
+      .filter((course) =>
+        filters.platform === "All" ? true : course.platform === filters.platform
+      )
+      .filter((course) =>
+        filters.level === "All" ? true : course.level === filters.level
+      )
+      .filter((course) => {
+        if (filters.priceType === "All") {
+          return true;
+        }
+        return filters.priceType === "Free"
+          ? course.priceType === "free"
+          : course.priceType === "paid";
+      });
+  }, [filters.level, filters.platform, filters.priceType, skillSlug]);
+
+  return (
+    <section className="flex flex-col gap-8 pb-24">
+      <div>
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">
+          Skill
+        </p>
+        <h2 className="text-3xl font-semibold text-slate-900">{skillTitle}</h2>
+        <p className="mt-2 text-slate-600">
+          Filtra y compara cursos para esta skill.
+        </p>
+      </div>
+
+      <Filters value={filters} onChange={setFilters} />
+
+      {filteredCourses.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center text-slate-600">
+          No encontramos cursos con esos filtros. Prueba otra combinación.
+        </div>
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-2">
+          {filteredCourses.map((course) => (
+            <CourseCard key={course.id} course={course} />
+          ))}
+        </div>
+      )}
+
+      <CompareBar />
+    </section>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "skills-compare",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.20",
+    "postcss": "8.4.41",
+    "tailwindcss": "3.4.10",
+    "typescript": "5.5.4"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCompareSelection } from "@/hooks/useCompareSelection";
+
+export const CompareBar = () => {
+  const router = useRouter();
+  const { selectedIds, clear } = useCompareSelection();
+  const enabled = selectedIds.length === 2;
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-20 border-t border-slate-200 bg-white/95 backdrop-blur">
+      <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-6 py-4 sm:flex-row">
+        <div>
+          <p className="text-sm font-semibold text-slate-900">
+            Comparar ({selectedIds.length})
+          </p>
+          <p className="text-xs text-slate-500">
+            Selecciona exactamente 2 cursos para comparar.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={clear}
+            className="text-xs font-semibold text-slate-500 hover:text-slate-700"
+          >
+            Limpiar selección
+          </button>
+          <button
+            type="button"
+            disabled={!enabled}
+            onClick={() =>
+              router.push(`/compare?ids=${selectedIds[0]},${selectedIds[1]}`)
+            }
+            className={`rounded-xl px-5 py-2 text-sm font-semibold text-white transition ${
+              enabled ? "bg-slate-900 hover:bg-slate-800" : "bg-slate-300"
+            }`}
+          >
+            Comparar ahora
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Link from "next/link";
+import { Course } from "@/types/course";
+import { useCompareSelection } from "@/hooks/useCompareSelection";
+
+type CourseCardProps = {
+  course: Course;
+};
+
+export const CourseCard = ({ course }: CourseCardProps) => {
+  const { toggle, isSelected, selectedIds } = useCompareSelection();
+  const selected = isSelected(course.id);
+  const disabled = !selected && selectedIds.length >= 2;
+
+  return (
+    <div className="flex h-full flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900">{course.title}</h3>
+          <p className="text-sm text-slate-500">
+            {course.platform} · {course.level}
+          </p>
+        </div>
+        {course.rating ? (
+          <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
+            ⭐ {course.rating.toFixed(1)}
+          </span>
+        ) : null}
+      </div>
+      <p className="text-sm text-slate-600">{course.shortDescription}</p>
+      <div className="grid gap-2 text-sm text-slate-600">
+        <div className="flex items-center justify-between">
+          <span>Duración</span>
+          <span className="font-medium text-slate-800">{course.durationText}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span>Precio</span>
+          <span className="font-medium text-slate-800">{course.priceText}</span>
+        </div>
+      </div>
+      <div className="mt-auto flex items-center justify-between gap-3">
+        <Link
+          href={`/courses/${course.id}`}
+          className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:border-slate-300"
+        >
+          Ver
+        </Link>
+        <label className="flex items-center gap-2 text-sm text-slate-600">
+          <input
+            type="checkbox"
+            checked={selected}
+            disabled={disabled}
+            onChange={() => toggle(course.id)}
+            className="h-4 w-4 rounded border-slate-300 text-slate-900"
+          />
+          Agregar a comparación
+        </label>
+      </div>
+      {disabled ? (
+        <p className="text-xs text-amber-600">
+          Solo puedes comparar 2 cursos a la vez.
+        </p>
+      ) : null}
+    </div>
+  );
+};

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+type FiltersState = {
+  platform: string;
+  level: string;
+  priceType: string;
+};
+
+type FiltersProps = {
+  value: FiltersState;
+  onChange: (next: FiltersState) => void;
+};
+
+const platforms = ["All", "Coursera", "Udemy", "Microsoft Learn", "edX"];
+const levels = ["All", "Beginner", "Intermediate", "Advanced"];
+const prices = ["All", "Free", "Paid"];
+
+export const Filters = ({ value, onChange }: FiltersProps) => {
+  return (
+    <div className="grid gap-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm md:grid-cols-3">
+      <label className="flex flex-col gap-2 text-sm font-medium text-slate-600">
+        Plataforma
+        <select
+          value={value.platform}
+          onChange={(event) =>
+            onChange({ ...value, platform: event.target.value })
+          }
+          className="rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700"
+        >
+          {platforms.map((platform) => (
+            <option key={platform} value={platform}>
+              {platform}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex flex-col gap-2 text-sm font-medium text-slate-600">
+        Nivel
+        <select
+          value={value.level}
+          onChange={(event) => onChange({ ...value, level: event.target.value })}
+          className="rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700"
+        >
+          {levels.map((level) => (
+            <option key={level} value={level}>
+              {level}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex flex-col gap-2 text-sm font-medium text-slate-600">
+        Precio
+        <select
+          value={value.priceType}
+          onChange={(event) =>
+            onChange({ ...value, priceType: event.target.value })
+          }
+          className="rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700"
+        >
+          {prices.map((price) => (
+            <option key={price} value={price}>
+              {price}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+};

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState } from "react";
+
+type SearchBarProps = {
+  placeholder?: string;
+  onSearch: (value: string) => void;
+};
+
+export const SearchBar = ({ placeholder, onSearch }: SearchBarProps) => {
+  const [value, setValue] = useState("");
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+      <input
+        type="text"
+        className="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm focus:border-slate-400 focus:outline-none"
+        placeholder={placeholder}
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+      />
+      <button
+        type="button"
+        onClick={() => onSearch(value)}
+        className="rounded-xl bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+      >
+        Buscar
+      </button>
+    </div>
+  );
+};

--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -1,0 +1,464 @@
+import { Course } from "@/types/course";
+
+export const courses: Course[] = [
+  {
+    id: "ai-fundamentals-01",
+    title: "AI Fundamentals: Concepts and Use Cases",
+    platform: "Coursera",
+    skillTags: ["AI Fundamentals", "Machine Learning"],
+    level: "Beginner",
+    priceType: "paid",
+    priceText: "Suscripción mensual",
+    durationText: "4 semanas",
+    rating: 4.6,
+    language: "Español",
+    certificate: true,
+    shortDescription:
+      "Introducción práctica a la IA, sus aplicaciones y el ciclo de vida de proyectos.",
+    syllabusBullets: [
+      "Historia y conceptos base de IA",
+      "Tipos de aprendizaje y casos reales",
+      "Ética y consideraciones de negocio",
+      "Flujo de trabajo de proyectos"
+    ],
+    prerequisitesBullets: ["Curiosidad por la tecnología", "No requiere experiencia previa"],
+    externalUrl: "https://example.com/ai-fundamentals"
+  },
+  {
+    id: "prompt-engineering-01",
+    title: "Prompt Engineering Essentials",
+    platform: "Udemy",
+    skillTags: ["Prompt Engineering", "LLMs"],
+    level: "Beginner",
+    priceType: "paid",
+    priceText: "Pago único",
+    durationText: "3 horas",
+    rating: 4.4,
+    language: "Español",
+    certificate: true,
+    shortDescription:
+      "Domina técnicas de prompts para lograr mejores resultados con modelos generativos.",
+    syllabusBullets: [
+      "Estructura de prompts efectivos",
+      "Iteración y evaluación",
+      "Prompts para tareas comunes",
+      "Errores habituales"
+    ],
+    prerequisitesBullets: ["Uso básico de herramientas de IA"],
+    externalUrl: "https://example.com/prompt-essentials"
+  },
+  {
+    id: "llm-practitioner-01",
+    title: "LLM Practitioner: From API to App",
+    platform: "edX",
+    skillTags: ["LLMs", "AI Fundamentals"],
+    level: "Intermediate",
+    priceType: "paid",
+    priceText: "Pago único",
+    durationText: "6 semanas",
+    rating: 4.5,
+    language: "Inglés",
+    certificate: true,
+    shortDescription:
+      "Aprende a integrar modelos de lenguaje en productos reales con enfoque práctico.",
+    syllabusBullets: [
+      "Conceptos clave de LLMs",
+      "Diseño de flujos conversacionales",
+      "Evaluación de resultados",
+      "Buenas prácticas de producto"
+    ],
+    prerequisitesBullets: ["Conocimientos básicos de programación"],
+    externalUrl: "https://example.com/llm-practitioner"
+  },
+  {
+    id: "ml-bootcamp-01",
+    title: "Machine Learning Bootcamp",
+    platform: "Coursera",
+    skillTags: ["Machine Learning", "AI Fundamentals"],
+    level: "Intermediate",
+    priceType: "paid",
+    priceText: "Suscripción mensual",
+    durationText: "8 semanas",
+    rating: 4.7,
+    language: "Inglés",
+    certificate: true,
+    shortDescription:
+      "Fundamentos y práctica de modelos de ML con un enfoque aplicado.",
+    syllabusBullets: [
+      "Preparación de datos",
+      "Modelos supervisados",
+      "Evaluación y métricas",
+      "Pipeline básico"
+    ],
+    prerequisitesBullets: ["Álgebra básica", "Conocimientos de Python"],
+    externalUrl: "https://example.com/ml-bootcamp"
+  },
+  {
+    id: "ai-product-01",
+    title: "AI Product Strategy",
+    platform: "Microsoft Learn",
+    skillTags: ["AI Fundamentals"],
+    level: "Beginner",
+    priceType: "free",
+    priceText: "Gratis",
+    durationText: "2 horas",
+    rating: 4.2,
+    language: "Español",
+    certificate: false,
+    shortDescription:
+      "Cómo identificar oportunidades de IA y convertirlas en productos viables.",
+    syllabusBullets: [
+      "Identificación de casos de uso",
+      "Métricas de éxito",
+      "Riesgos y gobernanza",
+      "Roadmap inicial"
+    ],
+    prerequisitesBullets: ["Interés en producto digital"],
+    externalUrl: "https://example.com/ai-product"
+  },
+  {
+    id: "genai-starter-01",
+    title: "Generative AI Starter",
+    platform: "edX",
+    skillTags: ["AI Fundamentals", "Prompt Engineering"],
+    level: "Beginner",
+    priceType: "free",
+    priceText: "Gratis",
+    durationText: "1 semana",
+    rating: 4.1,
+    language: "Inglés",
+    certificate: false,
+    shortDescription:
+      "Panorama de IA generativa, usos y límites para empezar con claridad.",
+    syllabusBullets: [
+      "Conceptos de IA generativa",
+      "Aplicaciones comunes",
+      "Riesgos y ética",
+      "Primeros prompts"
+    ],
+    prerequisitesBullets: ["No requiere experiencia previa"],
+    externalUrl: "https://example.com/genai-starter"
+  },
+  {
+    id: "prompt-advanced-01",
+    title: "Advanced Prompt Engineering",
+    platform: "Udemy",
+    skillTags: ["Prompt Engineering", "LLMs"],
+    level: "Advanced",
+    priceType: "paid",
+    priceText: "Pago único",
+    durationText: "5 horas",
+    rating: 4.8,
+    language: "Inglés",
+    certificate: true,
+    shortDescription:
+      "Estrategias avanzadas para prompts complejos y flujos de trabajo críticos.",
+    syllabusBullets: [
+      "Prompts multi paso",
+      "Control de tono y formato",
+      "Testing y métricas",
+      "Optimización iterativa"
+    ],
+    prerequisitesBullets: ["Experiencia previa con prompts"],
+    externalUrl: "https://example.com/prompt-advanced"
+  },
+  {
+    id: "ml-ops-basics-01",
+    title: "ML Ops Basics",
+    platform: "Microsoft Learn",
+    skillTags: ["Machine Learning", "AI Fundamentals"],
+    level: "Intermediate",
+    priceType: "free",
+    priceText: "Gratis",
+    durationText: "3 horas",
+    rating: 4.0,
+    language: "Español",
+    certificate: false,
+    shortDescription:
+      "Introducción al despliegue y monitoreo de modelos de ML.",
+    syllabusBullets: [
+      "Ciclo de vida de ML",
+      "Deploy inicial",
+      "Monitoreo básico",
+      "Colaboración entre equipos"
+    ],
+    prerequisitesBullets: ["Conocimientos básicos de ML"],
+    externalUrl: "https://example.com/ml-ops"
+  },
+  {
+    id: "llm-evaluation-01",
+    title: "LLM Evaluation and Quality",
+    platform: "Coursera",
+    skillTags: ["LLMs"],
+    level: "Advanced",
+    priceType: "paid",
+    priceText: "Suscripción mensual",
+    durationText: "4 semanas",
+    rating: 4.5,
+    language: "Inglés",
+    certificate: true,
+    shortDescription:
+      "Técnicas para evaluar calidad y seguridad en respuestas de LLMs.",
+    syllabusBullets: [
+      "Métricas automáticas",
+      "Evaluación humana",
+      "Sesgos y seguridad",
+      "Checklist de calidad"
+    ],
+    prerequisitesBullets: ["Experiencia con LLMs", "Conocimientos de métricas"],
+    externalUrl: "https://example.com/llm-evaluation"
+  },
+  {
+    id: "ai-for-business-01",
+    title: "AI for Business Leaders",
+    platform: "edX",
+    skillTags: ["AI Fundamentals"],
+    level: "Beginner",
+    priceType: "paid",
+    priceText: "Pago único",
+    durationText: "2 semanas",
+    rating: 4.3,
+    language: "Español",
+    certificate: true,
+    shortDescription:
+      "Comprende el impacto de la IA en procesos y modelos de negocio.",
+    syllabusBullets: [
+      "Casos de uso en industrias",
+      "ROI y viabilidad",
+      "Gestión del cambio",
+      "Riesgos legales"
+    ],
+    prerequisitesBullets: ["Experiencia en negocio o management"],
+    externalUrl: "https://example.com/ai-business"
+  },
+  {
+    id: "ml-math-01",
+    title: "Math for Machine Learning",
+    platform: "Coursera",
+    skillTags: ["Machine Learning"],
+    level: "Intermediate",
+    priceType: "paid",
+    priceText: "Suscripción mensual",
+    durationText: "5 semanas",
+    rating: 4.6,
+    language: "Inglés",
+    certificate: true,
+    shortDescription:
+      "Refuerza bases matemáticas clave para entender modelos de ML.",
+    syllabusBullets: [
+      "Álgebra lineal aplicada",
+      "Probabilidad",
+      "Optimización",
+      "Derivadas útiles"
+    ],
+    prerequisitesBullets: ["Bases de matemática", "Interés en ML"],
+    externalUrl: "https://example.com/ml-math"
+  },
+  {
+    id: "ai-ethics-01",
+    title: "Responsible AI & Ethics",
+    platform: "Microsoft Learn",
+    skillTags: ["AI Fundamentals"],
+    level: "Beginner",
+    priceType: "free",
+    priceText: "Gratis",
+    durationText: "2 horas",
+    rating: 4.2,
+    language: "Español",
+    certificate: false,
+    shortDescription:
+      "Principios de IA responsable para productos y equipos.",
+    syllabusBullets: [
+      "Principios de responsabilidad",
+      "Sesgos comunes",
+      "Transparencia",
+      "Checklist práctico"
+    ],
+    prerequisitesBullets: ["Interés en ética y tecnología"],
+    externalUrl: "https://example.com/ai-ethics"
+  },
+  {
+    id: "nlp-essentials-01",
+    title: "NLP Essentials",
+    platform: "Udemy",
+    skillTags: ["LLMs", "Machine Learning"],
+    level: "Intermediate",
+    priceType: "paid",
+    priceText: "Pago único",
+    durationText: "6 horas",
+    rating: 4.4,
+    language: "Español",
+    certificate: true,
+    shortDescription:
+      "Conceptos base de procesamiento de lenguaje natural y sus aplicaciones.",
+    syllabusBullets: [
+      "Tokenización y vectores",
+      "Modelos clásicos",
+      "Evaluación",
+      "Aplicaciones prácticas"
+    ],
+    prerequisitesBullets: ["Python básico", "Estadística básica"],
+    externalUrl: "https://example.com/nlp-essentials"
+  },
+  {
+    id: "llm-product-01",
+    title: "Building Products with LLMs",
+    platform: "Coursera",
+    skillTags: ["LLMs", "Prompt Engineering"],
+    level: "Intermediate",
+    priceType: "paid",
+    priceText: "Suscripción mensual",
+    durationText: "4 semanas",
+    rating: 4.5,
+    language: "Inglés",
+    certificate: true,
+    shortDescription:
+      "Diseña experiencias y flujos de producto usando LLMs.",
+    syllabusBullets: [
+      "Mapeo de journeys",
+      "Diseño de prompts",
+      "Evaluación de UX",
+      "Métricas de impacto"
+    ],
+    prerequisitesBullets: ["Experiencia en producto o UX"],
+    externalUrl: "https://example.com/llm-product"
+  },
+  {
+    id: "ai-data-ready-01",
+    title: "Data Readiness for AI",
+    platform: "edX",
+    skillTags: ["AI Fundamentals", "Machine Learning"],
+    level: "Intermediate",
+    priceType: "paid",
+    priceText: "Pago único",
+    durationText: "3 semanas",
+    rating: 4.1,
+    language: "Inglés",
+    certificate: true,
+    shortDescription:
+      "Aprende a preparar datos y procesos para proyectos de IA.",
+    syllabusBullets: [
+      "Calidad de datos",
+      "Gobernanza",
+      "Estrategia de datos",
+      "Roles y responsabilidades"
+    ],
+    prerequisitesBullets: ["Conocimientos básicos de datos"],
+    externalUrl: "https://example.com/data-ready"
+  },
+  {
+    id: "ml-foundations-01",
+    title: "Machine Learning Foundations",
+    platform: "Microsoft Learn",
+    skillTags: ["Machine Learning"],
+    level: "Beginner",
+    priceType: "free",
+    priceText: "Gratis",
+    durationText: "4 horas",
+    rating: 4.3,
+    language: "Español",
+    certificate: false,
+    shortDescription:
+      "Primeros pasos con modelos de aprendizaje automático.",
+    syllabusBullets: [
+      "Conceptos clave",
+      "Tipos de modelos",
+      "Ciclo de entrenamiento",
+      "Buenas prácticas"
+    ],
+    prerequisitesBullets: ["No requiere experiencia previa"],
+    externalUrl: "https://example.com/ml-foundations"
+  },
+  {
+    id: "ai-design-01",
+    title: "Designing AI Experiences",
+    platform: "Udemy",
+    skillTags: ["AI Fundamentals", "Prompt Engineering"],
+    level: "Intermediate",
+    priceType: "paid",
+    priceText: "Pago único",
+    durationText: "4 horas",
+    rating: 4.2,
+    language: "Español",
+    certificate: true,
+    shortDescription:
+      "Diseña interfaces y flujos que aprovechen IA de forma clara.",
+    syllabusBullets: [
+      "Principios de diseño",
+      "Conversaciones útiles",
+      "Feedback y corrección",
+      "Iteración rápida"
+    ],
+    prerequisitesBullets: ["Conocimientos de UX"],
+    externalUrl: "https://example.com/ai-design"
+  },
+  {
+    id: "llm-safety-01",
+    title: "LLM Safety Essentials",
+    platform: "edX",
+    skillTags: ["LLMs"],
+    level: "Advanced",
+    priceType: "paid",
+    priceText: "Pago único",
+    durationText: "3 semanas",
+    rating: 4.4,
+    language: "Inglés",
+    certificate: true,
+    shortDescription:
+      "Mitigación de riesgos y seguridad en aplicaciones con LLMs.",
+    syllabusBullets: [
+      "Riesgos comunes",
+      "Red teaming básico",
+      "Políticas y controles",
+      "Evaluación continua"
+    ],
+    prerequisitesBullets: ["Experiencia previa con LLMs"],
+    externalUrl: "https://example.com/llm-safety"
+  },
+  {
+    id: "prompt-team-01",
+    title: "Prompt Collaboration for Teams",
+    platform: "Coursera",
+    skillTags: ["Prompt Engineering"],
+    level: "Beginner",
+    priceType: "paid",
+    priceText: "Suscripción mensual",
+    durationText: "2 semanas",
+    rating: 4.0,
+    language: "Español",
+    certificate: true,
+    shortDescription:
+      "Estándares y colaboración para equipos que trabajan con prompts.",
+    syllabusBullets: [
+      "Estructuras compartidas",
+      "Documentación",
+      "Revisión en equipo",
+      "Buenas prácticas"
+    ],
+    prerequisitesBullets: ["Trabajo en equipos digitales"],
+    externalUrl: "https://example.com/prompt-team"
+  },
+  {
+    id: "ai-roadmap-01",
+    title: "AI Roadmap Planning",
+    platform: "Microsoft Learn",
+    skillTags: ["AI Fundamentals"],
+    level: "Intermediate",
+    priceType: "free",
+    priceText: "Gratis",
+    durationText: "3 horas",
+    rating: 4.1,
+    language: "Español",
+    certificate: false,
+    shortDescription:
+      "Planificación de un roadmap de IA alineado a objetivos de negocio.",
+    syllabusBullets: [
+      "Priorizar iniciativas",
+      "Definir métricas",
+      "Plan de adopción",
+      "Ejecución gradual"
+    ],
+    prerequisitesBullets: ["Experiencia en liderazgo o gestión"],
+    externalUrl: "https://example.com/ai-roadmap"
+  }
+];

--- a/src/hooks/useCompareSelection.ts
+++ b/src/hooks/useCompareSelection.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+const STORAGE_KEY = "skills-compare-selection";
+
+const readSelection = () => {
+  if (typeof window === "undefined") {
+    return [] as string[];
+  }
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (!stored) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+export const useCompareSelection = () => {
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    setSelectedIds(readSelection());
+  }, []);
+
+  const persist = useCallback((ids: string[]) => {
+    setSelectedIds(ids);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+    }
+  }, []);
+
+  const toggle = useCallback(
+    (id: string) => {
+      const current = readSelection();
+      const next = current.includes(id)
+        ? current.filter((item) => item !== id)
+        : [...current, id];
+      persist(next.slice(0, 2));
+    },
+    [persist]
+  );
+
+  const clear = useCallback(() => {
+    persist([]);
+  }, [persist]);
+
+  const isSelected = useCallback(
+    (id: string) => selectedIds.includes(id),
+    [selectedIds]
+  );
+
+  return useMemo(
+    () => ({ selectedIds, toggle, clear, isSelected }),
+    [selectedIds, toggle, clear, isSelected]
+  );
+};

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -1,0 +1,17 @@
+export type Course = {
+  id: string;
+  title: string;
+  platform: "Coursera" | "Udemy" | "Microsoft Learn" | "edX";
+  skillTags: string[];
+  level: "Beginner" | "Intermediate" | "Advanced";
+  priceType: "free" | "paid";
+  priceText: string;
+  durationText: string;
+  rating?: number;
+  language: string;
+  certificate: boolean;
+  shortDescription: string;
+  syllabusBullets: string[];
+  prerequisitesBullets: string[];
+  externalUrl: string;
+};

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,0 +1,13 @@
+export const slugify = (value: string) =>
+  value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+
+export const titleFromSlug = (slug: string) =>
+  slug
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}"
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["src/components/*"],
+      "@/data/*": ["src/data/*"],
+      "@/types/*": ["src/types/*"],
+      "@/utils/*": ["src/utils/*"],
+      "@/hooks/*": ["src/hooks/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Entregar un MVP funcional para validar la idea "Skills Compare": buscar skills, ver cursos mock, ver detalle y comparar exactamente 2 cursos. 
- Mantener arquitectura simple y product-minded usando Next.js App Router + TypeScript y UI ligera con Tailwind. 

### Description
- Scaffold completo del proyecto con App Router y Tailwind, incluyendo `app/page.tsx`, `app/skills/[skillSlug]/page.tsx`, `app/courses/[courseId]/page.tsx` y `app/compare/page.tsx`.
- Añadidos componentes reutilizables en `src/components`: `SearchBar`, `Filters`, `CourseCard` y `CompareBar`, más `src/hooks/useCompareSelection.ts` que persiste la selección en `localStorage` (máximo 2 ids).
- Datos mock en `src/data/courses.ts` (≥18 cursos relacionados con AI) y tipos en `src/types/course.ts`, más utilidades de slug en `src/utils/slugify.ts`.
- Lógica de filtros client-side en la página de skill, detalle de curso con objetivos/requisitos/temario y comparador que lee `?ids=ID1,ID2` y muestra una tabla comparativa; botón de comparación sólo habilitado cuando hay exactamente 2 cursos seleccionados.
- Documentación en `README.md` con instrucciones de instalación y estructura del proyecto; pequeño ajuste en detalle de curso para mostrar los primeros objetivos (`slice(0,3)`).

### Testing
- Intenté instalar dependencias con `npm install`, pero la ejecución falló con un error `403 Forbidden` al resolver algunos paquetes del registro, por lo que no fue posible levantar la app localmente ni ejecutar la app en `dev`.
- No hay tests automatizados incluidos en el MVP; la verificación funcional prevista es iniciar la app y probar las rutas (`/`, `/skills/:slug`, `/courses/:id`, `/compare?ids=...`) una vez resuelto el problema de instalación.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697269e10e10832bb0dd6de031de5d55)