### PR TITLE
Add agent guide for product-safe changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,7 @@ Use ingestion commands only for explicit data work. Data validation must pass be
 - Add source freshness fields only when they can be validated.
 - Preserve unknown prices and ratings until they are verified.
 - Keep normalized data schema changes small and reviewed.
+
+## Agent Workflow
+
+Agents working on this repository should follow [docs/AGENT_GUIDE.md](docs/AGENT_GUIDE.md).

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -1,0 +1,60 @@
+# Agent Guide
+
+This guide defines how coding agents should work on Skills Compare.
+
+## Product Direction
+
+Skills Compare is a decision engine for online courses. Users should be able to search a skill, explore relevant courses, compare options, decide what fits, and open the original course platform.
+
+It is not a generic course catalog.
+
+## Safe Changes Without Asking
+
+Agents may proceed without confirmation for:
+
+- Small UI copy improvements.
+- Internal navigation improvements.
+- Data display fixes that preserve existing schema semantics.
+- Optional schema extensions that are backward-compatible.
+- Documentation updates.
+- Local-only tracking structures that do not send data externally.
+- Refactors that remove duplication without changing behavior.
+
+## Stop And Ask
+
+Stop before:
+
+- Adding dependencies.
+- Calling external APIs or scraping.
+- Changing build scripts or deployment config.
+- Adding cookies, tracking providers, or backend analytics.
+- Making incompatible schema changes.
+- Inventing prices, ratings, review counts, rankings, or claims.
+- Deleting files or making destructive git changes.
+
+## Required Validation
+
+Every PR should run:
+
+```bash
+corepack pnpm validate:data
+corepack pnpm build
+```
+
+If validation or build fails twice for the same PR, stop and document the blocker.
+
+## Data Policy
+
+- Do not invent precise facts.
+- Keep unknown values as `null`, `unknown`, empty arrays, or explicit pending copy.
+- Safe generic bullets are acceptable only when inferred from existing title, provider, skill, level, and description.
+- Do not add fake ratings, review counts, prices, rankings, or outcome claims.
+- Data quality changes must pass validation before merge.
+
+## Product Copy Rules
+
+- Use neutral Spanish copy.
+- Prefer decision clarity over feature breadth.
+- Avoid visible MVP language in the product UI.
+- Missing data should read as `Pendiente de validar` or `No disponible`.
+- Price copy must not imply unverified amounts.


### PR DESCRIPTION
## Summary
- Adds `docs/AGENT_GUIDE.md` with product, data, validation, and stop-condition rules.
- Links the agent guide from the README.

## Product impact
- Makes future autonomous edits more consistent with Skills Compare as a decision engine.

## SEO / conversion impact
- No direct SEO or conversion UI change. Reduces risk of future low-quality product/data changes.

## Validation
- `corepack pnpm validate:data` passed.
- `corepack pnpm build` passed.

## Risk
- Safe: documentation only.

## Manual test checklist
- Open README and confirm the Agent Workflow link resolves.
- Review `docs/AGENT_GUIDE.md` for stop conditions and data policy.