### PR TITLE
Link compare titles to course details

### DIFF
--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 import { courses } from "@/lib/catalog-adapter";
@@ -151,7 +152,12 @@ export default function CompareClient() {
         <div className="grid grid-cols-3 gap-4 border-b border-slate-200 bg-slate-50 px-6 py-4 text-sm font-semibold text-slate-700">
           <span>Detalle</span>
           <span className="flex flex-col gap-3">
-            {leftCourse.title}
+            <Link
+              href={`/courses/${leftCourse.id}`}
+              className="text-slate-900 hover:underline"
+            >
+              {leftCourse.title}
+            </Link>
             <a
               href={leftCourse.externalUrl}
               target="_blank"
@@ -163,7 +169,12 @@ export default function CompareClient() {
             </a>
           </span>
           <span className="flex flex-col gap-3">
-            {rightCourse.title}
+            <Link
+              href={`/courses/${rightCourse.id}`}
+              className="text-slate-900 hover:underline"
+            >
+              {rightCourse.title}
+            </Link>
             <a
               href={rightCourse.externalUrl}
               target="_blank"


### PR DESCRIPTION
## Summary
- Adds internal links from compare course titles to their course detail pages.
- Keeps external `Ver curso` CTAs unchanged.

## Product impact
- Users can move from compare back into course detail for more context before leaving the product.

## SEO / conversion impact
- Strengthens internal linking between compare and course detail pages while preserving outbound conversion CTAs.

## Validation
- `corepack pnpm validate:data` passed.
- `corepack pnpm build` passed.

## Risk
- Product-review: compare navigation only.

## Manual test checklist
- Open compare with two courses.
- Click each course title and confirm it routes to `/courses/[courseId]`.
- Confirm `Ver curso` still opens the external platform.