### PR TITLE
Improve compare decision clarity

### DIFF
--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -3,10 +3,11 @@
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
+import { AdPlaceholder } from "@/components/AdPlaceholder";
+import { EXTERNAL_LINK_DISCLOSURE } from "@/lib/disclosure";
+import { formatCoursePrice } from "@/lib/formatPrice";
 import { courses } from "@/lib/catalog-adapter";
 import { trackOutboundCourseClick } from "@/lib/outbound-tracking";
-import { EXTERNAL_LINK_DISCLOSURE } from "@/lib/disclosure";
-import { AdPlaceholder } from "@/components/AdPlaceholder";
 
 const LAST_SKILL_KEY = "skills-compare-last-skill";
 
@@ -15,7 +16,10 @@ export default function CompareClient() {
   const searchParams = useSearchParams();
   const idsParam = searchParams.get("ids") ?? "";
 
-  const ids = useMemo(() => idsParam.split(",").filter(Boolean).slice(0, 2), [idsParam]);
+  const ids = useMemo(
+    () => idsParam.split(",").filter(Boolean).slice(0, 2),
+    [idsParam]
+  );
   const [leftId, rightId] = ids;
   const leftCourse = courses.find((course) => course.id === leftId);
   const rightCourse = courses.find((course) => course.id === rightId);
@@ -30,8 +34,12 @@ export default function CompareClient() {
   if (!hasTwoCourses) {
     return (
       <section className="flex flex-col items-center gap-4 rounded-2xl border border-dashed border-slate-300 bg-white p-10 text-center">
-        <h2 className="text-2xl font-semibold text-slate-900">Selecciona cursos para comparar</h2>
-        <p className="text-slate-600">Vuelve al listado y selecciona cursos para comparar.</p>
+        <h2 className="text-2xl font-semibold text-slate-900">
+          Selecciona cursos para comparar
+        </h2>
+        <p className="text-slate-600">
+          Vuelve al listado y selecciona cursos para comparar.
+        </p>
         <button
           type="button"
           onClick={handleChangeCourses}
@@ -43,55 +51,73 @@ export default function CompareClient() {
     );
   }
 
-  const formatPrice = (isFree: boolean, hasCertificate: boolean, model: string) => {
-    if (isFree) return hasCertificate ? "Gratis (certificado de pago)" : "Gratis";
-    if (model === "subscription") return "Gratis con opción de pago";
-    if (model === "paid_once") return hasCertificate ? "Pago (certificado incluido)" : "Pago";
-    return "Precio no verificado";
+  const formatLevel = (level: string) => {
+    if (level === "Beginner") return "Principiante";
+    if (level === "Intermediate") return "Intermedio";
+    if (level === "Advanced") return "Avanzado";
+    return level;
   };
 
+  const leftPrice = formatCoursePrice(leftCourse);
+  const rightPrice = formatCoursePrice(rightCourse);
+
   const rawRows = [
-    {
-      label: "Precio",
-      left: formatPrice(leftCourse.priceModel === "free", leftCourse.certificate, leftCourse.priceModel),
-      right: formatPrice(rightCourse.priceModel === "free", rightCourse.certificate, rightCourse.priceModel)
-    },
+    { label: "Precio", left: leftPrice, right: rightPrice },
     { label: "Plataforma", left: leftCourse.platform, right: rightCourse.platform },
     { label: "Duración", left: leftCourse.durationText, right: rightCourse.durationText },
-    { label: "Nivel", left: leftCourse.level, right: rightCourse.level },
+    {
+      label: "Nivel",
+      left: formatLevel(leftCourse.level),
+      right: formatLevel(rightCourse.level)
+    },
     { label: "Idioma", left: leftCourse.language, right: rightCourse.language },
-    { label: "Certificado", left: leftCourse.certificate ? "Sí" : "No", right: rightCourse.certificate ? "Sí" : "No" }
+    {
+      label: "Certificado",
+      left: leftCourse.certificate ? "Incluido" : "No verificado",
+      right: rightCourse.certificate ? "Incluido" : "No verificado"
+    }
   ];
 
   const summaryInsights = [
     leftCourse.level === rightCourse.level
-      ? `Ambos cursos son nivel ${leftCourse.level.toLowerCase()}.`
-      : `Los niveles son distintos: ${leftCourse.level} vs ${rightCourse.level}.`,
+      ? `Ambos cursos tienen nivel ${formatLevel(leftCourse.level).toLowerCase()}.`
+      : `Los niveles son distintos: ${formatLevel(leftCourse.level)} vs ${formatLevel(rightCourse.level)}.`,
     leftCourse.durationText === rightCourse.durationText
-      ? "Ambos cursos reportan la misma duración."
-      : `La duración reportada es distinta: ${leftCourse.durationText} vs ${rightCourse.durationText}.`,
+      ? "Ambos cursos declaran la misma duración."
+      : `La duración declarada es distinta: ${leftCourse.durationText} vs ${rightCourse.durationText}.`,
+    leftPrice === rightPrice
+      ? `El precio mostrado coincide: ${leftPrice}.`
+      : `El precio o modelo de pago cambia: ${leftPrice} vs ${rightPrice}.`,
+    leftCourse.language === rightCourse.language
+      ? `Ambos cursos están en ${leftCourse.language}.`
+      : `Los idiomas son distintos: ${leftCourse.language} vs ${rightCourse.language}.`,
     leftCourse.certificate === rightCourse.certificate
       ? leftCourse.certificate
         ? "Ambos cursos incluyen certificado."
-        : "En ambos cursos el certificado no está verificado."
-      : "Solo uno de los cursos incluye certificado.",
-    leftCourse.priceModel === rightCourse.priceModel
-      ? `El modelo de precio es el mismo en ambos (${leftCourse.priceModel}).`
-      : `Los modelos de precio son distintos: ${leftCourse.priceModel} vs ${rightCourse.priceModel}.`
+        : "En ambos cursos el certificado queda pendiente de validar."
+      : "Solo uno de los cursos declara certificado incluido."
   ];
 
   return (
     <section className="flex flex-col gap-8">
       <div className="flex flex-col gap-3">
-        <h2 className="text-3xl font-semibold text-slate-900">Comparativa de cursos</h2>
-        <p className="text-slate-600">Revisa diferencias verificadas para tomar una decisión más clara.</p>
+        <h2 className="text-3xl font-semibold text-slate-900">
+          Comparativa de cursos
+        </h2>
+        <p className="text-slate-600">
+          Revisa diferencias verificadas para tomar una decisión más clara.
+        </p>
       </div>
 
       <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h3 className="text-lg font-semibold text-slate-900">Resumen rápido</h3>
+        <h3 className="text-lg font-semibold text-slate-900">
+          Resumen rápido
+        </h3>
         <ul className="mt-3 grid gap-2 text-sm text-slate-600">
           {summaryInsights.map((insight) => (
-            <li key={insight} className="rounded-lg bg-slate-50 px-3 py-2">{insight}</li>
+            <li key={insight} className="rounded-lg bg-slate-50 px-3 py-2">
+              {insight}
+            </li>
           ))}
         </ul>
       </div>
@@ -100,21 +126,66 @@ export default function CompareClient() {
         <div className="grid grid-cols-3 gap-4 border-b border-slate-200 bg-slate-50 px-6 py-4 text-sm font-semibold text-slate-700">
           <span>Detalle</span>
           <span className="flex flex-col gap-3">
-            <Link href={`/courses/${leftCourse.id}`} className="text-slate-900 hover:underline">{leftCourse.title}</Link>
-            <a href={leftCourse.externalUrl} target="_blank" rel="noopener noreferrer" onClick={() => trackOutboundCourseClick(leftCourse, "compare")} className="w-fit rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500">Ver curso en {leftCourse.platform}</a>
-            <span className="text-xs font-normal text-slate-500">Se abrirá en una página externa.</span>
+            <Link
+              href={`/courses/${leftCourse.id}`}
+              className="text-slate-900 hover:underline"
+            >
+              {leftCourse.title}
+            </Link>
+            {leftCourse.shortDescription ? (
+              <span className="text-xs font-normal leading-relaxed text-slate-600">
+                {leftCourse.shortDescription}
+              </span>
+            ) : null}
+            <a
+              href={leftCourse.externalUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => trackOutboundCourseClick(leftCourse, "compare")}
+              className="w-fit rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+            >
+              Ver curso en {leftCourse.platform}
+            </a>
+            <span className="text-xs font-normal text-slate-500">
+              Se abrirá en una página externa.
+            </span>
           </span>
           <span className="flex flex-col gap-3">
-            <Link href={`/courses/${rightCourse.id}`} className="text-slate-900 hover:underline">{rightCourse.title}</Link>
-            <a href={rightCourse.externalUrl} target="_blank" rel="noopener noreferrer" onClick={() => trackOutboundCourseClick(rightCourse, "compare")} className="w-fit rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500">Ver curso en {rightCourse.platform}</a>
-            <span className="text-xs font-normal text-slate-500">Se abrirá en una página externa.</span>
+            <Link
+              href={`/courses/${rightCourse.id}`}
+              className="text-slate-900 hover:underline"
+            >
+              {rightCourse.title}
+            </Link>
+            {rightCourse.shortDescription ? (
+              <span className="text-xs font-normal leading-relaxed text-slate-600">
+                {rightCourse.shortDescription}
+              </span>
+            ) : null}
+            <a
+              href={rightCourse.externalUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => trackOutboundCourseClick(rightCourse, "compare")}
+              className="w-fit rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+            >
+              Ver curso en {rightCourse.platform}
+            </a>
+            <span className="text-xs font-normal text-slate-500">
+              Se abrirá en una página externa.
+            </span>
           </span>
         </div>
         <div className="divide-y divide-slate-200">
           {rawRows.map((row) => {
             const differs = row.left !== row.right;
             return (
-              <div key={row.label} className={`grid grid-cols-3 gap-4 px-6 py-4 text-sm text-slate-600 ${differs ? "bg-blue-50/50" : "bg-white"}`}>
+              <div
+                key={row.label}
+                className={`grid grid-cols-3 gap-4 px-6 py-4 text-sm text-slate-600 ${
+                  differs ? "bg-blue-50/50" : "bg-white"
+                }`}
+              >
                 <span className="font-semibold text-slate-700">{row.label}</span>
                 <span>{row.left}</span>
                 <span>{row.right}</span>
@@ -127,7 +198,13 @@ export default function CompareClient() {
       <AdPlaceholder />
       <p className="text-xs text-slate-500">{EXTERNAL_LINK_DISCLOSURE}</p>
 
-      <button type="button" onClick={handleChangeCourses} className="w-fit rounded-lg border border-blue-200 px-5 py-2 text-sm font-semibold text-blue-700 hover:border-blue-300">Cambiar cursos</button>
+      <button
+        type="button"
+        onClick={handleChangeCourses}
+        className="w-fit rounded-lg border border-blue-200 px-5 py-2 text-sm font-semibold text-blue-700 hover:border-blue-300"
+      >
+        Cambiar cursos
+      </button>
     </section>
   );
 }

--- a/src/lib/formatPrice.ts
+++ b/src/lib/formatPrice.ts
@@ -1,0 +1,36 @@
+import type { Course } from "@/types/course";
+
+type PriceInput = Pick<
+  Course,
+  "priceModel" | "priceAmount" | "currency" | "priceInterval"
+>;
+
+export const formatCoursePrice = (course: PriceInput): string => {
+  if (course.priceModel === "free") {
+    return "Gratis";
+  }
+
+  if (course.priceModel === "paid_once") {
+    if (course.priceAmount != null && course.currency) {
+      return `Pago único — ${course.priceAmount} ${course.currency}`;
+    }
+
+    return "Pago único — precio no verificado";
+  }
+
+  if (course.priceModel === "subscription") {
+    if (course.priceAmount != null && course.currency) {
+      if (course.priceInterval === "month") {
+        return `${course.priceAmount} ${course.currency} / mes`;
+      }
+
+      if (course.priceInterval === "year") {
+        return `${course.priceAmount} ${course.currency} / año`;
+      }
+    }
+
+    return "Suscripción — precio no verificado";
+  }
+
+  return "Precio no verificado";
+};


### PR DESCRIPTION
## Summary
- Added a reusable course price formatter for verified price model display.
- Updated the compare page to use decision-friendly price, level, language, duration and certificate copy.
- Added short course descriptions to the comparison header.

## Product impact
- Makes differences easier to scan before leaving for an external course platform.
- Removes misleading subscription copy and avoids exposing internal price model values.
- Keeps comparison neutral without declaring a winner or ranking courses.

## SEO / conversion impact
- Improves confidence at the decision step with clearer external CTAs and course summaries.
- Preserves existing outbound link behavior and disclosure placement.

## Validation
- `corepack pnpm validate:data` passed.
- `corepack pnpm build` passed.

## Risk
- Product-review risk: touches the compare experience and price presentation.
- No schema changes, dependencies, APIs, analytics or ranking logic added.

## Manual test checklist
- Open `/compare?ids=<courseA>,<courseB>` with two valid courses.
- Confirm price copy does not show internal values like `subscription` or misleading free copy.
- Confirm course descriptions appear under the compared titles.
- Confirm external CTAs open in a new tab.
- Confirm invalid or missing IDs show the selection empty state.

Refs #51