### PR TITLE
Add language filter and frequency skill suggestions

### DIFF
--- a/app/skills/[skillSlug]/SkillClient.tsx
+++ b/app/skills/[skillSlug]/SkillClient.tsx
@@ -34,6 +34,7 @@ type FiltersState = {
   platform: string;
   level: string;
   priceModel: string;
+  language: string;
 };
 
 type SkillClientProps = {
@@ -46,7 +47,8 @@ export default function SkillClient({ skillSlug: rawSkillSlug }: SkillClientProp
   const [filters, setFilters] = useState<FiltersState>({
     platform: "All",
     level: "All",
-    priceModel: "All"
+    priceModel: "All",
+    language: "All"
   });
 
   const availableSkillSlugs = useMemo(() => {
@@ -88,6 +90,10 @@ export default function SkillClient({ skillSlug: rawSkillSlug }: SkillClientProp
       options.push({ value: "unknown", label: "Desconocido" });
     }
     return options;
+  }, []);
+  const languageOptions = useMemo(() => {
+    const languages = Array.from(new Set(courses.map((course) => course.language))).sort();
+    return ["All", ...languages];
   }, []);
 
   useEffect(() => {
@@ -142,8 +148,13 @@ export default function SkillClient({ skillSlug: rawSkillSlug }: SkillClientProp
           return true;
         }
         return course.priceModel === filters.priceModel;
-      });
-  }, [filters.level, filters.platform, filters.priceModel, skillSlug]);
+      })
+      .filter((course) =>
+        filters.language === "All"
+          ? true
+          : course.language.toLowerCase() === filters.language.toLowerCase()
+      );
+  }, [filters.language, filters.level, filters.platform, filters.priceModel, skillSlug]);
 
   return (
     <section className="flex flex-col gap-8 pb-24">
@@ -188,7 +199,8 @@ export default function SkillClient({ skillSlug: rawSkillSlug }: SkillClientProp
         options={{
           platforms: platformOptions,
           levels: levelOptions,
-          prices: priceOptions
+          prices: priceOptions,
+          languages: languageOptions
         }}
       />
 

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -4,6 +4,7 @@ type FiltersState = {
   platform: string;
   level: string;
   priceModel: string;
+  language: string;
 };
 
 type FiltersProps = {
@@ -13,6 +14,7 @@ type FiltersProps = {
     platforms: string[];
     levels: string[];
     prices: { value: string; label: string }[];
+    languages: string[];
   };
 };
 
@@ -25,14 +27,16 @@ const prices = [
   { value: "subscription", label: "Suscripción" },
   { value: "unknown", label: "Desconocido" }
 ];
+const languages = ["All"];
 
 export const Filters = ({ value, onChange, options }: FiltersProps) => {
   const platformOptions = options?.platforms ?? platforms;
   const levelOptions = options?.levels ?? levels;
   const priceOptions = options?.prices ?? prices;
+  const languageOptions = options?.languages ?? languages;
 
   return (
-    <div className="grid gap-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm md:grid-cols-3">
+    <div className="grid gap-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm md:grid-cols-4">
       <label className="flex flex-col gap-2 text-sm font-medium text-slate-600">
         Plataforma
         <select
@@ -75,6 +79,22 @@ export const Filters = ({ value, onChange, options }: FiltersProps) => {
           {priceOptions.map((price) => (
             <option key={price.value} value={price.value}>
               {price.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex flex-col gap-2 text-sm font-medium text-slate-600">
+        Idioma
+        <select
+          value={value.language}
+          onChange={(event) =>
+            onChange({ ...value, language: event.target.value })
+          }
+          className="rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700"
+        >
+          {languageOptions.map((language) => (
+            <option key={language} value={language}>
+              {language === "All" ? "Todos" : language}
             </option>
           ))}
         </select>

--- a/src/lib/skill-routing.ts
+++ b/src/lib/skill-routing.ts
@@ -35,15 +35,22 @@ const stripRoutePrefix = (value: string) =>
   value.replace(/^\/?skills\/?/, "").replace(/^skills-?/, "");
 
 export const getSkillOptions = (): SkillOption[] => {
-  const slugs = new Set<string>();
+  const counts = new Map<string, number>();
 
   courses.forEach((course) => {
-    course.skillTags.forEach((tag) => slugs.add(slugify(tag)));
+    course.skillTags.forEach((tag) => {
+      const slug = slugify(tag);
+      counts.set(slug, (counts.get(slug) ?? 0) + 1);
+    });
   });
 
-  return Array.from(slugs)
-    .sort()
-    .map((slug) => ({
+  return Array.from(counts.entries())
+    .sort(([leftSlug, leftCount], [rightSlug, rightCount]) =>
+      rightCount === leftCount
+        ? leftSlug.localeCompare(rightSlug)
+        : rightCount - leftCount
+    )
+    .map(([slug]) => ({
       slug,
       title: titleFromSlug(slug)
     }));


### PR DESCRIPTION
## Summary
- Sorts skill suggestions by catalog frequency, then alphabetically.
- Adds a dynamic language filter based on course data.
- Applies the language filter on skill course listings.

## Product impact
- Suggestions prioritize more represented skills and users can narrow courses by language.

## SEO / conversion impact
- Better filtering helps users reach relevant decisions faster; no SEO metadata changes.

## Validation
- `corepack pnpm validate:data` passed.
- `corepack pnpm build` passed after fixing local type/syntax issues in this branch.

## Risk
- Product-review: filter UI and skill suggestion ordering.

## Manual test checklist
- Open a skill page and confirm Idioma filter is visible.
- Select `en` and confirm the course list remains valid.
- Confirm home suggestions still route to skill pages.