### PR TITLE
Improve course detail usefulness with available data

### DIFF
--- a/app/courses/[courseId]/CourseDetailClient.tsx
+++ b/app/courses/[courseId]/CourseDetailClient.tsx
@@ -43,6 +43,16 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
   const hasPrerequisites = course.prerequisitesBullets.length > 0;
   const hasSyllabus = course.syllabusBullets.length > 0;
   const hasLearningContent = hasObjectives || hasPrerequisites || hasSyllabus;
+  const evaluationFacts = [
+    { label: "Plataforma", value: course.platform },
+    { label: "Nivel", value: course.level },
+    { label: "Duracion", value: course.durationText },
+    { label: "Precio", value: course.priceText },
+    {
+      label: "Certificado",
+      value: course.certificate ? "Incluido" : "No verificado"
+    }
+  ];
 
   return (
     <section className="flex flex-col gap-8">
@@ -130,7 +140,23 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
             </div>
           ) : null}
         </div>
-      ) : null}
+      ) : (
+        <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 className="text-lg font-semibold text-slate-900">
+            Que puedes evaluar
+          </h3>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {evaluationFacts.map((fact) => (
+              <div key={fact.label} className="rounded-lg bg-slate-50 px-4 py-3">
+                <span className="block text-xs font-medium text-slate-500">
+                  {fact.label}
+                </span>
+                <span className="font-semibold text-slate-800">{fact.value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
           <h3 className="text-lg font-semibold text-slate-900">Detalles</h3>


### PR DESCRIPTION
## Summary
- Keeps the prominent `Ver curso` CTA and compare button near the course summary.
- Shows optional syllabus/prerequisite sections when catalog data exists.
- Adds a compact `Que puedes evaluar` fallback using platform, level, duration, price, and certificate when optional learning content is absent.
- Does not change the server metadata wrapper or data model.

## Why it improves usefulness
- Detail pages remain useful even when the catalog lacks syllabus/prerequisite data.
- Empty learning headings are avoided while still exposing decision facts.

## Validation
- `corepack pnpm validate:data` passed: 5 courses validated successfully.
- `corepack pnpm build` passed.

## Risk level
- Product-review: course detail UX only.

## Follow-ups
- Once PR #28 lands, enriched bullets will populate the learning-content sections.