### PR TITLE
Enrich existing course data conservatively

### DIFF
--- a/data/normalized/courses.json
+++ b/data/normalized/courses.json
@@ -17,6 +17,15 @@
     "certificate": true,
     "lastUpdatedAt": null,
     "shortDescription": "Machine Learning by Stanford University on Coursera (beginner level).",
+    "syllabusBullets": [
+      "Conceptos base de machine learning",
+      "Modelos y evaluacion de resultados",
+      "Aplicacion practica de aprendizaje automatico"
+    ],
+    "prerequisitesBullets": [
+      "Orientado a nivel beginner",
+      "Interes en datos e inteligencia artificial"
+    ],
     "source": "coursera-curated"
   },
   {
@@ -37,6 +46,15 @@
     "certificate": true,
     "lastUpdatedAt": null,
     "shortDescription": "Google Data Analytics by Google on Coursera (beginner level).",
+    "syllabusBullets": [
+      "Fundamentos de analisis de datos",
+      "Preparacion y exploracion de datos",
+      "Comunicacion de hallazgos"
+    ],
+    "prerequisitesBullets": [
+      "Orientado a nivel beginner",
+      "Interes en trabajar con datos"
+    ],
     "source": "coursera-curated"
   },
   {
@@ -57,6 +75,15 @@
     "certificate": true,
     "lastUpdatedAt": null,
     "shortDescription": "Deep Learning Specialization by DeepLearning.AI on Coursera (intermediate level).",
+    "syllabusBullets": [
+      "Conceptos de deep learning",
+      "Redes neuronales y entrenamiento",
+      "Aplicaciones practicas de modelos profundos"
+    ],
+    "prerequisitesBullets": [
+      "Nivel intermediate",
+      "Base previa en machine learning recomendada"
+    ],
     "source": "coursera-curated"
   },
   {
@@ -77,6 +104,15 @@
     "certificate": true,
     "lastUpdatedAt": null,
     "shortDescription": "IBM Data Science by IBM on Coursera (beginner level).",
+    "syllabusBullets": [
+      "Fundamentos de data science",
+      "Trabajo practico con datos",
+      "Introduccion a herramientas de ciencia de datos"
+    ],
+    "prerequisitesBullets": [
+      "Orientado a nivel beginner",
+      "Interes en analisis y ciencia de datos"
+    ],
     "source": "coursera-curated"
   },
   {
@@ -97,6 +133,15 @@
     "certificate": true,
     "lastUpdatedAt": null,
     "shortDescription": "Meta Front-End Developer by Meta on Coursera (beginner level).",
+    "syllabusBullets": [
+      "Fundamentos de desarrollo front-end",
+      "Construccion de interfaces web",
+      "Practica orientada a proyectos"
+    ],
+    "prerequisitesBullets": [
+      "Orientado a nivel beginner",
+      "Interes en crear interfaces web"
+    ],
     "source": "coursera-curated"
   }
 ]

--- a/src/lib/catalog-adapter.ts
+++ b/src/lib/catalog-adapter.ts
@@ -100,8 +100,8 @@ const mapCourse = (course: NormalizedCourse): Course | null => {
     language: course.language,
     certificate: course.certificate ?? false,
     shortDescription: course.shortDescription,
-    syllabusBullets: [],
-    prerequisitesBullets: [],
+    syllabusBullets: course.syllabusBullets,
+    prerequisitesBullets: course.prerequisitesBullets,
     externalUrl: course.url
   };
 };

--- a/src/lib/schema/course.ts
+++ b/src/lib/schema/course.ts
@@ -18,6 +18,8 @@ export const CourseSchema = z.object({
   certificate: z.boolean().nullable(),
   lastUpdatedAt: z.string().datetime().nullable(),
   shortDescription: z.string().nullable(),
+  syllabusBullets: z.array(z.string()).default([]),
+  prerequisitesBullets: z.array(z.string()).default([]),
   source: z.enum(["manual", "edx", "coursera", "coursera-curated", "other"]),
 });
 


### PR DESCRIPTION
## Summary
- Adds optional `syllabusBullets` and `prerequisitesBullets` to the normalized course schema.
- Maps those existing schema-supported fields through the catalog adapter into the runtime `Course` shape.
- Enriches the 5 existing normalized courses with short, conservative, decision-oriented bullets.

## Why it improves usefulness
- Course detail and compare surfaces can now show more than title/platform facts where the catalog has safe inferred content.
- No precise prices, ratings, review counts, or unverifiable claims were added.
- Fields remain empty by default when not available.

## Validation
- `corepack pnpm validate:data` passed: 5 courses validated successfully.
- `corepack pnpm build` passed.

## Risk level
- Product-review: data/schema adapter change, scoped to optional fields.

## Follow-ups
- Continue replacing inferred bullets with verified source-backed catalog data as ingestion improves.