### PR TITLE
Add external link disclosure copy

### DIFF
--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 import { courses } from "@/lib/catalog-adapter";
 import { trackOutboundCourseClick } from "@/lib/outbound-tracking";
+import { EXTERNAL_LINK_DISCLOSURE } from "@/lib/disclosure";
 
 const LAST_SKILL_KEY = "skills-compare-last-skill";
 

--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -3,6 +3,7 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 import { courses } from "@/lib/catalog-adapter";
+import { EXTERNAL_LINK_DISCLOSURE } from "@/lib/disclosure";
 
 const LAST_SKILL_KEY = "skills-compare-last-skill";
 
@@ -186,6 +187,7 @@ export default function CompareClient() {
           ))}
         </div>
       </div>
+      <p className="text-xs text-slate-500">{EXTERNAL_LINK_DISCLOSURE}</p>
 
       <button
         type="button"

--- a/app/courses/[courseId]/CourseDetailClient.tsx
+++ b/app/courses/[courseId]/CourseDetailClient.tsx
@@ -5,6 +5,7 @@ import { useMemo } from "react";
 import { courses } from "@/lib/catalog-adapter";
 import { useCompareSelection } from "@/contexts/CompareSelectionContext";
 import { trackOutboundCourseClick } from "@/lib/outbound-tracking";
+import { EXTERNAL_LINK_DISCLOSURE } from "@/lib/disclosure";
 
 type CourseDetailClientProps = {
   courseId: string;

--- a/app/courses/[courseId]/CourseDetailClient.tsx
+++ b/app/courses/[courseId]/CourseDetailClient.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useMemo } from "react";
 import { courses } from "@/lib/catalog-adapter";
 import { useCompareSelection } from "@/contexts/CompareSelectionContext";
+import { EXTERNAL_LINK_DISCLOSURE } from "@/lib/disclosure";
 
 type CourseDetailClientProps = {
   courseId: string;
@@ -87,6 +88,7 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
             {selected ? "Seleccionado para comparar" : "Agregar a comparación"}
           </button>
         </div>
+        <p className="text-xs text-slate-500">{EXTERNAL_LINK_DISCLOSURE}</p>
         {atLimit ? (
           <p className="text-xs text-amber-600">
             Ya tienes 2 cursos seleccionados. Quita uno para continuar.

--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Course } from "@/types/course";
 import { useCompareSelection } from "@/contexts/CompareSelectionContext";
 import { trackOutboundCourseClick } from "@/lib/outbound-tracking";
+import { EXTERNAL_LINK_DISCLOSURE } from "@/lib/disclosure";
 
 type CourseCardProps = {
   course: Course;

--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { Course } from "@/types/course";
 import { useCompareSelection } from "@/contexts/CompareSelectionContext";
+import { EXTERNAL_LINK_DISCLOSURE } from "@/lib/disclosure";
 
 type CourseCardProps = {
   course: Course;
@@ -85,6 +86,7 @@ export const CourseCard = ({ course }: CourseCardProps) => {
           Agregar a comparacion
         </label>
       </div>
+      <p className="text-xs text-slate-500">{EXTERNAL_LINK_DISCLOSURE}</p>
       {atLimit && !selected ? (
         <p className="text-xs text-amber-600">
           Limite alcanzado: quita un curso para agregar otro.

--- a/src/lib/disclosure.ts
+++ b/src/lib/disclosure.ts
@@ -1,0 +1,2 @@
+export const EXTERNAL_LINK_DISCLOSURE =
+  "Podemos recibir una comision si compras desde enlaces externos, sin coste adicional para ti.";


### PR DESCRIPTION
## Summary
- Adds a reusable external link disclosure string.
- Shows the disclosure near outbound CTAs on course cards, course detail, and compare.
- Uses neutral placeholder language and does not claim affiliate links are currently implemented.

## Why it improves trust and conversion readiness
- Makes future affiliate monetization expectations transparent before implementation.
- Keeps external course handoff honest without changing link behavior.

## Validation
- `corepack pnpm validate:data` passed: 5 courses validated successfully.
- `corepack pnpm build` passed.

## Risk level
- Product-review: visible disclosure copy near CTAs.

## Follow-ups
- Update the disclosure if/when real affiliate programs are enabled.