### PR TITLE
Fix course detail empty sections and CTA hierarchy

### DIFF
--- a/app/courses/[courseId]/CourseDetailClient.tsx
+++ b/app/courses/[courseId]/CourseDetailClient.tsx
@@ -39,6 +39,10 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
 
   const selected = isSelected(course.id);
   const atLimit = selectedIds.length >= 2 && !selected;
+  const hasObjectives = objectives.length > 0;
+  const hasPrerequisites = course.prerequisitesBullets.length > 0;
+  const hasSyllabus = course.syllabusBullets.length > 0;
+  const hasLearningContent = hasObjectives || hasPrerequisites || hasSyllabus;
 
   return (
     <section className="flex flex-col gap-8">
@@ -64,15 +68,25 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
             {course.priceText}
           </span>
         </div>
-        <button
-          type="button"
-          onClick={() => toggle(course.id)}
-          className={`w-fit rounded-lg px-5 py-2 text-sm font-semibold text-white transition ${
-            selected ? "bg-emerald-600 hover:bg-emerald-500" : "bg-blue-600 hover:bg-blue-500"
-          } ${atLimit ? "bg-slate-300" : ""}`}
-        >
-          {selected ? "Seleccionado para comparar" : "Agregar a comparación"}
-        </button>
+        <div className="flex flex-wrap items-center gap-3">
+          <a
+            href={course.externalUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-lg bg-blue-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-blue-500"
+          >
+            Ver curso
+          </a>
+          <button
+            type="button"
+            onClick={() => toggle(course.id)}
+            className={`w-fit rounded-lg px-5 py-2 text-sm font-semibold text-white transition ${
+              selected ? "bg-emerald-600 hover:bg-emerald-500" : "bg-slate-700 hover:bg-slate-600"
+            } ${atLimit ? "bg-slate-300" : ""}`}
+          >
+            {selected ? "Seleccionado para comparar" : "Agregar a comparación"}
+          </button>
+        </div>
         {atLimit ? (
           <p className="text-xs text-amber-600">
             Ya tienes 2 cursos seleccionados. Quita uno para continuar.
@@ -83,32 +97,42 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
         ) : null}
       </div>
 
-      <div className="grid gap-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm md:grid-cols-2">
-        <div>
+      {hasLearningContent ? (
+        <div className="grid gap-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm md:grid-cols-2">
+          {hasObjectives ? (
+            <div>
           <h3 className="text-lg font-semibold text-slate-900">Objetivos</h3>
           <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-600">
             {objectives.map((item) => (
               <li key={item}>{item}</li>
             ))}
           </ul>
-        </div>
-        <div>
+            </div>
+          ) : null}
+          {hasPrerequisites ? (
+            <div>
           <h3 className="text-lg font-semibold text-slate-900">Requisitos</h3>
           <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-600">
             {course.prerequisitesBullets.map((item) => (
               <li key={item}>{item}</li>
             ))}
           </ul>
-        </div>
-        <div>
+            </div>
+          ) : null}
+          {hasSyllabus ? (
+            <div>
           <h3 className="text-lg font-semibold text-slate-900">Temario resumido</h3>
           <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-600">
             {course.syllabusBullets.map((item) => (
               <li key={item}>{item}</li>
             ))}
           </ul>
+            </div>
+          ) : null}
         </div>
-        <div>
+      ) : null}
+
+      <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
           <h3 className="text-lg font-semibold text-slate-900">Detalles</h3>
           <div className="mt-3 space-y-2 text-sm text-slate-600">
             <p>
@@ -123,20 +147,8 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
                 <span className="font-semibold text-slate-800">Rating:</span> {course.rating.toFixed(1)}
               </p>
             ) : null}
-            <p>
-              <span className="font-semibold text-slate-800">Link externo:</span>{" "}
-              <a
-                href={course.externalUrl}
-                className="text-slate-900 underline"
-                target="_blank"
-                rel="noreferrer"
-              >
-                Ver curso
-              </a>
-            </p>
           </div>
         </div>
-      </div>
 
       <Link
         href="/"


### PR DESCRIPTION
## Summary
- Adds a prominent `Ver curso` CTA near the top of the course detail page.
- Keeps the compare button visible next to the primary CTA.
- Renders `Objetivos`, `Requisitos`, and `Temario resumido` only when their arrays contain items.
- Hides the optional learning-content container when all three sections are empty.
- Removes the duplicate `Link externo` row from `Detalles`.

## Decision / conversion / SEO impact
- Makes the primary conversion action easier to find.
- Removes empty headings that reduce trust and make sparse catalog data look broken.
- Keeps course details focused on verified available fields.

## Validation
- `corepack pnpm validate:data` passed: 5 courses validated successfully.
- `corepack pnpm build` passed.

## Risk level
- Product-review: touches course detail UX only.

## Follow-ups
- None.