### PR TITLE
Fix remaining English UI copy and strengthen comparison & blog guidance

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -34,8 +34,9 @@ export default function BlogPostPage({ params }: BlogPostPageProps) {
       <header className="space-y-2">
         <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Practical guide</p>
         <h2 className="text-3xl font-semibold text-slate-900">{post.title}</h2>
-        <p className="text-slate-600">{post.description}</p>
+      <p className="text-slate-600">{post.description}</p>
       </header>
+      <p className="rounded-lg bg-slate-50 px-4 py-3 text-sm leading-relaxed text-slate-700">{post.intro}</p>
       {post.sections.map((section, index) => (
         <section key={section.heading} className="space-y-3">
           <h3 className="text-xl font-semibold text-slate-800">{section.heading}</h3>
@@ -47,6 +48,36 @@ export default function BlogPostPage({ params }: BlogPostPageProps) {
           {index === 0 ? <AdPlaceholder /> : null}
         </section>
       ))}
+      <section className="space-y-3">
+        <h3 className="text-xl font-semibold text-slate-800">Common mistakes to avoid</h3>
+        <ul className="grid gap-2 text-slate-600">
+          {post.commonMistakes.map((mistake) => (
+            <li key={mistake} className="rounded-lg bg-amber-50 px-3 py-2 text-amber-800">{mistake}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-xl font-semibold text-slate-800">Helpful next steps in Skills Compare</h3>
+        <ul className="grid gap-2 text-slate-600 sm:grid-cols-2">
+          {post.internalLinks.map((item) => (
+            <li key={item.href}>
+              <Link href={item.href} className="block rounded-lg bg-blue-50 px-3 py-2 font-medium text-blue-700 hover:bg-blue-100">
+                {item.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-xl font-semibold text-slate-800">Final checklist</h3>
+        <ul className="grid gap-2 text-slate-600">
+          {post.checklist.map((item) => (
+            <li key={item} className="rounded-lg bg-emerald-50 px-3 py-2 text-emerald-800">{item}</li>
+          ))}
+        </ul>
+      </section>
     </article>
   );
 }

--- a/app/courses/[courseId]/CourseDetailClient.tsx
+++ b/app/courses/[courseId]/CourseDetailClient.tsx
@@ -47,7 +47,7 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
   const pendingSignals = [
     course.rating ? null : "Rating pending verification",
     course.priceAmount == null ? "Exact price pending verification" : null,
-    course.durationText.toLowerCase().includes("pendiente")
+    course.durationText.toLowerCase().includes("pending verification")
       ? "Duration pending verification"
       : null
   ].filter((item): item is string => item !== null);

--- a/app/skills/[skillSlug]/SkillClient.tsx
+++ b/app/skills/[skillSlug]/SkillClient.tsx
@@ -215,13 +215,33 @@ export default function SkillClient({ skillSlug: rawSkillSlug }: SkillClientProp
             Use these criteria to decide which course fits your context best.
           </p>
           <ul className="mt-3 grid gap-2 text-sm text-slate-600 sm:grid-cols-2 lg:grid-cols-5">
-            {["Price", "Duration", "Level", "Certificate", "Platform"].map(
-              (item) => (
-                <li key={item} className="rounded-lg bg-slate-50 px-3 py-2">
-                  {item}
-                </li>
-              )
-            )}
+            {[
+              {
+                label: "Price",
+                help: "Compare total cost, including subscription time and certificate fees."
+              },
+              {
+                label: "Duration",
+                help: "Check whether the weekly workload fits your real availability."
+              },
+              {
+                label: "Level",
+                help: "Choose a starting point that matches your current experience."
+              },
+              {
+                label: "Certificate",
+                help: "Verify whether certification is included or requires extra payment."
+              },
+              {
+                label: "Platform",
+                help: "Consider delivery format, support, and language experience."
+              }
+            ].map((item) => (
+              <li key={item.label} className="rounded-lg bg-slate-50 px-3 py-2">
+                <span className="block font-semibold text-slate-800">{item.label}</span>
+                <span>{item.help}</span>
+              </li>
+            ))}
           </ul>
         </div>
       ) : null}

--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -16,10 +16,10 @@ export const CourseCard = ({ course }: CourseCardProps) => {
   const atLimit = selectedIds.length >= 2;
   const hasKnownDuration = !course.durationText
     .toLowerCase()
-    .includes("no disponible");
+    .includes("pending verification");
   const hasKnownPrice = !course.priceText
     .toLowerCase()
-    .includes("no disponible");
+    .includes("pending verification");
   const facts = [
     { label: "Platform", value: course.platform },
     { label: "Level", value: course.level },

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -38,7 +38,7 @@ export const Filters = ({ value, onChange, options }: FiltersProps) => {
   return (
     <div className="grid gap-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm md:grid-cols-4">
       <label className="flex flex-col gap-2 text-sm font-medium text-slate-600">
-        Plataforma
+        Platform
         <select
           value={value.platform}
           onChange={(event) =>
@@ -48,13 +48,13 @@ export const Filters = ({ value, onChange, options }: FiltersProps) => {
         >
           {platformOptions.map((platform) => (
             <option key={platform} value={platform}>
-              {platform === "All" ? "Todas" : platform}
+              {platform === "All" ? "All" : platform}
             </option>
           ))}
         </select>
       </label>
       <label className="flex flex-col gap-2 text-sm font-medium text-slate-600">
-        Nivel
+        Level
         <select
           value={value.level}
           onChange={(event) => onChange({ ...value, level: event.target.value })}
@@ -68,7 +68,7 @@ export const Filters = ({ value, onChange, options }: FiltersProps) => {
         </select>
       </label>
       <label className="flex flex-col gap-2 text-sm font-medium text-slate-600">
-        Precio
+        Price
         <select
           value={value.priceModel}
           onChange={(event) =>
@@ -84,7 +84,7 @@ export const Filters = ({ value, onChange, options }: FiltersProps) => {
         </select>
       </label>
       <label className="flex flex-col gap-2 text-sm font-medium text-slate-600">
-        Idioma
+        Language
         <select
           value={value.language}
           onChange={(event) =>

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,36 +1,198 @@
+export type BlogSection = {
+  heading: string;
+  points: string[];
+};
+
 export type BlogPost = {
   slug: string;
   title: string;
   description: string;
-  sections: { heading: string; points: string[] }[];
+  intro: string;
+  sections: BlogSection[];
+  commonMistakes: string[];
+  internalLinks: { href: string; label: string }[];
+  checklist: string[];
 };
 
 export const blogPosts: BlogPost[] = [
   {
     slug: "how-to-choose-between-two-courses",
     title: "How to choose between two courses",
-    description: "A practical guide to compare two courses without assumptions and decide faster.",
+    description:
+      "A practical framework to compare two online courses with clear criteria and fewer regrets.",
+    intro:
+      "When two courses look similar, it helps to compare them with the same structure instead of relying on marketing copy. This guide shows a short process you can use in under 20 minutes before you enroll.",
     sections: [
-      { heading: "1) Define your decision criteria", points: ["Compare total real price.", "Compare weekly time and total duration.", "Verify whether the certificate is included or paid."] },
-      { heading: "2) Review verified differences", points: ["If the level is the same, focus on duration and certificate.", "If the platform changes, check language and format.", "Avoid deciding based on opinions without comparable data."] }
+      {
+        heading: "1) Start with your outcome and constraints",
+        points: [
+          "Write one concrete outcome, such as building a portfolio project or preparing for a role transition.",
+          "Set your weekly study capacity first (for example, 4 hours per week) so duration is realistic.",
+          "Define your maximum budget, including certificate cost if proof of completion matters to you."
+        ]
+      },
+      {
+        heading: "2) Compare total cost, not just the headline price",
+        points: [
+          "A free course can still require payment for graded assignments or certificates.",
+          "Subscriptions can become more expensive than one-time payments if completion takes longer than planned.",
+          "Use the compare view to verify whether each option is free, subscription-based, or one-time paid."
+        ]
+      },
+      {
+        heading: "3) Check duration against your real schedule",
+        points: [
+          "If one option is 12 hours and another is 40 hours, they are different commitments even if topics overlap.",
+          "Shorter courses can work better when you need momentum, while longer ones may be better for depth.",
+          "If duration is unverified, treat that as uncertainty and validate directly on the provider page."
+        ]
+      },
+      {
+        heading: "4) Match level and certificate expectations",
+        points: [
+          "Beginner courses are best when you are changing domains; advanced courses are more useful when foundations are already strong.",
+          "Certificate status should be verified before purchase if you need formal proof for hiring or internal promotion.",
+          "Example: choose a beginner option with verified certificate over an advanced option without clear certificate details when proof is mandatory."
+        ]
+      }
+    ],
+    commonMistakes: [
+      "Choosing based on platform reputation alone without checking level fit.",
+      "Ignoring total time commitment and dropping the course halfway.",
+      "Assuming certificates are included by default.",
+      "Comparing courses without opening provider pages for the latest terms."
+    ],
+    internalLinks: [
+      { href: "/compare", label: "Open side-by-side comparison" },
+      { href: "/skills/data-analysis", label: "Browse Data Analysis courses" },
+      { href: "/skills/project-management", label: "Browse Project Management courses" },
+      { href: "/", label: "Return to skills discovery" }
+    ],
+    checklist: [
+      "I can explain my learning outcome in one sentence.",
+      "I verified total cost and certificate terms for both options.",
+      "The course duration fits my weekly schedule.",
+      "The level matches my current starting point."
     ]
   },
   {
     slug: "what-to-compare-before-paying-for-a-course",
     title: "What to compare before paying for a course",
-    description: "A concrete checklist to pay for a course with more clarity.",
+    description:
+      "A decision checklist to review before paying, so your budget and time are aligned with the course.",
+    intro:
+      "Paying for a course is easier than finishing one. Before checkout, compare the factors that most often lead to poor learning outcomes: unclear level match, underestimated time, and hidden certificate costs.",
     sections: [
-      { heading: "Before you pay", points: ["Price model: one-time payment, subscription, or separate certificate.", "Estimated duration to complete the course.", "Declared level and whether it matches your starting point."] },
-      { heading: "Before enrolling", points: ["Review official syllabus and update date.", "Confirm access limits and cancellation terms.", "Check language and subtitles availability."] }
+      {
+        heading: "1) Validate payment model and true total",
+        points: [
+          "Identify whether the course is one-time paid, subscription, or free with optional paid certificate.",
+          "For subscriptions, estimate total spend based on your likely completion pace.",
+          "If price is unverified, do not assume discount or final amount—confirm on the provider page."
+        ]
+      },
+      {
+        heading: "2) Evaluate time-to-completion risk",
+        points: [
+          "Duration matters only when paired with your weekly availability.",
+          "Example: a 30-hour course can be realistic in 6 weeks at 5 hours/week, but risky at 1 hour/week.",
+          "Courses with missing duration should be treated as higher planning risk."
+        ]
+      },
+      {
+        heading: "3) Confirm content fit before checkout",
+        points: [
+          "Read syllabus bullets and prerequisites to avoid paying for material that is too basic or too advanced.",
+          "If your goal is job-ready output, prioritize practical assignments over broad theory-only outlines.",
+          "Use course detail pages to check whether key facts are verified or still pending."
+        ]
+      },
+      {
+        heading: "4) Compare platform experience and support",
+        points: [
+          "Platform differences can affect pacing, accessibility, and learner support.",
+          "Check language availability and subtitle options early if English is not your first language.",
+          "If two courses are close on cost and level, platform experience is often the tie-breaker."
+        ]
+      }
+    ],
+    commonMistakes: [
+      "Paying first, then realizing the prerequisites were not a fit.",
+      "Comparing only discounts, not total subscription cost.",
+      "Skipping language and subtitle checks.",
+      "Treating missing data as a positive signal instead of uncertainty."
+    ],
+    internalLinks: [
+      { href: "/compare", label: "Compare two selected courses" },
+      { href: "/skills/ai", label: "Explore AI learning paths" },
+      { href: "/skills/cloud-computing", label: "Explore Cloud Computing courses" },
+      { href: "/", label: "Start from the catalog" }
+    ],
+    checklist: [
+      "I verified payment model, certificate terms, and total expected spend.",
+      "I estimated completion time using my real weekly availability.",
+      "I reviewed prerequisites and key syllabus points.",
+      "I compared at least two options before paying."
     ]
   },
   {
     slug: "free-vs-paid-courses-what-really-changes",
     title: "Free vs paid courses: what really changes",
-    description: "A simple comparison to understand when a free or paid course fits better.",
+    description:
+      "A realistic comparison of free and paid online courses, with practical criteria for choosing each path.",
+    intro:
+      "Free and paid courses can both be useful, but they solve different problems. The right choice depends on your objective, timeline, and whether you need verified proof of completion.",
     sections: [
-      { heading: "What usually changes", points: ["Certificate: in many cases it requires payment.", "Support or mentoring: this can vary by platform.", "Commitment: paying may improve consistency, but not quality by itself."] },
-      { heading: "How to decide", points: ["If you need proof of learning, check certificate and total cost.", "If you want to explore a skill, start with a free option.", "Always compare duration, level, and language before deciding."] }
+      {
+        heading: "1) What free options do well",
+        points: [
+          "Great for exploration when you are still deciding whether a skill is relevant to your goals.",
+          "Lower financial risk lets you test interest before committing.",
+          "Good starting point for broad topics like AI, data analysis, or cybersecurity fundamentals."
+        ]
+      },
+      {
+        heading: "2) What paid options can add",
+        points: [
+          "Paid tracks may include structured assessments, graded projects, or verified certificates.",
+          "A financial commitment can improve consistency for some learners, but it does not guarantee better outcomes.",
+          "If certificate credibility matters, verify whether it is included or requires separate payment."
+        ]
+      },
+      {
+        heading: "3) Decision criteria that matter most",
+        points: [
+          "Choose based on level fit, expected duration, and language support before looking at promotions.",
+          "Compare total cost over expected completion time, especially for subscriptions.",
+          "Use side-by-side comparison to spot meaningful differences instead of relying on course titles."
+        ]
+      },
+      {
+        heading: "4) Example decision paths",
+        points: [
+          "If you are exploring a new field, begin with a free course and then upgrade only if you need deeper projects or certification.",
+          "If you need proof for your resume this quarter, a paid course with verified certificate details may be safer.",
+          "If time is limited, prioritize the option with clear duration and realistic weekly pacing."
+        ]
+      }
+    ],
+    commonMistakes: [
+      "Assuming paid always means better teaching quality.",
+      "Treating free courses as low value without checking syllabus depth.",
+      "Ignoring total subscription cost when completion takes longer.",
+      "Choosing a certificate path without confirming verification status."
+    ],
+    internalLinks: [
+      { href: "/skills/cybersecurity", label: "Browse Cybersecurity options" },
+      { href: "/skills/ai", label: "Browse AI courses" },
+      { href: "/compare", label: "Use comparison view" },
+      { href: "/", label: "Review all skill categories" }
+    ],
+    checklist: [
+      "I know whether my goal is exploration, portfolio output, or certification.",
+      "I compared total cost and completion timeline, not just free vs paid labels.",
+      "I confirmed certificate requirements before deciding.",
+      "I picked a course whose level and language match my current needs."
     ]
   }
 ];


### PR DESCRIPTION
### Motivation
- Remove remaining Spanish user-facing strings and improve decision-support content to increase product trust and usefulness before monetization work. 
- Make comparison guidance actionable so users can choose courses with clearer criteria and improve evergreen blog content for SEO/readability without changing infrastructure.

### Description
- Translate Spanish filter and related UI labels to English in the filters and touched views so selection labels read `Platform`, `Level`, `Price`, `Language`, and `All`. 
- Replace shallow criterion labels with concise explanations in the “How to compare courses” block (Price, Duration, Level, Certificate, Platform) to make the guidance actionable. 
- Normalize pending-data checks to English and keep copy consistent in course cards and course detail pages. 
- Expand existing blog posts into richer evergreen guides and update rendering to surface `intro`, `sections`, `commonMistakes`, `internalLinks`, and a final `checklist` without adding MDX/CMS or new dependencies.
- Files changed: `src/components/Filters.tsx`, `app/skills/[skillSlug]/SkillClient.tsx`, `src/components/CourseCard.tsx`, `app/courses/[courseId]/CourseDetailClient.tsx`, `src/lib/blog.ts`, and `app/blog/[slug]/page.tsx`.
- Risk level: `product-review` (user-facing changes under `app/**` and `src/**`, scoped to copy and content only). 
- Follow-up: consider normalizing legacy `src/data/courses.ts` text in a separate, small PR if broader content standardization is desired.

### Testing
- Ran data validation with `pnpm validate:data`, which reported `19 courses validated successfully.`
- Built the app with `pnpm build`, which completed successfully (Next.js compiled, type/lint checks and static pages generated). 
- The build included lint/type checks as part of the process and they passed.
- Confirmations: no external APIs, no scraping, no affiliate links, no ads added, no database changes, no full i18n introduced, no SEO route changes, and no ranking/outcome claims.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b820bb8ac832b99029193bbb643d4)