### PR TITLE
Add local outbound course click tracking

### DIFF
--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -3,6 +3,7 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 import { courses } from "@/lib/catalog-adapter";
+import { trackOutboundCourseClick } from "@/lib/outbound-tracking";
 
 const LAST_SKILL_KEY = "skills-compare-last-skill";
 
@@ -154,6 +155,7 @@ export default function CompareClient() {
               href={leftCourse.externalUrl}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={() => trackOutboundCourseClick(leftCourse, "compare")}
               className="w-fit rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
             >
               Ver curso
@@ -165,6 +167,7 @@ export default function CompareClient() {
               href={rightCourse.externalUrl}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={() => trackOutboundCourseClick(rightCourse, "compare")}
               className="w-fit rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
             >
               Ver curso

--- a/app/courses/[courseId]/CourseDetailClient.tsx
+++ b/app/courses/[courseId]/CourseDetailClient.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useMemo } from "react";
 import { courses } from "@/lib/catalog-adapter";
 import { useCompareSelection } from "@/contexts/CompareSelectionContext";
+import { trackOutboundCourseClick } from "@/lib/outbound-tracking";
 
 type CourseDetailClientProps = {
   courseId: string;
@@ -73,6 +74,7 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
             href={course.externalUrl}
             target="_blank"
             rel="noopener noreferrer"
+            onClick={() => trackOutboundCourseClick(course, "detail")}
             className="rounded-lg bg-blue-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-blue-500"
           >
             Ver curso

--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { Course } from "@/types/course";
 import { useCompareSelection } from "@/contexts/CompareSelectionContext";
+import { trackOutboundCourseClick } from "@/lib/outbound-tracking";
 
 type CourseCardProps = {
   course: Course;
@@ -64,6 +65,7 @@ export const CourseCard = ({ course }: CourseCardProps) => {
             href={course.externalUrl}
             target="_blank"
             rel="noopener noreferrer"
+            onClick={() => trackOutboundCourseClick(course, "card")}
             className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
           >
             Ver curso

--- a/src/lib/outbound-tracking.ts
+++ b/src/lib/outbound-tracking.ts
@@ -1,0 +1,34 @@
+import type { Course } from "@/types/course";
+
+export type OutboundCourseClickSource = "card" | "detail" | "compare";
+
+type OutboundCourseClickEvent = {
+  eventName: "outbound_course_click";
+  source: OutboundCourseClickSource;
+  courseId: string;
+  courseTitle: string;
+  platform: Course["platform"];
+  externalUrl: string;
+  occurredAt: string;
+};
+
+export const trackOutboundCourseClick = (
+  course: Course,
+  source: OutboundCourseClickSource
+) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const event: OutboundCourseClickEvent = {
+    eventName: "outbound_course_click",
+    source,
+    courseId: course.id,
+    courseTitle: course.title,
+    platform: course.platform,
+    externalUrl: course.externalUrl,
+    occurredAt: new Date().toISOString()
+  };
+
+  console.info("[tracking]", event);
+};


### PR DESCRIPTION
## Summary
- Adds `trackOutboundCourseClick` as a small local tracking utility.
- Tracks outbound course clicks from card, detail, and compare surfaces.
- Uses `console.info` with a structured local event only; no analytics provider or external request is added.
- Keeps external link behavior unchanged.

## Why it improves conversion measurement
- Establishes a consistent event shape for future analytics or affiliate tracking.
- Captures the source surface (`card`, `detail`, `compare`) needed to understand CTA performance later.

## Validation
- `corepack pnpm validate:data` passed: 5 courses validated successfully.
- `corepack pnpm build` passed.

## Risk level
- Product-review: client CTA click handlers, no external data transmission.

## Follow-ups
- Replace local console logging with an approved analytics destination when monetization tracking is ready.