### PR TITLE
Clarify course card decision data

### DIFF
--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -50,6 +50,9 @@ export const CourseCard = ({ course }: CourseCardProps) => {
       {course.shortDescription ? (
         <p className="text-sm text-slate-600">{course.shortDescription}</p>
       ) : null}
+      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+        Datos para decidir
+      </p>
       <div className="grid gap-2 text-sm text-slate-600 sm:grid-cols-2">
         {facts.map((fact) => (
           <div key={fact.label} className="rounded-lg bg-slate-50 px-3 py-2">


### PR DESCRIPTION
## Summary
- Adds a small `Datos para decidir` label above course card facts.
- Keeps existing card content, CTA, comparison checkbox, and data unchanged.

## Product impact
- Helps users understand that the card facts are the decision surface, not decorative metadata.

## SEO / conversion impact
- No metadata change. Improves scan clarity before users click detail or external CTA.

## Validation
- `corepack pnpm validate:data` passed.
- `corepack pnpm build` passed.

## Risk
- Product-review: minimal card UI copy.

## Manual test checklist
- Open a skill page.
- Confirm each course card shows `Datos para decidir` above facts.
- Confirm card CTA and compare selection still work.