### PR TITLE
Add conditional Plausible pageview analytics loader

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import "./globals.css";
 import { Providers } from "./providers";
+import { AnalyticsLoader } from "@/components/seo/AnalyticsLoader";
 
 export const metadata: Metadata = {
   title: "Compare online courses | Skills Compare",
@@ -36,6 +37,7 @@ export default function RootLayout({
             </footer>
           </div>
         </Providers>
+        <AnalyticsLoader />
       </body>
     </html>
   );

--- a/src/components/seo/AnalyticsLoader.tsx
+++ b/src/components/seo/AnalyticsLoader.tsx
@@ -1,0 +1,16 @@
+import Script from "next/script";
+import { ANALYTICS_DOMAIN } from "../../config/analytics";
+
+export function AnalyticsLoader() {
+  if (!ANALYTICS_DOMAIN) {
+    return null;
+  }
+
+  return (
+    <Script
+      src="https://plausible.io/js/script.js"
+      data-domain={ANALYTICS_DOMAIN}
+      strategy="afterInteractive"
+    />
+  );
+}

--- a/src/config/analytics.ts
+++ b/src/config/analytics.ts
@@ -1,0 +1,1 @@
+export const ANALYTICS_DOMAIN = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN ?? "";


### PR DESCRIPTION
### Motivation
- Add a lightweight, privacy-friendly Plausible analytics integration that can be toggled via an environment variable without touching core app logic or data.

### Description
- Added `src/config/analytics.ts` exporting `ANALYTICS_DOMAIN` from `process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN` (default empty string), added `src/components/seo/AnalyticsLoader.tsx` which conditionally renders a `Script` (from `next/script`) to load `https://plausible.io/js/script.js` with `data-domain={ANALYTICS_DOMAIN}` and `strategy="afterInteractive"`, and updated `app/layout.tsx` to import and render `<AnalyticsLoader />`; the script is loaded only when the environment variable is set and no compare/search/selection flows or core course data files were modified.

### Testing
- Ran `pnpm build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0afa89f218832ba096115c1c5f7d2a)