### PR TITLE
Add external course CTAs

### DIFF
--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -141,8 +141,28 @@ export default function CompareClient() {
       <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
         <div className="grid grid-cols-3 gap-4 border-b border-slate-200 bg-slate-50 px-6 py-4 text-sm font-semibold text-slate-700">
           <span>Detalle</span>
-          <span>{leftCourse.title}</span>
-          <span>{rightCourse.title}</span>
+          <span className="flex flex-col gap-3">
+            {leftCourse.title}
+            <a
+              href={leftCourse.externalUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-fit rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+            >
+              Ver curso
+            </a>
+          </span>
+          <span className="flex flex-col gap-3">
+            {rightCourse.title}
+            <a
+              href={rightCourse.externalUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-fit rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+            >
+              Ver curso
+            </a>
+          </span>
         </div>
         <div className="divide-y divide-slate-200">
           {rows.map((row) => (

--- a/app/courses/[courseId]/page.tsx
+++ b/app/courses/[courseId]/page.tsx
@@ -66,15 +66,25 @@ export default function CourseDetailPage() {
             {course.priceText}
           </span>
         </div>
-        <button
-          type="button"
-          onClick={() => toggle(course.id)}
-          className={`w-fit rounded-lg px-5 py-2 text-sm font-semibold text-white transition ${
-            selected ? "bg-emerald-600 hover:bg-emerald-500" : "bg-blue-600 hover:bg-blue-500"
-          } ${atLimit ? "bg-slate-300" : ""}`}
-        >
-          {selected ? "Seleccionado para comparar" : "Agregar a comparación"}
-        </button>
+        <div className="flex flex-wrap items-center gap-3">
+          <a
+            href={course.externalUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-lg bg-blue-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-blue-500"
+          >
+            Ver curso
+          </a>
+          <button
+            type="button"
+            onClick={() => toggle(course.id)}
+            className={`w-fit rounded-lg px-5 py-2 text-sm font-semibold text-white transition ${
+              selected ? "bg-emerald-600 hover:bg-emerald-500" : "bg-slate-700 hover:bg-slate-600"
+            } ${atLimit ? "bg-slate-300" : ""}`}
+          >
+            {selected ? "Seleccionado para comparar" : "Agregar a comparación"}
+          </button>
+        </div>
         {atLimit ? (
           <p className="text-xs text-amber-600">
             Ya tienes 2 cursos seleccionados. Quita uno para continuar.
@@ -131,7 +141,7 @@ export default function CourseDetailPage() {
                 href={course.externalUrl}
                 className="text-slate-900 underline"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
               >
                 Ver curso
               </a>

--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -41,13 +41,23 @@ export const CourseCard = ({ course }: CourseCardProps) => {
           <span className="font-medium text-slate-800">{course.priceText}</span>
         </div>
       </div>
-      <div className="mt-auto flex items-center justify-between gap-3">
-        <Link
-          href={`/courses/${course.id}`}
-          className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:border-slate-300"
-        >
-          Ver
-        </Link>
+      <div className="mt-auto flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <a
+            href={course.externalUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+          >
+            Ver curso
+          </a>
+          <Link
+            href={`/courses/${course.id}`}
+            className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:border-slate-300"
+          >
+            Detalles
+          </Link>
+        </div>
         <label className="flex items-center gap-2 text-sm text-slate-600">
           <input
             type="checkbox"


### PR DESCRIPTION
## Summary
- Adds `Ver curso` CTA buttons to course cards.
- Highlights `Ver curso` on the course detail page.
- Adds external CTAs for both courses in the compare page header.
- Uses `target="_blank"` with `rel="noopener noreferrer"` for all new external links.

## Decision / conversion / SEO impact
- Gives users a direct path from evaluation to the external course platform.
- Keeps comparison and details available while making the conversion action visible.

## Validation
- `corepack pnpm validate:data` passed: 5 courses validated successfully.
- `corepack pnpm build` passed.

## Risk level
- Product-review: touches conversion UX on course cards, detail, and compare.

## Follow-ups
- None.