### PR TITLE
Robust skill routing aliases

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,23 +2,20 @@
 
 import { useRouter } from "next/navigation";
 import { SearchBar } from "@/components/SearchBar";
-import { slugify, titleFromSlug } from "@/utils/slugify";
-import { courses } from "@/lib/catalog-adapter";
+import { getSkillOptions, resolveSkillSlug } from "@/lib/skill-routing";
 
 export default function HomePage() {
   const router = useRouter();
 
   const handleSearch = (value: string) => {
-    const trimmed = value.trim();
-    if (!trimmed) {
+    const skillSlug = resolveSkillSlug(value);
+    if (!skillSlug) {
       return;
     }
-    router.push(`/skills/${slugify(trimmed)}`);
+    router.push(`/skills/${skillSlug}`);
   };
 
-  const suggestions = Array.from(
-    new Set(courses.flatMap((c) => c.skillTags))
-  );
+  const suggestions = getSkillOptions();
 
   return (
     <section className="flex flex-col gap-8">
@@ -42,12 +39,12 @@ export default function HomePage() {
       <div className="flex flex-wrap gap-2">
         {suggestions.map((skill) => (
           <button
-            key={skill}
+            key={skill.slug}
             type="button"
-            onClick={() => router.push(`/skills/${slugify(skill)}`)}
+            onClick={() => router.push(`/skills/${skill.slug}`)}
             className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300"
           >
-            {titleFromSlug(skill)}
+            {skill.title}
           </button>
         ))}
       </div>

--- a/app/skills/[skillSlug]/page.tsx
+++ b/app/skills/[skillSlug]/page.tsx
@@ -8,27 +8,13 @@ import { Filters } from "@/components/Filters";
 import { CompareBar } from "@/components/CompareBar";
 import { courses } from "@/lib/catalog-adapter";
 import { slugify, titleFromSlug } from "@/utils/slugify";
+import {
+  getSkillOptions,
+  getSkillSuggestions,
+  resolveSkillSlug
+} from "@/lib/skill-routing";
 
 const LAST_SKILL_KEY = "skills-compare-last-skill";
-
-const normalizeSkillSlug = (value: string) => {
-  const normalized = slugify(value);
-
-  const withoutPrefix = normalized.startsWith("skills")
-    ? normalized.replace(/^skills-?/, "")
-    : normalized;
-
-  const aliases: Record<string, string> = {
-    "machine": "ai",
-    "machine-learning": "ai",
-    "ai-fundamentals": "ai",
-    "prompt-engineering": "ai",
-    "llms": "ai",
-    "data-analytics": "data-analysis"
-  };
-
-  return aliases[withoutPrefix] ?? withoutPrefix;
-};
 
 type FiltersState = {
   platform: string;
@@ -42,7 +28,7 @@ export default function SkillPage() {
     ? params.skillSlug[0]
     : params.skillSlug;
 
-  const skillSlug = rawSkillSlug ? normalizeSkillSlug(rawSkillSlug) : undefined;
+  const skillSlug = rawSkillSlug ? resolveSkillSlug(rawSkillSlug) : null;
 
   const [filters, setFilters] = useState<FiltersState>({
     platform: "All",
@@ -51,14 +37,11 @@ export default function SkillPage() {
   });
 
   const availableSkillSlugs = useMemo(() => {
-    const slugs = new Set<string>();
-    courses.forEach((course) => {
-      course.skillTags.forEach((tag) => slugs.add(slugify(tag)));
-    });
-    return slugs;
+    return new Set(getSkillOptions().map((skill) => skill.slug));
   }, []);
 
   const skillExists = skillSlug ? availableSkillSlugs.has(skillSlug) : false;
+  const suggestions = useMemo(() => getSkillSuggestions(), []);
 
   const platformOptions = useMemo(() => {
     const platforms = Array.from(
@@ -151,15 +134,19 @@ export default function SkillPage() {
       {!skillExists ? (
         <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center text-slate-600">
           <p>
-            No encontramos esta skill. Revisa el enlace o vuelve a buscar desde
-            el inicio.
+            No encontramos esta skill. Prueba una de estas opciones del catalogo.
           </p>
-          <Link
-            href="/"
-            className="mt-4 inline-flex rounded-lg bg-blue-600 px-5 py-2 text-sm font-semibold text-white hover:bg-blue-500"
-          >
-            Volver al Home
-          </Link>
+          <div className="mt-5 flex flex-wrap justify-center gap-2">
+            {suggestions.map((skill) => (
+              <Link
+                key={skill.slug}
+                href={`/skills/${skill.slug}`}
+                className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300"
+              >
+                {skill.title}
+              </Link>
+            ))}
+          </div>
         </div>
       ) : filteredCourses.length === 0 ? (
         <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center text-slate-600">

--- a/src/lib/skill-routing.ts
+++ b/src/lib/skill-routing.ts
@@ -1,0 +1,66 @@
+import { courses } from "@/lib/catalog-adapter";
+import { slugify, titleFromSlug } from "@/utils/slugify";
+
+const SKILL_ALIASES: Record<string, string> = {
+  ai: "ai",
+  "artificial-intelligence": "ai",
+  "artificial-inteligence": "ai",
+  "inteligencia-artificial": "ai",
+  ia: "ai",
+  llm: "ai",
+  llms: "ai",
+  ml: "ai",
+  "machine-learning": "ai",
+  "machine-learning-ai": "ai",
+  "ai-fundamentals": "ai",
+  "prompt-engineering": "ai",
+  analytics: "data-analysis",
+  "data-analytics": "data-analysis",
+  "data-analyst": "data-analysis",
+  "analisis-de-datos": "data-analysis",
+  "data-science": "data-science",
+  "ciencia-de-datos": "data-science",
+  frontend: "frontend",
+  "front-end": "frontend",
+  "web-development": "frontend",
+  react: "frontend"
+};
+
+export type SkillOption = {
+  slug: string;
+  title: string;
+};
+
+const stripRoutePrefix = (value: string) =>
+  value.replace(/^\/?skills\/?/, "").replace(/^skills-?/, "");
+
+export const getSkillOptions = (): SkillOption[] => {
+  const slugs = new Set<string>();
+
+  courses.forEach((course) => {
+    course.skillTags.forEach((tag) => slugs.add(slugify(tag)));
+  });
+
+  return Array.from(slugs)
+    .sort()
+    .map((slug) => ({
+      slug,
+      title: titleFromSlug(slug)
+    }));
+};
+
+export const resolveSkillSlug = (value: string): string | null => {
+  const normalized = slugify(stripRoutePrefix(value));
+
+  if (!normalized) {
+    return null;
+  }
+
+  const candidate = SKILL_ALIASES[normalized] ?? normalized;
+  const validSlugs = new Set(getSkillOptions().map((skill) => skill.slug));
+
+  return validSlugs.has(candidate) ? candidate : null;
+};
+
+export const getSkillSuggestions = (limit = 4): SkillOption[] =>
+  getSkillOptions().slice(0, limit);


### PR DESCRIPTION
## Summary
- Centralizes skill alias resolution in `src/lib/skill-routing.ts`.
- Routes home search through valid catalog skill slugs.
- Shows real skill suggestions on unknown skill pages instead of a dead end.

## Decision / conversion / SEO impact
- Users searching for common terms like `AI`, `ml`, `llm`, or `machine learning` land on the existing catalog page.
- Unknown searches now expose valid alternatives, reducing broken journeys.
- Keeps skill URLs stable around existing `skillSlug` values.

## Validation
- `corepack pnpm validate:data` passed: 5 courses validated successfully.
- `corepack pnpm build` passed.

## Risk level
- Product-review: touches home and skill routing UX.

## Follow-ups
- None.