### PR TITLE
Normalize price label wording and add course source metadata scaffold

### DIFF
--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -53,25 +53,24 @@ export default function CompareClient() {
     if (!course) {
       return null;
     }
+
     if (course.priceModel === "free") {
-      return course.certificate ? "Gratis" : "Gratis (sin certificado)";
+      return course.certificate
+        ? "Gratis (certificado de pago)"
+        : "Gratis";
     }
-    if (course.priceAmount == null || course.currency == null) {
-      if (course.priceModel === "subscription") {
-        return course.certificate ? "Pago (certificado)" : "Precio no verificado";
-      }
-      if (course.priceModel === "paid_once") {
-        return course.certificate ? "Pago (certificado)" : "Precio no verificado";
-      }
-      return "Precio no verificado";
-    }
-    const formattedAmount = `${course.currency === "EUR" ? "EUR " : `${course.currency} `}${course.priceAmount}`;
+
     if (course.priceModel === "subscription") {
-      return course.priceInterval === "month"
-        ? `${formattedAmount}/mes`
-        : "Precio no verificado";
+      return "Gratis con opción de pago";
     }
-    return formattedAmount;
+
+    if (course.priceModel === "paid_once") {
+      return course.certificate
+        ? "Pago (certificado incluido)"
+        : "Pago";
+    }
+
+    return "Precio no verificado";
   };
 
   const truncateText = (value: string, maxLength: number) => {

--- a/data/normalized/course-source-metadata.json
+++ b/data/normalized/course-source-metadata.json
@@ -1,0 +1,42 @@
+[
+  {
+    "courseId": "machine-learning-stanford-university",
+    "sourceUrl": "https://www.coursera.org/learn/machine-learning",
+    "verificationStatus": "pending",
+    "verifiedAt": null,
+    "verifiedBy": null,
+    "notes": "Source URL captured from normalized catalog. Manual verification still pending."
+  },
+  {
+    "courseId": "google-data-analytics-google",
+    "sourceUrl": "https://www.coursera.org/professional-certificates/google-data-analytics",
+    "verificationStatus": "pending",
+    "verifiedAt": null,
+    "verifiedBy": null,
+    "notes": "Source URL captured from normalized catalog. Manual verification still pending."
+  },
+  {
+    "courseId": "deep-learning-specialization-deeplearningai",
+    "sourceUrl": "https://www.coursera.org/specializations/deep-learning",
+    "verificationStatus": "pending",
+    "verifiedAt": null,
+    "verifiedBy": null,
+    "notes": "Source URL captured from normalized catalog. Manual verification still pending."
+  },
+  {
+    "courseId": "ibm-data-science-ibm",
+    "sourceUrl": "https://www.coursera.org/professional-certificates/ibm-data-science",
+    "verificationStatus": "pending",
+    "verifiedAt": null,
+    "verifiedBy": null,
+    "notes": "Source URL captured from normalized catalog. Manual verification still pending."
+  },
+  {
+    "courseId": "meta-front-end-developer-meta",
+    "sourceUrl": "https://www.coursera.org/professional-certificates/meta-front-end-developer",
+    "verificationStatus": "pending",
+    "verifiedAt": null,
+    "verifiedBy": null,
+    "notes": "Source URL captured from normalized catalog. Manual verification still pending."
+  }
+]

--- a/docs/MVP_READINESS.md
+++ b/docs/MVP_READINESS.md
@@ -21,6 +21,11 @@
 - No sitemap or Open Graph layer exists yet.
 - Course freshness and source verification are limited.
 
+## Phase 1 Progress
+
+- ✅ Added a per-course source metadata file scaffold at `data/normalized/course-source-metadata.json`.
+- Current entries are intentionally marked `pending` until manual verification is completed.
+
 ## Current Limitations
 
 - Skills Compare should not claim a course is best without real ranking criteria.

--- a/src/lib/catalog-adapter.ts
+++ b/src/lib/catalog-adapter.ts
@@ -46,35 +46,18 @@ const formatDurationText = (durationHours: number | null): string => {
 
 const formatPriceText = (course: NormalizedCourse): string => {
   if (course.priceModel === "free") {
-    return "Gratis";
+    return course.certificate ? "Gratis (certificado de pago)" : "Gratis";
   }
 
-  const amountKnown = course.priceAmount != null && course.currency != null;
-
   if (course.priceModel === "subscription") {
-    if (!amountKnown) {
-      return "Desde suscripción";
-    }
-
-    const intervalLabel =
-      course.priceInterval === "year"
-        ? "año"
-        : course.priceInterval === "month"
-          ? "mes"
-          : "periodo";
-
-    return `${course.currency}${course.priceAmount}/${intervalLabel}`;
+    return "Gratis con opción de pago";
   }
 
   if (course.priceModel === "paid_once") {
-    if (!amountKnown) {
-      return "Pago único";
-    }
-
-    return `${course.currency}${course.priceAmount}`;
+    return course.certificate ? "Pago (certificado incluido)" : "Pago";
   }
 
-  return "Precio pendiente de validar";
+  return "Precio no verificado";
 };
 
 const mapCourse = (course: NormalizedCourse): Course | null => {


### PR DESCRIPTION
### Motivation

- Standardize how course pricing and certificate-related labels are presented across the app and mark unknown prices explicitly as unverified. 
- Add a scaffold for per-course source metadata so source verification can be tracked independently from the normalized catalog.

### Description

- Update price formatting in the compare UI (`app/compare/CompareClient.tsx`) to use consistent, certificate-aware Spanish labels and clearer fallbacks for subscription, one-time payment, and unknown pricing. 
- Mirror the same price-label adjustments in the catalog adapter (`src/lib/catalog-adapter.ts`) so the normalized `priceText` is consistent across listings and details. 
- Add a new scaffold file `data/normalized/course-source-metadata.json` containing initial `pending` entries for several normalized courses to capture source URLs and verification status. 
- Document the addition in `docs/MVP_READINESS.md` under a new "Phase 1 Progress" section.

### Testing

- Ran `corepack pnpm build` to validate the production build and it completed successfully. 
- Ran `corepack pnpm validate:data` to ensure normalized data validation still passes and it completed successfully. 
- No automated test changes were required for these string/metadata updates and existing checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20dd1951c832bb01969e1187d31f5)