### PR TITLE
Add homepage internal SEO links and Next.js sitemap route

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import HomeClient from "./HomeClient";
+import { SeoLinks } from "../src/components/seo/SeoLinks";
 
 export const metadata: Metadata = {
   title: "Compare courses online | Skills Compare",
@@ -8,5 +9,14 @@ export const metadata: Metadata = {
 };
 
 export default function HomePage() {
-  return <HomeClient />;
+  return (
+    <div className="space-y-10">
+      <HomeClient />
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold text-slate-900">Explorar cursos por skill</h2>
+        <SeoLinks />
+      </section>
+    </div>
+  );
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,30 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "../src/config/siteConfig";
+import { getAllSeoPages } from "../src/lib/seo/seoPages";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+  const seoPages = getAllSeoPages();
+
+  return [
+    {
+      url: `${SITE_URL}/`,
+      lastModified: now,
+      priority: 1
+    },
+    {
+      url: `${SITE_URL}/compare`,
+      lastModified: now,
+      priority: 0.8
+    },
+    ...seoPages.map((page) => {
+      const updatedAt = (page as { updatedAt?: string | number | Date }).updatedAt;
+
+      return {
+        url: `${SITE_URL}/${page.slug}`,
+        lastModified: new Date(updatedAt || Date.now()),
+        priority: 0.6
+      };
+    })
+  ];
+}

--- a/src/components/seo/SeoLinks.tsx
+++ b/src/components/seo/SeoLinks.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+import { SEO_SKILLS } from "../../config/seoConfig";
+
+export function SeoLinks() {
+  return (
+    <ul className="grid gap-3 sm:grid-cols-2">
+      {SEO_SKILLS.map((skill) => (
+        <li key={skill.slug}>
+          <Link
+            href={`/best-${skill.slug}-courses`}
+            className="block rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 hover:border-slate-300 hover:text-slate-900"
+          >
+            <span className="font-semibold">{skill.label}</span>
+            <span className="ml-2 text-slate-500">Ver cursos de {skill.label}</span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -1,0 +1,1 @@
+export const SITE_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://skillcompare.dev";


### PR DESCRIPTION
### Motivation
- Expose the generated SEO pages internally from the homepage so users and crawlers can discover them without changing generation logic. 
- Provide a centralized site URL constant to ensure consistent canonical/sitemap URLs across environments via `NEXT_PUBLIC_APP_URL`. 
- Add a sitemap following Next.js App Router conventions to improve crawlability for search engines.

### Description
- Add `src/config/siteConfig.ts` exporting `SITE_URL` that uses `process.env.NEXT_PUBLIC_APP_URL` with a fallback to `https://skillcompare.dev`.
- Add a lean `SeoLinks` component at `src/components/seo/SeoLinks.tsx` that imports `SEO_SKILLS` and renders links to `/best-{skillSlug}-courses` with the CTA `Ver cursos de {skill}`.
- Integrate `SeoLinks` into the homepage by importing and rendering it near the bottom of `app/page.tsx` inside a section titled `Explorar cursos por skill` without reordering or removing existing content.
- Add `app/sitemap.ts` as a Next.js App Router sitemap route which imports `getAllSeoPages()` and `SITE_URL` and returns a `MetadataRoute.Sitemap[]` including the homepage, `/compare`, and each generated SEO page; the sitemap defensively handles an optional `updatedAt` field.
- No core compare/search/selection hooks (`src/data/courses.ts`, `useCompareSelection`, etc.) or existing SEO generation logic were modified.

### Testing
- Ran `pnpm generate:seo` which generated the SEO pages JSON successfully (skipping pages with no matching courses as expected) and wrote `src/data/generated/seoPages.json`.
- Ran `pnpm validate:data` which completed successfully with validated courses.
- Ran `pnpm build` which completed successfully and generated the static routes including `/sitemap.xml`.
- Started the app and verified `http://localhost:3000/sitemap.xml` served XML containing the homepage, `/compare`, and the generated SEO pages (checked via `curl`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aee01173c832b919b7d55084706e0)