### PR TITLE
Clean visible MVP and temporary copy

### DIFF
--- a/app/courses/[courseId]/CourseDetailClient.tsx
+++ b/app/courses/[courseId]/CourseDetailClient.tsx
@@ -33,7 +33,7 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
           href="/"
           className="rounded-lg bg-blue-600 px-5 py-2 text-sm font-semibold text-white hover:bg-blue-500"
         >
-          Ir al Home
+          Ir al inicio
         </Link>
       </section>
     );
@@ -192,7 +192,7 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
         href={course.skillTags[0] ? `/skills/${course.skillTags[0]}` : "/"}
         className="text-sm font-semibold text-slate-600 hover:text-slate-900"
       >
-        ← Volver al Home
+        Volver a cursos relacionados
       </Link>
     </section>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,13 +25,10 @@ export default function RootLayout({
                 </p>
                 <h1 className="text-xl font-semibold">Encuentra el curso ideal</h1>
               </Link>
-              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
-                MVP
-              </span>
             </header>
             <main className="flex-1 py-8">{children}</main>
             <footer className="border-t border-slate-200 py-6 text-sm text-slate-500">
-              MVP para validar Skills Compare con datos curados y enlaces a plataformas externas.
+              Datos curados y enlaces a plataformas externas.
             </footer>
           </div>
         </Providers>

--- a/src/contexts/CompareSelectionContext.tsx
+++ b/src/contexts/CompareSelectionContext.tsx
@@ -76,7 +76,7 @@ export const CompareSelectionProvider = ({ children }: { children: React.ReactNo
         return current.filter((item) => item !== id);
       }
       if (current.length >= MAX_COMPARE) {
-        setNotice(`Solo puedes comparar ${MAX_COMPARE} cursos por ahora.`);
+        setNotice(`Solo puedes comparar ${MAX_COMPARE} cursos.`);
         return current;
       }
       setNotice(null);


### PR DESCRIPTION
## Summary
- Removes visible `MVP` UI label and footer copy.
- Replaces `Home` wording in course detail with Spanish navigation copy.
- Removes `por ahora` from compare limit notice.

## Product impact
- Product UI feels less like an internal prototype and more like a user-facing decision tool.

## SEO / conversion impact
- Cleaner footer/header copy reduces trust friction. No metadata changes.

## Validation
- `corepack pnpm validate:data` passed.
- `corepack pnpm build` passed.

## Risk
- Product-review: visible copy cleanup only.

## Manual test checklist
- Confirm header no longer shows `MVP`.
- Confirm footer copy is neutral.
- Confirm course detail back link still works.