### PR TITLE
Clarify home search flow

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -20,18 +20,22 @@ export default function HomeClient() {
     <section className="flex flex-col gap-8">
       <div className="space-y-3">
         <h2 className="text-3xl font-semibold text-slate-900">
-          Compara cursos online antes de elegir.
+          Encuentra cursos online por skill.
         </h2>
         <p className="max-w-2xl text-slate-600">
-          Busca una skill del catalogo, revisa cursos reales lado a lado y abre
-          la plataforma original cuando encuentres una opcion que encaje contigo.
+          Busca lo que quieres aprender, explora opciones disponibles y compara
+          cuando tengas cursos candidatos.
         </p>
       </div>
 
       <SearchBar placeholder="Ej: ai, data analysis, frontend" onSearch={handleSearch} />
-      <p className="text-sm text-slate-500">
-        Selecciona 2 cursos para comparar precio, duracion, nivel y certificado.
-      </p>
+      <div className="grid gap-3 text-sm text-slate-600 sm:grid-cols-3">
+        {["Buscar skill", "Explorar cursos", "Comparar opciones"].map((step) => (
+          <div key={step} className="rounded-lg bg-white px-4 py-3 shadow-sm">
+            {step}
+          </div>
+        ))}
+      </div>
 
       <div className="flex flex-wrap gap-2">
         {suggestions.map((skill) => (


### PR DESCRIPTION
## Summary
- Updates home copy to explain the product in 5 seconds.
- Uses the flow `Buscar skill -> Explorar cursos -> Comparar opciones`.
- Removes comparison-heavy copy before the user has searched.
- Keeps available skill suggestions visible.

## Product impact
- Aligns the home page with user intent: start by searching a skill, then evaluate courses.

## SEO / conversion impact
- Clearer first viewport should reduce confusion and move users into skill pages faster.

## Validation
- `corepack pnpm validate:data` passed.
- `corepack pnpm build` passed.

## Risk
- Product-review: home page copy and layout only.

## Manual test checklist
- Open `/` and confirm the flow is visible.
- Search for `ai` and confirm routing works.
- Click a skill suggestion and confirm it opens a skill page.