### PR TITLE
Improve internal course and skill links

### DIFF
--- a/app/courses/[courseId]/CourseDetailClient.tsx
+++ b/app/courses/[courseId]/CourseDetailClient.tsx
@@ -55,6 +55,14 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
           {course.shortDescription ?? "Descripción no disponible."}
         </p>
         <div className="flex flex-wrap gap-2 text-sm text-slate-600">
+          {course.skillTags[0] ? (
+            <Link
+              href={`/skills/${course.skillTags[0]}`}
+              className="rounded-full bg-blue-50 px-3 py-1 font-medium text-blue-700 hover:bg-blue-100"
+            >
+              Ver skill
+            </Link>
+          ) : null}
           <span className="rounded-full bg-slate-100 px-3 py-1">
             {course.platform}
           </span>
@@ -151,7 +159,7 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
         </div>
 
       <Link
-        href="/"
+        href={course.skillTags[0] ? `/skills/${course.skillTags[0]}` : "/"}
         className="text-sm font-semibold text-slate-600 hover:text-slate-900"
       >
         ← Volver al Home

--- a/app/skills/[skillSlug]/SkillClient.tsx
+++ b/app/skills/[skillSlug]/SkillClient.tsx
@@ -163,6 +163,12 @@ export default function SkillClient({ skillSlug: rawSkillSlug }: SkillClientProp
           <p>
             No encontramos esta skill. Estas opciones si tienen cursos disponibles.
           </p>
+          <Link
+            href="/"
+            className="mt-4 inline-flex rounded-lg border border-blue-200 px-4 py-2 text-sm font-semibold text-blue-700 hover:border-blue-300"
+          >
+            Ver alternativas
+          </Link>
           <div className="mt-5 flex flex-wrap justify-center gap-2">
             {alternatives.map((skill) => (
               <Link


### PR DESCRIPTION
## Summary
- Adds a skill-page link pill to course detail pages when a course has a skill tag.
- Points the course detail footer link back to related skill courses when possible.
- Adds an explicit `Ver alternativas` link from the unknown skill state.

## Why it improves SEO and navigation
- Creates clearer internal paths between home, skills, and course detail pages.
- Helps users recover from unknown skill URLs without leaving the product flow.

## Validation
- `corepack pnpm validate:data` passed: 5 courses validated successfully.
- `corepack pnpm build` passed.

## Risk level
- Product-review: internal navigation changes only.

## Follow-ups
- None.