### PR TITLE
Clarify local outbound tracking mode

### DIFF
--- a/src/lib/outbound-tracking.ts
+++ b/src/lib/outbound-tracking.ts
@@ -9,6 +9,7 @@ type OutboundCourseClickEvent = {
   courseTitle: string;
   platform: Course["platform"];
   externalUrl: string;
+  trackingMode: "local_console_only";
   occurredAt: string;
 };
 
@@ -27,8 +28,9 @@ export const trackOutboundCourseClick = (
     courseTitle: course.title,
     platform: course.platform,
     externalUrl: course.externalUrl,
+    trackingMode: "local_console_only",
     occurredAt: new Date().toISOString()
   };
 
-  console.info("[tracking]", event);
+  console.info("[outbound-course-click]", event);
 };


### PR DESCRIPTION
## Summary
- Adds `trackingMode: local_console_only` to outbound course click events.
- Renames the console label to `[outbound-course-click]`.
- Keeps tracking local; no cookies, backend, provider, or external requests.

## Product impact
- Makes the monetization measurement foundation explicit and safer to evolve later.

## SEO / conversion impact
- No SEO change. Conversion click events are easier to identify during manual testing.

## Validation
- `corepack pnpm validate:data` passed.
- `corepack pnpm build` passed.

## Risk
- Product-review: local console event shape only.

## Manual test checklist
- Click `Ver curso` from card, detail, and compare.
- Confirm browser console logs `[outbound-course-click]` with source `card`, `detail`, or `compare`.
- Confirm links still open in a new tab.