### PR TITLE
Ignore generated project artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.next/
+node_modules/
+out/
+*.tsbuildinfo
+.env*.local


### PR DESCRIPTION
## Summary
- Adds a minimal `.gitignore` for generated dependency/build outputs and local env files.
- Confirmed there are no tracked test/spec files to remove in the current repo state.
- Leaves runtime code unchanged.

## Decision / conversion / SEO impact
- No product behavior change.
- Keeps future cleanup safer by preventing `.next`, `node_modules`, and local env files from entering PRs.

## Validation
- `corepack pnpm validate:data` passed: 5 courses validated successfully.
- `corepack pnpm build` passed.

## Risk level
- Safe: repo cleanup only, no runtime behavior change.

## Follow-ups
- None.