### PR TITLE
Phase 2: Decision-first comparison UX and SEO support

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -17,37 +17,35 @@ export default function HomeClient() {
   };
 
   return (
-    <section className="flex flex-col gap-8">
+    <section className="flex flex-col gap-10">
       <div className="space-y-3">
-        <h2 className="text-3xl font-semibold text-slate-900">
-          Encuentra cursos online por skill.
+        <h2 className="text-3xl font-semibold leading-tight text-slate-900">
+          Compara cursos online para decidir mejor.
         </h2>
         <p className="max-w-2xl text-slate-600">
-          Busca lo que quieres aprender, explora opciones disponibles y compara
-          cuando tengas cursos candidatos.
+          Encuentra una skill y revisa cursos reales por precio, duración, nivel y
+          certificado para elegir con claridad.
         </p>
       </div>
 
       <SearchBar placeholder="Ej: ai, data analysis, frontend" onSearch={handleSearch} />
-      <div className="grid gap-3 text-sm text-slate-600 sm:grid-cols-3">
-        {["Buscar skill", "Explorar cursos", "Comparar opciones"].map((step) => (
-          <div key={step} className="rounded-lg bg-white px-4 py-3 shadow-sm">
-            {step}
-          </div>
-        ))}
-      </div>
 
-      <div className="flex flex-wrap gap-2">
-        {suggestions.map((skill) => (
-          <button
-            key={skill.slug}
-            type="button"
-            onClick={() => router.push(`/skills/${skill.slug}`)}
-            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300"
-          >
-            {skill.title}
-          </button>
-        ))}
+      <div className="space-y-3">
+        <p className="text-sm font-semibold uppercase tracking-[0.16em] text-slate-500">
+          Skills disponibles
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {suggestions.map((skill) => (
+            <button
+              key={skill.slug}
+              type="button"
+              onClick={() => router.push(`/skills/${skill.slug}`)}
+              className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300"
+            >
+              {skill.title}
+            </button>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { blogPosts, getBlogPost } from "@/lib/blog";
+
+type BlogPostPageProps = {
+  params: { slug: string };
+};
+
+export const generateStaticParams = () => blogPosts.map((post) => ({ slug: post.slug }));
+
+export const generateMetadata = ({ params }: BlogPostPageProps): Metadata => {
+  const post = getBlogPost(params.slug);
+  if (!post) {
+    return { title: "Artículo no encontrado | Blog", description: "Artículo no disponible." };
+  }
+  return { title: `${post.title} | Comparar cursos`, description: post.description };
+};
+
+export default function BlogPostPage({ params }: BlogPostPageProps) {
+  const post = getBlogPost(params.slug);
+
+  if (!post) {
+    return (
+      <section className="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center text-slate-600">
+        <p>Artículo no encontrado.</p>
+        <Link href="/blog" className="mt-4 inline-flex rounded-lg border border-blue-200 px-4 py-2 text-sm font-semibold text-blue-700">Volver al blog</Link>
+      </section>
+    );
+  }
+
+  return (
+    <article className="mx-auto flex max-w-3xl flex-col gap-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <header className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Guía práctica</p>
+        <h2 className="text-3xl font-semibold text-slate-900">{post.title}</h2>
+        <p className="text-slate-600">{post.description}</p>
+      </header>
+      {post.sections.map((section) => (
+        <section key={section.heading} className="space-y-3">
+          <h3 className="text-xl font-semibold text-slate-800">{section.heading}</h3>
+          <ul className="grid gap-2 text-slate-600">
+            {section.points.map((point) => (
+              <li key={point} className="rounded-lg bg-slate-50 px-3 py-2">{point}</li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </article>
+  );
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { blogPosts } from "@/lib/blog";
+
+export const metadata: Metadata = {
+  title: "Blog | Comparar cursos online",
+  description: "Guías prácticas para comparar cursos online y decidir antes de pagar."
+};
+
+export default function BlogPage() {
+  return (
+    <section className="flex flex-col gap-8">
+      <div className="space-y-2">
+        <h2 className="text-3xl font-semibold text-slate-900">Blog de comparación</h2>
+        <p className="text-slate-600">Contenido práctico para decidir entre cursos con datos claros.</p>
+      </div>
+      <div className="grid gap-4">
+        {blogPosts.map((post) => (
+          <article key={post.slug} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h3 className="text-xl font-semibold text-slate-900">{post.title}</h3>
+            <p className="mt-2 text-slate-600">{post.description}</p>
+            <Link href={`/blog/${post.slug}`} className="mt-3 inline-flex text-sm font-semibold text-blue-700 hover:text-blue-600">Leer artículo</Link>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -14,10 +14,7 @@ export default function CompareClient() {
   const searchParams = useSearchParams();
   const idsParam = searchParams.get("ids") ?? "";
 
-  const ids = useMemo(
-    () => idsParam.split(",").filter(Boolean).slice(0, 2),
-    [idsParam]
-  );
+  const ids = useMemo(() => idsParam.split(",").filter(Boolean).slice(0, 2), [idsParam]);
   const [leftId, rightId] = ids;
   const leftCourse = courses.find((course) => course.id === leftId);
   const rightCourse = courses.find((course) => course.id === rightId);
@@ -32,12 +29,8 @@ export default function CompareClient() {
   if (!hasTwoCourses) {
     return (
       <section className="flex flex-col items-center gap-4 rounded-2xl border border-dashed border-slate-300 bg-white p-10 text-center">
-        <h2 className="text-2xl font-semibold text-slate-900">
-          Selecciona cursos para comparar
-        </h2>
-        <p className="text-slate-600">
-          Vuelve al listado y selecciona cursos para comparar.
-        </p>
+        <h2 className="text-2xl font-semibold text-slate-900">Selecciona cursos para comparar</h2>
+        <p className="text-slate-600">Vuelve al listado y selecciona cursos para comparar.</p>
         <button
           type="button"
           onClick={handleChangeCourses}
@@ -49,184 +42,81 @@ export default function CompareClient() {
     );
   }
 
-  const formatPrice = (course: typeof leftCourse) => {
-    if (!course) {
-      return null;
-    }
-
-    if (course.priceModel === "free") {
-      return course.certificate
-        ? "Gratis (certificado de pago)"
-        : "Gratis";
-    }
-
-    if (course.priceModel === "subscription") {
-      return "Gratis con opción de pago";
-    }
-
-    if (course.priceModel === "paid_once") {
-      return course.certificate
-        ? "Pago (certificado incluido)"
-        : "Pago";
-    }
-
+  const formatPrice = (isFree: boolean, hasCertificate: boolean, model: string) => {
+    if (isFree) return hasCertificate ? "Gratis (certificado de pago)" : "Gratis";
+    if (model === "subscription") return "Gratis con opción de pago";
+    if (model === "paid_once") return hasCertificate ? "Pago (certificado incluido)" : "Pago";
     return "Precio no verificado";
-  };
-
-  const truncateText = (value: string, maxLength: number) => {
-    if (value.length <= maxLength) {
-      return value;
-    }
-    return `${value.slice(0, maxLength).trim()}…`;
-  };
-
-  const formatDescription = (course: typeof leftCourse) => {
-    const description = course?.shortDescription;
-    if (!description) {
-      return null;
-    }
-    return truncateText(description, 140);
-  };
-
-  const formatRating = (course: typeof leftCourse) => {
-    if (!course?.rating) {
-      return null;
-    }
-    return course.rating.toFixed(1);
   };
 
   const rawRows = [
     {
       label: "Precio",
-      left: formatPrice(leftCourse),
-      right: formatPrice(rightCourse)
-    },
-    {
-      label: "Descripción",
-      left: formatDescription(leftCourse),
-      right: formatDescription(rightCourse),
-      className: "text-sm text-slate-600"
+      left: formatPrice(leftCourse.priceModel === "free", leftCourse.certificate, leftCourse.priceModel),
+      right: formatPrice(rightCourse.priceModel === "free", rightCourse.certificate, rightCourse.priceModel)
     },
     { label: "Plataforma", left: leftCourse.platform, right: rightCourse.platform },
     { label: "Duración", left: leftCourse.durationText, right: rightCourse.durationText },
     { label: "Nivel", left: leftCourse.level, right: rightCourse.level },
-    {
-      label: "Rating",
-      left: formatRating(leftCourse),
-      right: formatRating(rightCourse)
-    },
     { label: "Idioma", left: leftCourse.language, right: rightCourse.language },
-    {
-      label: "Certificado",
-      left: leftCourse.certificate ? "Sí" : "No",
-      right: rightCourse.certificate ? "Sí" : "No"
-    },
-    {
-      label: "Puntos clave",
-      left:
-        leftCourse.syllabusBullets?.length
-          ? leftCourse.syllabusBullets.slice(0, 3).join(" · ")
-          : null,
-      right:
-        rightCourse.syllabusBullets?.length
-          ? rightCourse.syllabusBullets.slice(0, 3).join(" · ")
-          : null,
-      className: "text-sm text-slate-600"
-    }
+    { label: "Certificado", left: leftCourse.certificate ? "Sí" : "No", right: rightCourse.certificate ? "Sí" : "No" }
   ];
-  const rows = rawRows.filter((row) => row.left || row.right);
-  const getRowGroup = (label: string) => {
-    if (label === "Precio" || label === "Certificado") {
-      return "Coste";
-    }
-    if (label === "DuraciÃ³n") {
-      return "Esfuerzo";
-    }
-    if (label === "Nivel") {
-      return "Nivel";
-    }
-    if (label === "DescripciÃ³n" || label === "Puntos clave") {
-      return "Contenido";
-    }
-    return "Contexto";
-  };
+
+  const summaryInsights = [
+    leftCourse.level === rightCourse.level
+      ? `Ambos cursos son nivel ${leftCourse.level.toLowerCase()}.`
+      : `Los niveles son distintos: ${leftCourse.level} vs ${rightCourse.level}.`,
+    leftCourse.durationText === rightCourse.durationText
+      ? "Ambos cursos reportan la misma duración."
+      : `La duración reportada es distinta: ${leftCourse.durationText} vs ${rightCourse.durationText}.`,
+    leftCourse.certificate === rightCourse.certificate
+      ? leftCourse.certificate
+        ? "Ambos cursos incluyen certificado."
+        : "En ambos cursos el certificado no está verificado."
+      : "Solo uno de los cursos incluye certificado.",
+    leftCourse.priceModel === rightCourse.priceModel
+      ? `El modelo de precio es el mismo en ambos (${leftCourse.priceModel}).`
+      : `Los modelos de precio son distintos: ${leftCourse.priceModel} vs ${rightCourse.priceModel}.`
+  ];
 
   return (
     <section className="flex flex-col gap-8">
       <div className="flex flex-col gap-3">
-        <h2 className="text-3xl font-semibold text-slate-900">
-          Comparativa de cursos
-        </h2>
-        <p className="text-slate-600">
-          Revisa rápidamente las diferencias clave entre ambos cursos.
-        </p>
+        <h2 className="text-3xl font-semibold text-slate-900">Comparativa de cursos</h2>
+        <p className="text-slate-600">Revisa diferencias verificadas para tomar una decisión más clara.</p>
+      </div>
+
+      <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h3 className="text-lg font-semibold text-slate-900">Resumen rápido</h3>
+        <ul className="mt-3 grid gap-2 text-sm text-slate-600">
+          {summaryInsights.map((insight) => (
+            <li key={insight} className="rounded-lg bg-slate-50 px-3 py-2">{insight}</li>
+          ))}
+        </ul>
       </div>
 
       <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
         <div className="grid grid-cols-3 gap-4 border-b border-slate-200 bg-slate-50 px-6 py-4 text-sm font-semibold text-slate-700">
           <span>Detalle</span>
           <span className="flex flex-col gap-3">
-            <Link
-              href={`/courses/${leftCourse.id}`}
-              className="text-slate-900 hover:underline"
-            >
-              {leftCourse.title}
-            </Link>
-            <a
-              href={leftCourse.externalUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => trackOutboundCourseClick(leftCourse, "compare")}
-              className="w-fit rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
-            >
-              Ver curso
-            </a>
+            <Link href={`/courses/${leftCourse.id}`} className="text-slate-900 hover:underline">{leftCourse.title}</Link>
+            <a href={leftCourse.externalUrl} target="_blank" rel="noopener noreferrer" onClick={() => trackOutboundCourseClick(leftCourse, "compare")} className="w-fit rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500">Ver curso en {leftCourse.platform}</a>
+            <span className="text-xs font-normal text-slate-500">Se abrirá en una página externa.</span>
           </span>
           <span className="flex flex-col gap-3">
-            <Link
-              href={`/courses/${rightCourse.id}`}
-              className="text-slate-900 hover:underline"
-            >
-              {rightCourse.title}
-            </Link>
-            <a
-              href={rightCourse.externalUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => trackOutboundCourseClick(rightCourse, "compare")}
-              className="w-fit rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
-            >
-              Ver curso
-            </a>
+            <Link href={`/courses/${rightCourse.id}`} className="text-slate-900 hover:underline">{rightCourse.title}</Link>
+            <a href={rightCourse.externalUrl} target="_blank" rel="noopener noreferrer" onClick={() => trackOutboundCourseClick(rightCourse, "compare")} className="w-fit rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500">Ver curso en {rightCourse.platform}</a>
+            <span className="text-xs font-normal text-slate-500">Se abrirá en una página externa.</span>
           </span>
         </div>
         <div className="divide-y divide-slate-200">
-          {rows.map((row, index) => {
-            const group = getRowGroup(row.label);
-            const previousGroup =
-              index > 0 ? getRowGroup(rows[index - 1].label) : null;
+          {rawRows.map((row) => {
             const differs = row.left !== row.right;
-
             return (
-              <div key={row.label}>
-                {group !== previousGroup ? (
-                  <div className="bg-slate-100 px-6 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
-                    {group}
-                  </div>
-                ) : null}
-                <div
-                  className={`grid grid-cols-3 gap-4 px-6 py-4 text-sm text-slate-600 ${
-                    differs ? "bg-blue-50/50" : "bg-white"
-                  }`}
-                >
-                  <span className="font-semibold text-slate-700">{row.label}</span>
-                  <span className={row.className}>
-                    {row.left ?? "Pendiente de validar"}
-                  </span>
-                  <span className={row.className}>
-                    {row.right ?? "Pendiente de validar"}
-                  </span>
-                </div>
+              <div key={row.label} className={`grid grid-cols-3 gap-4 px-6 py-4 text-sm text-slate-600 ${differs ? "bg-blue-50/50" : "bg-white"}`}>
+                <span className="font-semibold text-slate-700">{row.label}</span>
+                <span>{row.left}</span>
+                <span>{row.right}</span>
               </div>
             );
           })}
@@ -234,13 +124,7 @@ export default function CompareClient() {
       </div>
       <p className="text-xs text-slate-500">{EXTERNAL_LINK_DISCLOSURE}</p>
 
-      <button
-        type="button"
-        onClick={handleChangeCourses}
-        className="w-fit rounded-lg border border-blue-200 px-5 py-2 text-sm font-semibold text-blue-700 hover:border-blue-300"
-      >
-        Cambiar cursos
-      </button>
+      <button type="button" onClick={handleChangeCourses} className="w-fit rounded-lg border border-blue-200 px-5 py-2 text-sm font-semibold text-blue-700 hover:border-blue-300">Cambiar cursos</button>
     </section>
   );
 }

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -5,9 +5,9 @@ import { Suspense } from "react";
 import CompareClient from "./CompareClient";
 
 export const metadata: Metadata = {
-  title: "Comparar cursos | Skills Compare",
+  title: "Compare two online courses | Skills Compare",
   description:
-    "Compara dos cursos online por precio, duracion, nivel, certificado y plataforma antes de elegir."
+    "Course comparison page to compare two online courses by price, duration, level, certificate and platform."
 };
 
 export default function ComparePage() {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,8 +4,8 @@ import "./globals.css";
 import { Providers } from "./providers";
 
 export const metadata: Metadata = {
-  title: "Skills Compare",
-  description: "Compara cursos online y elige donde aprender"
+  title: "Compare online courses | Skills Compare",
+  description: "Course comparison tool to compare online courses by price, duration, level and certificate."
 };
 
 export default function RootLayout({
@@ -25,6 +25,10 @@ export default function RootLayout({
                 </p>
                 <h1 className="text-xl font-semibold">Encuentra el curso ideal</h1>
               </Link>
+              <nav className="flex items-center gap-4 text-sm font-medium text-slate-600">
+                <Link href="/compare" className="hover:text-slate-900">Comparar cursos</Link>
+                <Link href="/blog" className="hover:text-slate-900">Blog</Link>
+              </nav>
             </header>
             <main className="flex-1 py-8">{children}</main>
             <footer className="border-t border-slate-200 py-6 text-sm text-slate-500">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,9 +2,9 @@ import type { Metadata } from "next";
 import HomeClient from "./HomeClient";
 
 export const metadata: Metadata = {
-  title: "Skills Compare | Compara cursos online",
+  title: "Compare courses online | Skills Compare",
   description:
-    "Busca una skill, compara cursos online por precio, duración, nivel y certificado, y elige dónde aprender."
+    "Compare online courses by price, duration, level and certificate before deciding."
 };
 
 export default function HomePage() {

--- a/app/skills/[skillSlug]/SkillClient.tsx
+++ b/app/skills/[skillSlug]/SkillClient.tsx
@@ -169,14 +169,19 @@ export default function SkillClient({ skillSlug: rawSkillSlug }: SkillClientProp
           {skillIntro ??
             "No tenemos cursos validados para esta skill. Revisa alternativas disponibles en el catalogo."}
         </p>
-        {skillExists ? (
-          <p className="mt-2 text-sm text-slate-500">
-            Catalogo actual: {skillCourses.length} cursos
+        
+      </div>
+
+      {skillExists ? (
+        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <h3 className="text-lg font-semibold text-slate-900">Sobre esta skill</h3>
+          <p className="mt-2 text-sm text-slate-600">
+            {skillCourses.length} cursos verificados
             {availablePlatforms ? ` en ${availablePlatforms}` : ""}
             {availableLevels ? `, niveles ${availableLevels}` : ""}.
           </p>
-        ) : null}
-      </div>
+        </div>
+      ) : null}
 
       {skillExists ? (
         <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">

--- a/app/skills/[skillSlug]/page.tsx
+++ b/app/skills/[skillSlug]/page.tsx
@@ -22,7 +22,7 @@ export const generateMetadata = ({ params }: SkillPageProps): Metadata => {
   const courseCount = getCoursesForSkill(skill.slug).length;
 
   return {
-    title: `Cursos de ${skill.title} | Skills Compare`,
+    title: `Compare ${skill.title} courses online | Skills Compare`,
     description: `Compara ${courseCount} cursos de ${skill.title} por plataforma, precio, duracion y nivel antes de elegir.`
   };
 };

--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -23,17 +23,17 @@ export const CourseCard = ({ course }: CourseCardProps) => {
   const facts = [
     { label: "Plataforma", value: course.platform },
     { label: "Nivel", value: course.level },
-    hasKnownDuration ? { label: "Duracion", value: course.durationText } : null,
+    hasKnownDuration ? { label: "Duración", value: course.durationText } : null,
     hasKnownPrice ? { label: "Precio", value: course.priceText } : null,
     {
       label: "Certificado",
       value: course.certificate ? "Incluido" : "No verificado"
     },
-    course.rating ? { label: "Rating", value: course.rating.toFixed(1) } : null
+    course.language ? { label: "Idioma", value: course.language } : null
   ].filter((fact): fact is { label: string; value: string } => fact !== null);
 
   return (
-    <div className="flex h-full flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+    <div className="flex h-full flex-col gap-5 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
       <div className="flex items-start justify-between gap-4">
         <div>
           <h3 className="text-lg font-semibold text-slate-900">{course.title}</h3>
@@ -48,20 +48,22 @@ export const CourseCard = ({ course }: CourseCardProps) => {
         ) : null}
       </div>
       {course.shortDescription ? (
-        <p className="text-sm text-slate-600">{course.shortDescription}</p>
+        <p className="text-sm leading-relaxed text-slate-600">{course.shortDescription}</p>
       ) : null}
-      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
-        Datos para decidir
-      </p>
-      <div className="grid gap-2 text-sm text-slate-600 sm:grid-cols-2">
-        {facts.map((fact) => (
-          <div key={fact.label} className="rounded-lg bg-slate-50 px-3 py-2">
-            <span className="block text-xs font-medium text-slate-500">
-              {fact.label}
-            </span>
-            <span className="font-semibold text-slate-800">{fact.value}</span>
-          </div>
-        ))}
+      <div className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+          Datos para decidir
+        </p>
+        <div className="grid gap-2 text-sm text-slate-600 sm:grid-cols-2">
+          {facts.map((fact) => (
+            <div key={fact.label} className="rounded-lg bg-slate-50 px-3 py-2">
+              <span className="block text-xs font-medium text-slate-500">
+                {fact.label}
+              </span>
+              <span className="font-semibold text-slate-800">{fact.value}</span>
+            </div>
+          ))}
+        </div>
       </div>
       <div className="mt-auto flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
@@ -72,7 +74,7 @@ export const CourseCard = ({ course }: CourseCardProps) => {
             onClick={() => trackOutboundCourseClick(course, "card")}
             className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
           >
-            Ver curso
+            Ver curso en {course.platform}
           </a>
           <Link
             href={`/courses/${course.id}`}
@@ -88,13 +90,14 @@ export const CourseCard = ({ course }: CourseCardProps) => {
             onChange={() => toggle(course.id)}
             className="h-4 w-4 rounded border-slate-300 text-slate-900"
           />
-          Agregar a comparacion
+          Agregar a comparación
         </label>
       </div>
+      <p className="text-xs text-slate-500">Se abrirá en una página externa.</p>
       <p className="text-xs text-slate-500">{EXTERNAL_LINK_DISCLOSURE}</p>
       {atLimit && !selected ? (
         <p className="text-xs text-amber-600">
-          Limite alcanzado: quita un curso para agregar otro.
+          Límite alcanzado: quita un curso para agregar otro.
         </p>
       ) : null}
     </div>

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,0 +1,38 @@
+export type BlogPost = {
+  slug: string;
+  title: string;
+  description: string;
+  sections: { heading: string; points: string[] }[];
+};
+
+export const blogPosts: BlogPost[] = [
+  {
+    slug: "como-elegir-entre-dos-cursos",
+    title: "Cómo elegir entre dos cursos",
+    description: "Guía práctica para comparar dos cursos sin suposiciones y decidir más rápido.",
+    sections: [
+      { heading: "1) Define tu criterio de decisión", points: ["Compara por precio total real.", "Compara por tiempo semanal y duración.", "Verifica si el certificado está incluido o es de pago."] },
+      { heading: "2) Revisa diferencias verificadas", points: ["Si el nivel es igual, enfócate en duración y certificado.", "Si la plataforma cambia, revisa idioma y formato.", "Evita decidir por opiniones sin datos comparables."] }
+    ]
+  },
+  {
+    slug: "que-comparar-antes-de-pagar-un-curso",
+    title: "Qué comparar antes de pagar un curso",
+    description: "Checklist concreta para pagar un curso con más claridad.",
+    sections: [
+      { heading: "Antes de pagar", points: ["Modelo de precio: pago único, suscripción o certificado aparte.", "Duración estimada para completar el curso.", "Nivel declarado y si coincide con tu punto de partida."] },
+      { heading: "Evita errores comunes", points: ["No uses solo el rating para decidir.", "No asumas que certificado significa empleabilidad.", "No pagues sin comparar al menos dos opciones."] }
+    ]
+  },
+  {
+    slug: "curso-gratis-vs-de-pago-que-cambia-realmente",
+    title: "Curso gratis vs de pago: qué cambia realmente",
+    description: "Comparación simple para entender cuándo un curso gratis o de pago encaja mejor.",
+    sections: [
+      { heading: "Qué suele cambiar", points: ["Certificado: en muchos casos requiere pago.", "Soporte o acompañamiento: puede variar por plataforma.", "Compromiso: pagar puede influir en constancia, pero no en calidad por sí solo."] },
+      { heading: "Cómo decidir", points: ["Si necesitas validar aprendizaje, revisa certificado y coste total.", "Si quieres explorar una skill, empieza por opción gratis.", "Compara siempre duración, nivel e idioma antes de decidir."] }
+    ]
+  }
+];
+
+export const getBlogPost = (slug: string) => blogPosts.find((post) => post.slug === slug);


### PR DESCRIPTION
### Motivation
- Focus the product on course comparison by removing non-functional UI and tightening entry copy so users take real actions (search / open skill). 
- Improve decision clarity and trust in comparisons by surfacing only factual differences and clearer outbound CTAs. 
- Add lightweight SEO content that supports comparison decisions without introducing recommendations, external APIs, or ranking.

### Description
- Clean UX and entry copy: removed the placeholder steps block and tightened homepage copy to emphasize comparison-first flows (`app/HomeClient.tsx`).
- Compare improvements: added a factual `Resumen rápido` block, simplified comparison rows to decision-relevant fields, and updated outbound CTAs with platform-specific labels and external-page notices (`app/compare/CompareClient.tsx`, `app/compare/page.tsx`).
- Course cards and skill context: made `Datos para decidir` consistent with compare fields, improved spacing/readability, added explicit external notice, and added a light “Sobre esta skill” block showing verified counts/platforms/levels without recommendations (`src/components/CourseCard.tsx`, `app/skills/[skillSlug]/SkillClient.tsx`, `app/skills/[skillSlug]/page.tsx`).
- SEO & blog support: added a small local blog system and pages with three practical comparison articles and updated site/page metadata and header nav to emphasize comparison intent (`src/lib/blog.ts`, `app/blog/page.tsx`, `app/blog/[slug]/page.tsx`, `app/layout.tsx`, `app/page.tsx`).
- Files changed by category: Product UX (`app/HomeClient.tsx`, `app/compare/CompareClient.tsx`, `src/components/CourseCard.tsx`, `app/skills/[skillSlug]/SkillClient.tsx`, `app/layout.tsx`), SEO/content (`app/page.tsx`, `app/compare/page.tsx`, `app/skills/[skillSlug]/page.tsx`, `app/blog/page.tsx`, `app/blog/[slug]/page.tsx`, `src/lib/blog.ts`).
- Follow-ups / notes: consider internal links from skill/compare pages to relevant blog articles and extend `Resumen rápido` rules when more verified fields become available.

### Testing
- Ran `corepack pnpm validate:data` which completed successfully (`5 courses validated successfully`).
- Ran `corepack pnpm build` which completed successfully (Next.js build and static pages generated).
- Risk level: `product-review` because changes touch `app/**` and `src/components/**` and affect user-facing UX and SEO text.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21e8a6888832ba74a7fbe0ca01610)