### PR TITLE
Improve course detail hierarchy

### DIFF
--- a/app/courses/[courseId]/page.tsx
+++ b/app/courses/[courseId]/page.tsx
@@ -41,10 +41,25 @@ export default function CourseDetailPage() {
 
   const selected = isSelected(course.id);
   const atLimit = selectedIds.length >= 2 && !selected;
+  const keyFacts = [
+    { label: "Plataforma", value: course.platform },
+    { label: "Nivel", value: course.level },
+    { label: "Duracion", value: course.durationText },
+    { label: "Precio", value: course.priceText },
+    { label: "Idioma", value: course.language },
+    {
+      label: "Certificado",
+      value: course.certificate ? "Incluido" : "No verificado"
+    },
+    course.rating ? { label: "Rating", value: course.rating.toFixed(1) } : null
+  ].filter((fact): fact is { label: string; value: string } => fact !== null);
+  const hasObjectives = objectives.length > 0;
+  const hasPrerequisites = course.prerequisitesBullets.length > 0;
+  const hasSyllabus = course.syllabusBullets.length > 0;
 
   return (
     <section className="flex flex-col gap-8">
-      <div className="space-y-3">
+      <div className="space-y-5">
         <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">
           Curso
         </p>
@@ -66,6 +81,14 @@ export default function CourseDetailPage() {
             {course.priceText}
           </span>
         </div>
+        <a
+          href={course.externalUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex w-fit rounded-lg bg-blue-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-blue-500"
+        >
+          Ver curso
+        </a>
         <button
           type="button"
           onClick={() => toggle(course.id)}
@@ -85,7 +108,23 @@ export default function CourseDetailPage() {
         ) : null}
       </div>
 
+      <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-slate-900">Datos clave</h3>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {keyFacts.map((fact) => (
+            <div key={fact.label} className="rounded-lg bg-slate-50 px-4 py-3">
+              <span className="block text-xs font-medium text-slate-500">
+                {fact.label}
+              </span>
+              <span className="font-semibold text-slate-800">{fact.value}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {(hasObjectives || hasPrerequisites || hasSyllabus) ? (
       <div className="grid gap-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm md:grid-cols-2">
+        {hasObjectives ? (
         <div>
           <h3 className="text-lg font-semibold text-slate-900">Objetivos</h3>
           <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-600">
@@ -94,6 +133,8 @@ export default function CourseDetailPage() {
             ))}
           </ul>
         </div>
+        ) : null}
+        {hasPrerequisites ? (
         <div>
           <h3 className="text-lg font-semibold text-slate-900">Requisitos</h3>
           <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-600">
@@ -102,6 +143,8 @@ export default function CourseDetailPage() {
             ))}
           </ul>
         </div>
+        ) : null}
+        {hasSyllabus ? (
         <div>
           <h3 className="text-lg font-semibold text-slate-900">Temario resumido</h3>
           <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-600">
@@ -110,6 +153,7 @@ export default function CourseDetailPage() {
             ))}
           </ul>
         </div>
+        ) : null}
         <div>
           <h3 className="text-lg font-semibold text-slate-900">Detalles</h3>
           <div className="mt-3 space-y-2 text-sm text-slate-600">
@@ -139,6 +183,7 @@ export default function CourseDetailPage() {
           </div>
         </div>
       </div>
+      ) : null}
 
       <Link
         href="/"


### PR DESCRIPTION
## Summary
- Highlights the external `Ver curso` CTA near the course title.
- Adds a key-facts section for platform, level, duration, price, language, certificate, and rating when available.
- Hides the objectives/prerequisites/syllabus panel when no useful learning-content data exists.

## Decision / conversion / SEO impact
- Makes the detail page faster to scan before users leave for the platform.
- Puts the conversion action above secondary compare behavior.
- Reduces empty sections caused by currently sparse normalized catalog data.

## Validation
- `corepack pnpm validate:data` passed: 5 courses validated successfully.
- `corepack pnpm build` passed.

## Risk level
- Product-review: touches course detail UX.

## Follow-ups
- None.