### PR TITLE
Clarify real catalog home page

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -2,22 +2,18 @@
 
 import { useRouter } from "next/navigation";
 import { SearchBar } from "@/components/SearchBar";
-import { courses } from "@/lib/catalog-adapter";
-import { slugify, titleFromSlug } from "@/utils/slugify";
-
-const getCatalogSkills = () =>
-  Array.from(new Set(courses.flatMap((course) => course.skillTags))).sort();
+import { getSkillOptions, resolveSkillSlug } from "@/lib/skill-routing";
 
 export default function HomeClient() {
   const router = useRouter();
-  const suggestions = getCatalogSkills();
+  const suggestions = getSkillOptions();
 
   const handleSearch = (value: string) => {
-    const trimmed = value.trim();
-    if (!trimmed) {
+    const skillSlug = resolveSkillSlug(value);
+    if (!skillSlug) {
       return;
     }
-    router.push(`/skills/${slugify(trimmed)}`);
+    router.push(`/skills/${skillSlug}`);
   };
 
   return (
@@ -40,12 +36,12 @@ export default function HomeClient() {
       <div className="flex flex-wrap gap-2">
         {suggestions.map((skill) => (
           <button
-            key={skill}
+            key={skill.slug}
             type="button"
-            onClick={() => router.push(`/skills/${slugify(skill)}`)}
+            onClick={() => router.push(`/skills/${skill.slug}`)}
             className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300"
           >
-            {titleFromSlug(skill)}
+            {skill.title}
           </button>
         ))}
       </div>

--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { SearchBar } from "@/components/SearchBar";
+import { courses } from "@/lib/catalog-adapter";
+import { slugify, titleFromSlug } from "@/utils/slugify";
+
+const getCatalogSkills = () =>
+  Array.from(new Set(courses.flatMap((course) => course.skillTags))).sort();
+
+export default function HomeClient() {
+  const router = useRouter();
+  const suggestions = getCatalogSkills();
+
+  const handleSearch = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return;
+    }
+    router.push(`/skills/${slugify(trimmed)}`);
+  };
+
+  return (
+    <section className="flex flex-col gap-8">
+      <div className="space-y-3">
+        <h2 className="text-3xl font-semibold text-slate-900">
+          Compara cursos online antes de elegir.
+        </h2>
+        <p className="max-w-2xl text-slate-600">
+          Busca una skill del catalogo, revisa cursos reales lado a lado y abre
+          la plataforma original cuando encuentres una opcion que encaje contigo.
+        </p>
+      </div>
+
+      <SearchBar placeholder="Ej: ai, data analysis, frontend" onSearch={handleSearch} />
+      <p className="text-sm text-slate-500">
+        Selecciona 2 cursos para comparar precio, duracion, nivel y certificado.
+      </p>
+
+      <div className="flex flex-wrap gap-2">
+        {suggestions.map((skill) => (
+          <button
+            key={skill}
+            type="button"
+            onClick={() => router.push(`/skills/${slugify(skill)}`)}
+            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300"
+          >
+            {titleFromSlug(skill)}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,56 +1,12 @@
-"use client";
+import type { Metadata } from "next";
+import HomeClient from "./HomeClient";
 
-import { useRouter } from "next/navigation";
-import { SearchBar } from "@/components/SearchBar";
-import { slugify, titleFromSlug } from "@/utils/slugify";
-import { courses } from "@/lib/catalog-adapter";
+export const metadata: Metadata = {
+  title: "Skills Compare | Compara cursos online",
+  description:
+    "Busca una skill, compara cursos online por precio, duracion, nivel y certificado, y elige donde aprender."
+};
 
 export default function HomePage() {
-  const router = useRouter();
-
-  const handleSearch = (value: string) => {
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return;
-    }
-    router.push(`/skills/${slugify(trimmed)}`);
-  };
-
-  const suggestions = Array.from(
-    new Set(courses.flatMap((c) => c.skillTags))
-  );
-
-  return (
-    <section className="flex flex-col gap-8">
-      <div className="space-y-3">
-        <h2 className="text-3xl font-semibold text-slate-900">
-          Busca una skill y compara cursos.
-        </h2>
-        <p className="text-slate-600">
-          Encuentra cursos y compáralos lado a lado para elegir el mejor para ti.
-        </p>
-      </div>
-
-      <SearchBar
-        placeholder="Ej: AI"
-        onSearch={handleSearch}
-      />
-      <p className="text-sm text-slate-500">
-        Selecciona 2 cursos para compararlos lado a lado.
-      </p>
-
-      <div className="flex flex-wrap gap-2">
-        {suggestions.map((skill) => (
-          <button
-            key={skill}
-            type="button"
-            onClick={() => router.push(`/skills/${slugify(skill)}`)}
-            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300"
-          >
-            {titleFromSlug(skill)}
-          </button>
-        ))}
-      </div>
-    </section>
-  );
+  return <HomeClient />;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,54 +1,12 @@
 import type { Metadata } from "next";
 import HomeClient from "./HomeClient";
 
-import { useRouter } from "next/navigation";
-import { SearchBar } from "@/components/SearchBar";
-import { getSkillOptions, resolveSkillSlug } from "@/lib/skill-routing";
+export const metadata: Metadata = {
+  title: "Skills Compare | Compara cursos online",
+  description:
+    "Busca una skill, compara cursos online por precio, duración, nivel y certificado, y elige dónde aprender."
+};
 
 export default function HomePage() {
-  const router = useRouter();
-
-  const handleSearch = (value: string) => {
-    const skillSlug = resolveSkillSlug(value);
-    if (!skillSlug) {
-      return;
-    }
-    router.push(`/skills/${skillSlug}`);
-  };
-
-  const suggestions = getSkillOptions();
-
-  return (
-    <section className="flex flex-col gap-8">
-      <div className="space-y-3">
-        <h2 className="text-3xl font-semibold text-slate-900">
-          Busca una skill y compara cursos.
-        </h2>
-        <p className="text-slate-600">
-          Encuentra cursos y compáralos lado a lado para elegir el mejor para ti.
-        </p>
-      </div>
-
-      <SearchBar
-        placeholder="Ej: AI"
-        onSearch={handleSearch}
-      />
-      <p className="text-sm text-slate-500">
-        Selecciona 2 cursos para compararlos lado a lado.
-      </p>
-
-      <div className="flex flex-wrap gap-2">
-        {suggestions.map((skill) => (
-          <button
-            key={skill.slug}
-            type="button"
-            onClick={() => router.push(`/skills/${skill.slug}`)}
-            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300"
-          >
-            {skill.title}
-          </button>
-        ))}
-      </div>
-    </section>
-  );
+  return <HomeClient />;
 }


### PR DESCRIPTION
## Summary
- Splits the interactive home search into `app/HomeClient.tsx` so the route can export metadata.
- Updates home copy to explain the product around course comparison and platform handoff.
- Keeps suggestions generated from catalog `skillTags` and updates the search placeholder to real skills.

## Decision / conversion / SEO impact
- Makes the first screen clearer about the decision workflow: search, compare, choose.
- Uses real catalog skills instead of implying unsupported examples.
- Adds a page title and description for the home route.

## Validation
- `corepack pnpm validate:data` passed: 5 courses validated successfully.
- `corepack pnpm build` passed.

## Risk level
- Product-review: touches home-page UX and metadata.

## Follow-ups
- None.