### PR TITLE
Add SEO base for skill pages

### DIFF
--- a/app/skills/[skillSlug]/SkillClient.tsx
+++ b/app/skills/[skillSlug]/SkillClient.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { CourseCard } from "@/components/CourseCard";
+import { Filters } from "@/components/Filters";
+import { CompareBar } from "@/components/CompareBar";
+import { courses } from "@/lib/catalog-adapter";
+import { getSkillAlternatives, getSkillIntro } from "@/lib/skill-catalog";
+import { slugify, titleFromSlug } from "@/utils/slugify";
+
+const LAST_SKILL_KEY = "skills-compare-last-skill";
+
+const normalizeSkillSlug = (value: string) => {
+  const normalized = slugify(value);
+
+  const withoutPrefix = normalized.startsWith("skills")
+    ? normalized.replace(/^skills-?/, "")
+    : normalized;
+
+  const aliases: Record<string, string> = {
+    "machine": "ai",
+    "machine-learning": "ai",
+    "ai-fundamentals": "ai",
+    "prompt-engineering": "ai",
+    "llms": "ai",
+    "data-analytics": "data-analysis"
+  };
+
+  return aliases[withoutPrefix] ?? withoutPrefix;
+};
+
+type FiltersState = {
+  platform: string;
+  level: string;
+  priceModel: string;
+};
+
+type SkillClientProps = {
+  skillSlug: string;
+};
+
+export default function SkillClient({ skillSlug: rawSkillSlug }: SkillClientProps) {
+  const skillSlug = rawSkillSlug ? normalizeSkillSlug(rawSkillSlug) : undefined;
+
+  const [filters, setFilters] = useState<FiltersState>({
+    platform: "All",
+    level: "All",
+    priceModel: "All"
+  });
+
+  const availableSkillSlugs = useMemo(() => {
+    const slugs = new Set<string>();
+    courses.forEach((course) => {
+      course.skillTags.forEach((tag) => slugs.add(slugify(tag)));
+    });
+    return slugs;
+  }, []);
+
+  const skillExists = skillSlug ? availableSkillSlugs.has(skillSlug) : false;
+  const alternatives = useMemo(() => getSkillAlternatives(), []);
+
+  const platformOptions = useMemo(() => {
+    const platforms = Array.from(
+      new Set(courses.map((course) => course.platform))
+    ).sort();
+    return ["All", ...platforms];
+  }, []);
+
+  const levelOptions = useMemo(() => {
+    const levels = Array.from(new Set(courses.map((course) => course.level))).sort();
+    return ["All", ...levels];
+  }, []);
+
+  const priceOptions = useMemo(() => {
+    const models = new Set(courses.map((course) => course.priceModel));
+    const options = [{ value: "All", label: "Todos" }];
+    if (models.has("free")) {
+      options.push({ value: "free", label: "Gratis" });
+    }
+    if (models.has("paid_once")) {
+      options.push({ value: "paid_once", label: "Pago único" });
+    }
+    if (models.has("subscription")) {
+      options.push({ value: "subscription", label: "Suscripción" });
+    }
+    if (models.has("unknown")) {
+      options.push({ value: "unknown", label: "Desconocido" });
+    }
+    return options;
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && skillSlug) {
+      window.localStorage.setItem(LAST_SKILL_KEY, skillSlug);
+    }
+  }, [skillSlug]);
+
+  const skillTitle = titleFromSlug(skillSlug ?? "");
+  const skillIntro = skillExists
+    ? getSkillIntro({
+        slug: skillSlug ?? "",
+        title: skillTitle,
+        courseCount: courses.filter((course) =>
+          course.skillTags.some((tag) => slugify(tag) === skillSlug)
+        ).length
+      })
+    : null;
+
+  const filteredCourses = useMemo(() => {
+    if (!skillSlug || !skillExists) {
+      return [];
+    }
+    return courses
+      .filter((course) =>
+        course.skillTags.some((tag) => slugify(tag) === skillSlug)
+      )
+      .filter((course) =>
+        filters.platform === "All"
+          ? true
+          : course.platform.toLowerCase() === filters.platform.toLowerCase()
+      )
+      .filter((course) =>
+        filters.level === "All"
+          ? true
+          : course.level.toLowerCase() === filters.level.toLowerCase()
+      )
+      .filter((course) => {
+        if (filters.priceModel === "All") {
+          return true;
+        }
+        return course.priceModel === filters.priceModel;
+      });
+  }, [filters.level, filters.platform, filters.priceModel, skillSlug]);
+
+  return (
+    <section className="flex flex-col gap-8 pb-24">
+      <div>
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">
+          Skill
+        </p>
+        <h2 className="text-3xl font-semibold text-slate-900">
+          {skillExists ? skillTitle : "Skill no encontrada"}
+        </h2>
+        <p className="mt-2 text-slate-600">
+          {skillIntro ??
+            "No tenemos cursos para esta skill todavia. Puedes revisar alternativas reales del catalogo."}
+        </p>
+      </div>
+
+      <Filters
+        value={filters}
+        onChange={setFilters}
+        options={{
+          platforms: platformOptions,
+          levels: levelOptions,
+          prices: priceOptions
+        }}
+      />
+
+      {!skillExists ? (
+        <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center text-slate-600">
+          <p>
+            No encontramos esta skill. Estas opciones si tienen cursos disponibles.
+          </p>
+          <div className="mt-5 flex flex-wrap justify-center gap-2">
+            {alternatives.map((skill) => (
+              <Link
+                key={skill.slug}
+                href={`/skills/${skill.slug}`}
+                className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300"
+              >
+                {skill.title}
+              </Link>
+            ))}
+          </div>
+        </div>
+      ) : filteredCourses.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center text-slate-600">
+          No encontramos cursos con esos filtros. Prueba ajustar la búsqueda o
+          limpiar filtros.
+        </div>
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-2">
+          {filteredCourses.map((course) => (
+            <CourseCard key={course.id} course={course} />
+          ))}
+        </div>
+      )}
+
+      <CompareBar />
+    </section>
+  );
+}

--- a/app/skills/[skillSlug]/page.tsx
+++ b/app/skills/[skillSlug]/page.tsx
@@ -1,180 +1,32 @@
-"use client";
+import type { Metadata } from "next";
+import { getCoursesForSkill, getSkillSummary } from "@/lib/skill-catalog";
+import SkillClient from "./SkillClient";
 
-import { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
-import { useParams } from "next/navigation";
-import { CourseCard } from "@/components/CourseCard";
-import { Filters } from "@/components/Filters";
-import { CompareBar } from "@/components/CompareBar";
-import { courses } from "@/lib/catalog-adapter";
-import { slugify, titleFromSlug } from "@/utils/slugify";
-
-const LAST_SKILL_KEY = "skills-compare-last-skill";
-
-const normalizeSkillSlug = (value: string) => {
-  const normalized = slugify(value);
-
-  const withoutPrefix = normalized.startsWith("skills")
-    ? normalized.replace(/^skills-?/, "")
-    : normalized;
-
-  const aliases: Record<string, string> = {
-    "machine": "ai",
-    "machine-learning": "ai",
-    "ai-fundamentals": "ai",
-    "prompt-engineering": "ai",
-    "llms": "ai",
-    "data-analytics": "data-analysis"
+type SkillPageProps = {
+  params: {
+    skillSlug: string;
   };
-
-  return aliases[withoutPrefix] ?? withoutPrefix;
 };
 
-type FiltersState = {
-  platform: string;
-  level: string;
-  priceModel: string;
+export const generateMetadata = ({ params }: SkillPageProps): Metadata => {
+  const skill = getSkillSummary(params.skillSlug);
+
+  if (!skill) {
+    return {
+      title: "Skill no encontrada | Skills Compare",
+      description:
+        "Revisa alternativas reales del catalogo de Skills Compare para comparar cursos online."
+    };
+  }
+
+  const courseCount = getCoursesForSkill(skill.slug).length;
+
+  return {
+    title: `Cursos de ${skill.title} | Skills Compare`,
+    description: `Compara ${courseCount} cursos de ${skill.title} por plataforma, precio, duracion y nivel antes de elegir.`
+  };
 };
 
-export default function SkillPage() {
-  const params = useParams();
-  const rawSkillSlug = Array.isArray(params.skillSlug)
-    ? params.skillSlug[0]
-    : params.skillSlug;
-
-  const skillSlug = rawSkillSlug ? normalizeSkillSlug(rawSkillSlug) : undefined;
-
-  const [filters, setFilters] = useState<FiltersState>({
-    platform: "All",
-    level: "All",
-    priceModel: "All"
-  });
-
-  const availableSkillSlugs = useMemo(() => {
-    const slugs = new Set<string>();
-    courses.forEach((course) => {
-      course.skillTags.forEach((tag) => slugs.add(slugify(tag)));
-    });
-    return slugs;
-  }, []);
-
-  const skillExists = skillSlug ? availableSkillSlugs.has(skillSlug) : false;
-
-  const platformOptions = useMemo(() => {
-    const platforms = Array.from(
-      new Set(courses.map((course) => course.platform))
-    ).sort();
-    return ["All", ...platforms];
-  }, []);
-
-  const levelOptions = useMemo(() => {
-    const levels = Array.from(new Set(courses.map((course) => course.level))).sort();
-    return ["All", ...levels];
-  }, []);
-
-  const priceOptions = useMemo(() => {
-    const models = new Set(courses.map((course) => course.priceModel));
-    const options = [{ value: "All", label: "Todos" }];
-    if (models.has("free")) {
-      options.push({ value: "free", label: "Gratis" });
-    }
-    if (models.has("paid_once")) {
-      options.push({ value: "paid_once", label: "Pago único" });
-    }
-    if (models.has("subscription")) {
-      options.push({ value: "subscription", label: "Suscripción" });
-    }
-    if (models.has("unknown")) {
-      options.push({ value: "unknown", label: "Desconocido" });
-    }
-    return options;
-  }, []);
-
-  useEffect(() => {
-    if (typeof window !== "undefined" && skillSlug) {
-      window.localStorage.setItem(LAST_SKILL_KEY, skillSlug);
-    }
-  }, [skillSlug]);
-
-  const skillTitle = titleFromSlug(skillSlug ?? "");
-
-  const filteredCourses = useMemo(() => {
-    if (!skillSlug || !skillExists) {
-      return [];
-    }
-    return courses
-      .filter((course) =>
-        course.skillTags.some((tag) => slugify(tag) === skillSlug)
-      )
-      .filter((course) =>
-        filters.platform === "All"
-          ? true
-          : course.platform.toLowerCase() === filters.platform.toLowerCase()
-      )
-      .filter((course) =>
-        filters.level === "All"
-          ? true
-          : course.level.toLowerCase() === filters.level.toLowerCase()
-      )
-      .filter((course) => {
-        if (filters.priceModel === "All") {
-          return true;
-        }
-        return course.priceModel === filters.priceModel;
-      });
-  }, [filters.level, filters.platform, filters.priceModel, skillSlug]);
-
-  return (
-    <section className="flex flex-col gap-8 pb-24">
-      <div>
-        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">
-          Skill
-        </p>
-        <h2 className="text-3xl font-semibold text-slate-900">
-          {skillExists ? skillTitle : "Skill no encontrada"}
-        </h2>
-        <p className="mt-2 text-slate-600">
-          Filtra cursos y selecciona 2 para compararlos lado a lado (por ahora).
-        </p>
-      </div>
-
-      <Filters
-        value={filters}
-        onChange={setFilters}
-        options={{
-          platforms: platformOptions,
-          levels: levelOptions,
-          prices: priceOptions
-        }}
-      />
-
-      {!skillExists ? (
-        <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center text-slate-600">
-          <p>
-            No encontramos esta skill. Revisa el enlace o vuelve a buscar desde
-            el inicio.
-          </p>
-          <Link
-            href="/"
-            className="mt-4 inline-flex rounded-lg bg-blue-600 px-5 py-2 text-sm font-semibold text-white hover:bg-blue-500"
-          >
-            Volver al Home
-          </Link>
-        </div>
-      ) : filteredCourses.length === 0 ? (
-        <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center text-slate-600">
-          No encontramos cursos con esos filtros. Prueba ajustar la búsqueda o
-          limpiar filtros.
-        </div>
-      ) : (
-        <div className="grid gap-6 lg:grid-cols-2">
-          {filteredCourses.map((course) => (
-            <CourseCard key={course.id} course={course} />
-          ))}
-        </div>
-      )}
-
-      <CompareBar />
-    </section>
-  );
+export default function SkillPage({ params }: SkillPageProps) {
+  return <SkillClient skillSlug={params.skillSlug} />;
 }

--- a/app/skills/[skillSlug]/page.tsx
+++ b/app/skills/[skillSlug]/page.tsx
@@ -2,161 +2,30 @@ import type { Metadata } from "next";
 import { getCoursesForSkill, getSkillSummary } from "@/lib/skill-catalog";
 import SkillClient from "./SkillClient";
 
-import { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
-import { useParams } from "next/navigation";
-import { CourseCard } from "@/components/CourseCard";
-import { Filters } from "@/components/Filters";
-import { CompareBar } from "@/components/CompareBar";
-import { courses } from "@/lib/catalog-adapter";
-import { slugify, titleFromSlug } from "@/utils/slugify";
-import {
-  getSkillOptions,
-  getSkillSuggestions,
-  resolveSkillSlug
-} from "@/lib/skill-routing";
-
-const LAST_SKILL_KEY = "skills-compare-last-skill";
-
-type FiltersState = {
-  platform: string;
-  level: string;
-  priceModel: string;
+type SkillPageProps = {
+  params: {
+    skillSlug: string;
+  };
 };
 
-export default function SkillPage() {
-  const params = useParams();
-  const rawSkillSlug = Array.isArray(params.skillSlug)
-    ? params.skillSlug[0]
-    : params.skillSlug;
+export const generateMetadata = ({ params }: SkillPageProps): Metadata => {
+  const skill = getSkillSummary(params.skillSlug);
 
-  const skillSlug = rawSkillSlug ? resolveSkillSlug(rawSkillSlug) : null;
-
-  const [filters, setFilters] = useState<FiltersState>({
-    platform: "All",
-    level: "All",
-    priceModel: "All"
-  });
-
-  const availableSkillSlugs = useMemo(() => {
-    return new Set(getSkillOptions().map((skill) => skill.slug));
-  }, []);
-
-  const skillExists = skillSlug ? availableSkillSlugs.has(skillSlug) : false;
-  const suggestions = useMemo(() => getSkillSuggestions(), []);
+  if (!skill) {
+    return {
+      title: "Skill no encontrada | Skills Compare",
+      description:
+        "Revisa alternativas reales del catalogo de Skills Compare para comparar cursos online."
+    };
+  }
 
   const courseCount = getCoursesForSkill(skill.slug).length;
 
-  const levelOptions = useMemo(() => {
-    const levels = Array.from(new Set(courses.map((course) => course.level))).sort();
-    return ["All", ...levels];
-  }, []);
-
-  const priceOptions = useMemo(() => {
-    const models = new Set(courses.map((course) => course.priceModel));
-    const options = [{ value: "All", label: "Todos" }];
-    if (models.has("free")) {
-      options.push({ value: "free", label: "Gratis" });
-    }
-    if (models.has("paid_once")) {
-      options.push({ value: "paid_once", label: "Pago único" });
-    }
-    if (models.has("subscription")) {
-      options.push({ value: "subscription", label: "Suscripción" });
-    }
-    if (models.has("unknown")) {
-      options.push({ value: "unknown", label: "Desconocido" });
-    }
-    return options;
-  }, []);
-
-  useEffect(() => {
-    if (typeof window !== "undefined" && skillSlug) {
-      window.localStorage.setItem(LAST_SKILL_KEY, skillSlug);
-    }
-  }, [skillSlug]);
-
-  const skillTitle = titleFromSlug(skillSlug ?? "");
-
-  const filteredCourses = useMemo(() => {
-    if (!skillSlug || !skillExists) {
-      return [];
-    }
-    return courses
-      .filter((course) =>
-        course.skillTags.some((tag) => slugify(tag) === skillSlug)
-      )
-      .filter((course) =>
-        filters.platform === "All"
-          ? true
-          : course.platform.toLowerCase() === filters.platform.toLowerCase()
-      )
-      .filter((course) =>
-        filters.level === "All"
-          ? true
-          : course.level.toLowerCase() === filters.level.toLowerCase()
-      )
-      .filter((course) => {
-        if (filters.priceModel === "All") {
-          return true;
-        }
-        return course.priceModel === filters.priceModel;
-      });
-  }, [filters.level, filters.platform, filters.priceModel, skillSlug]);
-
-  return (
-    <section className="flex flex-col gap-8 pb-24">
-      <div>
-        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">
-          Skill
-        </p>
-        <h2 className="text-3xl font-semibold text-slate-900">
-          {skillExists ? skillTitle : "Skill no encontrada"}
-        </h2>
-        <p className="mt-2 text-slate-600">
-          Filtra cursos y selecciona 2 para compararlos lado a lado (por ahora).
-        </p>
-      </div>
-
-      <Filters
-        value={filters}
-        onChange={setFilters}
-        options={{
-          platforms: platformOptions,
-          levels: levelOptions,
-          prices: priceOptions
-        }}
-      />
-
-      {!skillExists ? (
-        <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center text-slate-600">
-          <p>
-            No encontramos esta skill. Prueba una de estas opciones del catalogo.
-          </p>
-          <div className="mt-5 flex flex-wrap justify-center gap-2">
-            {suggestions.map((skill) => (
-              <Link
-                key={skill.slug}
-                href={`/skills/${skill.slug}`}
-                className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300"
-              >
-                {skill.title}
-              </Link>
-            ))}
-          </div>
-        </div>
-      ) : filteredCourses.length === 0 ? (
-        <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center text-slate-600">
-          No encontramos cursos con esos filtros. Prueba ajustar la búsqueda o
-          limpiar filtros.
-        </div>
-      ) : (
-        <div className="grid gap-6 lg:grid-cols-2">
-          {filteredCourses.map((course) => (
-            <CourseCard key={course.id} course={course} />
-          ))}
-        </div>
-      )}
+  return {
+    title: `Cursos de ${skill.title} | Skills Compare`,
+    description: `Compara ${courseCount} cursos de ${skill.title} por plataforma, precio, duracion y nivel antes de elegir.`
+  };
+};
 
 export default function SkillPage({ params }: SkillPageProps) {
   return <SkillClient skillSlug={params.skillSlug} />;

--- a/src/lib/skill-catalog.ts
+++ b/src/lib/skill-catalog.ts
@@ -1,0 +1,42 @@
+import { courses } from "@/lib/catalog-adapter";
+import type { Course } from "@/types/course";
+import { slugify, titleFromSlug } from "@/utils/slugify";
+
+export type SkillSummary = {
+  slug: string;
+  title: string;
+  courseCount: number;
+};
+
+export const getSkillSummaries = (): SkillSummary[] => {
+  const counts = new Map<string, number>();
+
+  courses.forEach((course) => {
+    course.skillTags.forEach((tag) => {
+      const slug = slugify(tag);
+      counts.set(slug, (counts.get(slug) ?? 0) + 1);
+    });
+  });
+
+  return Array.from(counts.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([slug, courseCount]) => ({
+      slug,
+      title: titleFromSlug(slug),
+      courseCount
+    }));
+};
+
+export const getCoursesForSkill = (skillSlug: string): Course[] =>
+  courses.filter((course) =>
+    course.skillTags.some((tag) => slugify(tag) === skillSlug)
+  );
+
+export const getSkillSummary = (skillSlug: string): SkillSummary | null =>
+  getSkillSummaries().find((skill) => skill.slug === skillSlug) ?? null;
+
+export const getSkillAlternatives = (limit = 4): SkillSummary[] =>
+  getSkillSummaries().slice(0, limit);
+
+export const getSkillIntro = (skill: SkillSummary) =>
+  `Compara ${skill.courseCount} cursos de ${skill.title} disponibles en el catalogo. Revisa plataforma, precio, duracion y nivel antes de abrir el curso en su plataforma original.`;


### PR DESCRIPTION
## Summary
- Converts the skill route to a server page with a client component for filters and compare selection.
- Adds dynamic metadata for valid and unknown skill pages.
- Adds short data-derived intro copy to skill pages.
- Shows real catalog alternatives when a skill page has no matching courses.

## Decision / conversion / SEO impact
- Skill pages now have specific titles and descriptions for search visibility.
- Intro copy helps users understand what they can compare without inventing course data.
- Unknown skill URLs avoid empty content and route users to valid catalog skills.

## Validation
- `corepack pnpm validate:data` passed: 5 courses validated successfully.
- `corepack pnpm build` passed.

## Risk level
- Product-review: touches skill page rendering and metadata.

## Follow-ups
- None.