### PR TITLE
Actualizar copy del MVP para enfatizar comparar 2 cursos

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,10 +26,10 @@ export default function HomePage() {
     <section className="flex flex-col gap-8">
       <div className="space-y-3">
         <h2 className="text-3xl font-semibold text-slate-900">
-          ¿Qué skill quieres aprender?
+          Busca una skill y compara cursos.
         </h2>
         <p className="text-slate-600">
-          Busca una skill para ver cursos recomendados y compararlos rápidamente.
+          Encuentra cursos y compáralos lado a lado para elegir el mejor para ti.
         </p>
       </div>
 
@@ -37,6 +37,9 @@ export default function HomePage() {
         placeholder="Ej: Prompt Engineering"
         onSearch={handleSearch}
       />
+      <p className="text-sm text-slate-500">
+        Selecciona 2 cursos para compararlos lado a lado.
+      </p>
 
       <div className="flex flex-wrap gap-2">
         {suggestions.map((skill) => (

--- a/app/skills/[skillSlug]/page.tsx
+++ b/app/skills/[skillSlug]/page.tsx
@@ -67,7 +67,7 @@ export default function SkillPage() {
         </p>
         <h2 className="text-3xl font-semibold text-slate-900">{skillTitle}</h2>
         <p className="mt-2 text-slate-600">
-          Filtra y compara cursos para esta skill.
+          Filtra cursos y selecciona 2 para compararlos lado a lado.
         </p>
       </div>
 
@@ -75,7 +75,8 @@ export default function SkillPage() {
 
       {filteredCourses.length === 0 ? (
         <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center text-slate-600">
-          No encontramos cursos con esos filtros. Prueba otra combinación.
+          No encontramos cursos con esos filtros. Prueba ajustar la búsqueda o
+          los filtros.
         </div>
       ) : (
         <div className="grid gap-6 lg:grid-cols-2">

--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -13,10 +13,10 @@ export const CompareBar = () => {
       <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-6 py-4 sm:flex-row">
         <div>
           <p className="text-sm font-semibold text-slate-900">
-            Comparar ({selectedIds.length})
+            Comparar ({selectedIds.length}/2)
           </p>
           <p className="text-xs text-slate-500">
-            Selecciona exactamente 2 cursos para comparar.
+            Selecciona 2 cursos para habilitar la comparación.
           </p>
         </div>
         <div className="flex items-center gap-3">


### PR DESCRIPTION
### Motivation
- Reflejar la nueva propuesta de valor “Busca una skill, encuentra cursos y compáralos lado a lado para elegir el mejor para ti.” y guiar al usuario a seleccionar 2 cursos para comparar.

### Description
- Cambios mínimos de copy sin alterar lógica: actualicé el `headline`/`subheadline` en `app/page.tsx` y añadí microcopy bajo el `SearchBar`, ajusté el texto descriptivo y el estado vacío en `app/skills/[skillSlug]/page.tsx`, y cambié el título y la ayuda en `src/components/CompareBar.tsx` a `Comparar (n/2)` y `Selecciona 2 cursos para habilitar la comparación.`.

### Testing
- Levanté el servidor de desarrollo con `npm run dev` y se inició correctamente, y un intento automatizado de capturar una pantalla con Playwright falló por limitaciones del entorno (Playwright/Chromium SIGSEGV).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cba3ea3fc832bb09565e0df7e05ad)