### PR TITLE
Add trust, SEO, and data quality foundation

### DIFF
--- a/app/(seo)/artificial-intelligence-certification/page.tsx
+++ b/app/(seo)/artificial-intelligence-certification/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "artificial-intelligence-certification";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/artificial-intelligence-for-beginners/page.tsx
+++ b/app/(seo)/artificial-intelligence-for-beginners/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "artificial-intelligence-for-beginners";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/best-artificial-intelligence-courses/page.tsx
+++ b/app/(seo)/best-artificial-intelligence-courses/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "best-artificial-intelligence-courses";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/best-cloud-computing-courses/page.tsx
+++ b/app/(seo)/best-cloud-computing-courses/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "best-cloud-computing-courses";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/best-cybersecurity-courses/page.tsx
+++ b/app/(seo)/best-cybersecurity-courses/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "best-cybersecurity-courses";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/best-data-analytics-courses/page.tsx
+++ b/app/(seo)/best-data-analytics-courses/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "best-data-analytics-courses";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/best-project-management-courses/page.tsx
+++ b/app/(seo)/best-project-management-courses/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "best-project-management-courses";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/cloud-computing-certification/page.tsx
+++ b/app/(seo)/cloud-computing-certification/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "cloud-computing-certification";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/cloud-computing-for-beginners/page.tsx
+++ b/app/(seo)/cloud-computing-for-beginners/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "cloud-computing-for-beginners";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/cybersecurity-certification/page.tsx
+++ b/app/(seo)/cybersecurity-certification/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "cybersecurity-certification";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/cybersecurity-for-beginners/page.tsx
+++ b/app/(seo)/cybersecurity-for-beginners/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "cybersecurity-for-beginners";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/data-analytics-certification/page.tsx
+++ b/app/(seo)/data-analytics-certification/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "data-analytics-certification";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/data-analytics-for-beginners/page.tsx
+++ b/app/(seo)/data-analytics-for-beginners/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "data-analytics-for-beginners";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/learn-artificial-intelligence/page.tsx
+++ b/app/(seo)/learn-artificial-intelligence/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "learn-artificial-intelligence";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/learn-cloud-computing/page.tsx
+++ b/app/(seo)/learn-cloud-computing/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "learn-cloud-computing";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/learn-cybersecurity/page.tsx
+++ b/app/(seo)/learn-cybersecurity/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "learn-cybersecurity";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/learn-data-analytics/page.tsx
+++ b/app/(seo)/learn-data-analytics/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "learn-data-analytics";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/learn-project-management/page.tsx
+++ b/app/(seo)/learn-project-management/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "learn-project-management";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/project-management-certification/page.tsx
+++ b/app/(seo)/project-management-certification/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "project-management-certification";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/(seo)/project-management-for-beginners/page.tsx
+++ b/app/(seo)/project-management-for-beginners/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { SeoPageTemplate } from "@/components/seo/SeoPageTemplate";
+import { buildSeoPageMetadata } from "@/lib/metadata";
 import { getSeoPageBySlug } from "@/lib/seo/seoPages";
 
 const slug = "project-management-for-beginners";
@@ -9,10 +10,7 @@ export const generateMetadata = (): Metadata => {
   const page = getSeoPageBySlug(slug);
   if (!page) return { title: "Page not found" };
 
-  return {
-    title: page.title,
-    description: page.metaDescription
-  };
+  return buildSeoPageMetadata(page);
 };
 
 export default function SeoRoutePage() {

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { blogPosts, getBlogPost } from "@/lib/blog";
 import { AdPlaceholder } from "@/components/AdPlaceholder";
+import { buildPageMetadata } from "@/lib/metadata";
 
 type BlogPostPageProps = {
   params: { slug: string };
@@ -12,9 +13,19 @@ export const generateStaticParams = () => blogPosts.map((post) => ({ slug: post.
 export const generateMetadata = ({ params }: BlogPostPageProps): Metadata => {
   const post = getBlogPost(params.slug);
   if (!post) {
-    return { title: "Article not found | Blog", description: "Article unavailable." };
+    return buildPageMetadata({
+      title: "Article not found | Blog",
+      description: "Article unavailable.",
+      path: `/blog/${params.slug}`,
+      type: "article"
+    });
   }
-  return { title: `${post.title} | Compare courses`, description: post.description };
+  return buildPageMetadata({
+    title: `${post.title} | Compare courses`,
+    description: post.description,
+    path: `/blog/${post.slug}`,
+    type: "article"
+  });
 };
 
 export default function BlogPostPage({ params }: BlogPostPageProps) {

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -2,11 +2,13 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { blogPosts } from "@/lib/blog";
 import { AdPlaceholder } from "@/components/AdPlaceholder";
+import { buildPageMetadata } from "@/lib/metadata";
 
-export const metadata: Metadata = {
+export const metadata: Metadata = buildPageMetadata({
   title: "Blog | Compare online courses",
-  description: "Practical guides to compare online courses and decide before you pay."
-};
+  description: "Practical guides to compare online courses and decide before you pay.",
+  path: "/blog"
+});
 
 export default function BlogPage() {
   return (

--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -130,8 +130,8 @@ export default function CompareClient() {
       </div>
 
       <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
-        <div className="grid grid-cols-3 gap-4 border-b border-slate-200 bg-slate-50 px-6 py-4 text-sm font-semibold text-slate-700">
-          <span>Detail</span>
+        <div className="grid gap-4 border-b border-slate-200 bg-slate-50 px-4 py-4 text-sm font-semibold text-slate-700 sm:grid-cols-3 sm:px-6">
+          <span className="hidden sm:block">Detail</span>
           <span className="flex flex-col gap-3">
             <Link
               href={`/courses/${leftCourse.id}`}
@@ -186,13 +186,23 @@ export default function CompareClient() {
             return (
               <div
                 key={row.label}
-                className={`grid grid-cols-3 gap-4 px-6 py-4 text-sm text-slate-600 ${
+                className={`grid gap-3 px-4 py-4 text-sm text-slate-600 sm:grid-cols-3 sm:gap-4 sm:px-6 ${
                   differs ? "bg-blue-50/50" : "bg-white"
                 }`}
               >
                 <span className="font-semibold text-slate-700">{row.label}</span>
-                <span>{row.left}</span>
-                <span>{row.right}</span>
+                <span className="rounded-lg bg-white/70 px-3 py-2 sm:rounded-none sm:bg-transparent sm:px-0 sm:py-0">
+                  <span className="block text-xs font-semibold text-slate-500 sm:hidden">
+                    {leftCourse.title}
+                  </span>
+                  {row.left}
+                </span>
+                <span className="rounded-lg bg-white/70 px-3 py-2 sm:rounded-none sm:bg-transparent sm:px-0 sm:py-0">
+                  <span className="block text-xs font-semibold text-slate-500 sm:hidden">
+                    {rightCourse.title}
+                  </span>
+                  {row.right}
+                </span>
               </div>
             );
           })}

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -3,19 +3,21 @@ export const dynamic = "force-dynamic";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import CompareClient from "./CompareClient";
+import { buildPageMetadata } from "@/lib/metadata";
 
-export const metadata: Metadata = {
+export const metadata: Metadata = buildPageMetadata({
   title: "Compare two online courses | Skills Compare",
   description:
-    "Course comparison page to compare two online courses by price, duration, level, certificate and platform."
-};
+    "Course comparison page to compare two online courses by price, duration, level, certificate and platform.",
+  path: "/compare"
+});
 
 export default function ComparePage() {
   return (
     <Suspense
       fallback={
         <section className="flex flex-col items-center gap-4 rounded-2xl border border-dashed border-slate-300 bg-white p-10 text-center">
-          <h2 className="text-2xl font-semibold text-slate-900">Loading…</h2>
+          <h2 className="text-2xl font-semibold text-slate-900">Loading...</h2>
           <p className="text-slate-600">Preparing comparison.</p>
         </section>
       }

--- a/app/courses/[courseId]/page.tsx
+++ b/app/courses/[courseId]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { courses } from "@/lib/catalog-adapter";
+import { buildPageMetadata } from "@/lib/metadata";
 import CourseDetailClient from "./CourseDetailClient";
 
 type CoursePageProps = {
@@ -14,19 +15,21 @@ export async function generateMetadata({
   const course = courses.find((item) => item.id === params.courseId);
 
   if (!course) {
-    return {
+    return buildPageMetadata({
       title: "Course not found | Skills Compare",
       description:
-        "Check the Skills Compare catalog to find available online courses."
-    };
+        "Check the Skills Compare catalog to find available online courses.",
+      path: `/courses/${params.courseId}`
+    });
   }
 
-  return {
+  return buildPageMetadata({
     title: `${course.title} | Skills Compare`,
     description:
       course.shortDescription ??
-      `Compare details for ${course.title} on ${course.platform}: level, price, duration, and certificate.`
-  };
+      `Compare details for ${course.title} on ${course.platform}: level, price, duration, and certificate.`,
+    path: `/courses/${course.id}`
+  });
 }
 
 export default function CourseDetailPage({ params }: CoursePageProps) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,10 +3,20 @@ import Link from "next/link";
 import "./globals.css";
 import { Providers } from "./providers";
 import { AnalyticsLoader } from "@/components/seo/AnalyticsLoader";
+import { SITE_NAME } from "@/config/siteConfig";
+import { siteBaseUrl } from "@/lib/metadata";
 
 export const metadata: Metadata = {
+  metadataBase: siteBaseUrl,
   title: "Compare online courses | Skills Compare",
-  description: "Course comparison tool to compare online courses by price, duration, level and certificate."
+  description: "Course comparison tool to compare online courses by price, duration, level and certificate.",
+  openGraph: {
+    title: "Compare online courses | Skills Compare",
+    description: "Course comparison tool to compare online courses by price, duration, level and certificate.",
+    siteName: SITE_NAME,
+    type: "website",
+    url: "/"
+  }
 };
 
 export default function RootLayout({
@@ -15,7 +25,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="es">
+    <html lang="en">
       <body className="min-h-screen">
         <Providers>
           <div className="mx-auto flex min-h-screen max-w-6xl flex-col px-6">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,14 @@
 import type { Metadata } from "next";
 import HomeClient from "./HomeClient";
 import { SeoLinks } from "../src/components/seo/SeoLinks";
+import { buildPageMetadata } from "@/lib/metadata";
 
-export const metadata: Metadata = {
+export const metadata: Metadata = buildPageMetadata({
   title: "Compare courses online | Skills Compare",
   description:
-    "Compare online courses by price, duration, level and certificate before deciding."
-};
+    "Compare online courses by price, duration, level and certificate before deciding.",
+  path: "/"
+});
 
 export default function HomePage() {
   return (

--- a/app/skills/[skillSlug]/page.tsx
+++ b/app/skills/[skillSlug]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { getCoursesForSkill, getSkillSummary } from "@/lib/skill-catalog";
+import { buildPageMetadata } from "@/lib/metadata";
 import SkillClient from "./SkillClient";
 
 type SkillPageProps = {
@@ -12,19 +13,21 @@ export const generateMetadata = ({ params }: SkillPageProps): Metadata => {
   const skill = getSkillSummary(params.skillSlug);
 
   if (!skill) {
-    return {
+    return buildPageMetadata({
       title: "Skill not found | Skills Compare",
       description:
-        "Review real alternatives in the Skills Compare catalog to compare online courses."
-    };
+        "Review real alternatives in the Skills Compare catalog to compare online courses.",
+      path: `/skills/${params.skillSlug}`
+    });
   }
 
   const courseCount = getCoursesForSkill(skill.slug).length;
 
-  return {
+  return buildPageMetadata({
     title: `Compare ${skill.title} courses online | Skills Compare`,
-    description: `Compare ${courseCount} ${skill.title} courses by platform, price, duration, and level before choosing.`
-  };
+    description: `Compare ${courseCount} ${skill.title} courses by platform, price, duration, and level before choosing.`,
+    path: `/skills/${skill.slug}`
+  });
 };
 
 export default function SkillPage({ params }: SkillPageProps) {

--- a/data/normalized/course-source-metadata.json
+++ b/data/normalized/course-source-metadata.json
@@ -2,41 +2,324 @@
   {
     "courseId": "machine-learning-stanford-university",
     "sourceUrl": "https://www.coursera.org/learn/machine-learning",
+    "sourceType": "official_provider_page",
     "verificationStatus": "pending",
-    "verifiedAt": null,
-    "verifiedBy": null,
-    "notes": "Source URL captured from normalized catalog. Manual verification still pending."
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
   },
   {
     "courseId": "google-data-analytics-google",
     "sourceUrl": "https://www.coursera.org/professional-certificates/google-data-analytics",
+    "sourceType": "official_provider_page",
     "verificationStatus": "pending",
-    "verifiedAt": null,
-    "verifiedBy": null,
-    "notes": "Source URL captured from normalized catalog. Manual verification still pending."
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
   },
   {
     "courseId": "deep-learning-specialization-deeplearningai",
     "sourceUrl": "https://www.coursera.org/specializations/deep-learning",
+    "sourceType": "official_provider_page",
     "verificationStatus": "pending",
-    "verifiedAt": null,
-    "verifiedBy": null,
-    "notes": "Source URL captured from normalized catalog. Manual verification still pending."
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
   },
   {
     "courseId": "ibm-data-science-ibm",
     "sourceUrl": "https://www.coursera.org/professional-certificates/ibm-data-science",
+    "sourceType": "official_provider_page",
     "verificationStatus": "pending",
-    "verifiedAt": null,
-    "verifiedBy": null,
-    "notes": "Source URL captured from normalized catalog. Manual verification still pending."
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
   },
   {
     "courseId": "meta-front-end-developer-meta",
     "sourceUrl": "https://www.coursera.org/professional-certificates/meta-front-end-developer",
+    "sourceType": "official_provider_page",
     "verificationStatus": "pending",
-    "verifiedAt": null,
-    "verifiedBy": null,
-    "notes": "Source URL captured from normalized catalog. Manual verification still pending."
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
+  },
+  {
+    "courseId": "ibm-cybersecurity-analyst-ibm",
+    "sourceUrl": "https://www.coursera.org/professional-certificates/ibm-cybersecurity-analyst",
+    "sourceType": "official_provider_page",
+    "verificationStatus": "pending",
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
+  },
+  {
+    "courseId": "google-cybersecurity-google",
+    "sourceUrl": "https://www.coursera.org/professional-certificates/google-cybersecurity",
+    "sourceType": "official_provider_page",
+    "verificationStatus": "pending",
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
+  },
+  {
+    "courseId": "introduction-cyber-security-nyux-edx",
+    "sourceUrl": "https://www.edx.org/learn/cybersecurity/new-york-university-introduction-to-cyber-security",
+    "sourceType": "official_provider_page",
+    "verificationStatus": "pending",
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
+  },
+  {
+    "courseId": "aws-cloud-technical-essentials-aws",
+    "sourceUrl": "https://www.coursera.org/learn/aws-cloud-technical-essentials",
+    "sourceType": "official_provider_page",
+    "verificationStatus": "pending",
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
+  },
+  {
+    "courseId": "google-cloud-fundamentals-core-infrastructure-google",
+    "sourceUrl": "https://www.coursera.org/learn/gcp-fundamentals",
+    "sourceType": "official_provider_page",
+    "verificationStatus": "pending",
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
+  },
+  {
+    "courseId": "introduction-to-cloud-computing-ibm",
+    "sourceUrl": "https://www.coursera.org/learn/introduction-to-cloud",
+    "sourceType": "official_provider_page",
+    "verificationStatus": "pending",
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
+  },
+  {
+    "courseId": "google-project-management-google",
+    "sourceUrl": "https://www.coursera.org/professional-certificates/google-project-management",
+    "sourceType": "official_provider_page",
+    "verificationStatus": "pending",
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
+  },
+  {
+    "courseId": "introduction-project-management-edx-adelaidex",
+    "sourceUrl": "https://www.edx.org/learn/project-management/the-university-of-adelaide-introduction-to-project-management",
+    "sourceType": "official_provider_page",
+    "verificationStatus": "pending",
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
+  },
+  {
+    "courseId": "project-management-principles-practices-umci",
+    "sourceUrl": "https://www.coursera.org/specializations/project-management",
+    "sourceType": "official_provider_page",
+    "verificationStatus": "pending",
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
+  },
+  {
+    "courseId": "ibm-data-analyst-ibm",
+    "sourceUrl": "https://www.coursera.org/professional-certificates/ibm-data-analyst",
+    "sourceType": "official_provider_page",
+    "verificationStatus": "pending",
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
+  },
+  {
+    "courseId": "google-advanced-data-analytics-google",
+    "sourceUrl": "https://www.coursera.org/professional-certificates/google-advanced-data-analytics",
+    "sourceType": "official_provider_page",
+    "verificationStatus": "pending",
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
+  },
+  {
+    "courseId": "data-analytics-essentials-cisco",
+    "sourceUrl": "https://www.coursera.org/learn/data-analytics-essentials",
+    "sourceType": "official_provider_page",
+    "verificationStatus": "pending",
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
+  },
+  {
+    "courseId": "ai-for-everyone-deeplearningai",
+    "sourceUrl": "https://www.coursera.org/learn/ai-for-everyone",
+    "sourceType": "official_provider_page",
+    "verificationStatus": "pending",
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
+  },
+  {
+    "courseId": "ibm-ai-engineering-ibm",
+    "sourceUrl": "https://www.coursera.org/professional-certificates/ai-engineer",
+    "sourceType": "official_provider_page",
+    "verificationStatus": "pending",
+    "lastVerifiedAt": null,
+    "verifiedFields": {
+      "title": false,
+      "platform": false,
+      "price": false,
+      "duration": false,
+      "certificate": false,
+      "language": false,
+      "level": false
+    },
+    "notes": "Pending manual verification against provider page."
   }
 ]

--- a/docs/MVP_READINESS.md
+++ b/docs/MVP_READINESS.md
@@ -1,47 +1,61 @@
 # MVP Readiness
 
+## Current State
+
+- Skills Compare is an English UI for finding skills, reviewing relevant online courses, comparing two options, and opening the original provider page.
+- The normalized catalog currently contains 19 curated courses.
+- Generated SEO pages, sitemap support, and internal SEO links are present.
+- Provider CTA copy and external-link disclosure copy are centralized.
+- Provider URLs are direct official provider URLs only.
+- Outbound tracking is local-only and does not send data to an external analytics vendor.
+- Source metadata exists for normalized courses in `data/normalized/course-source-metadata.json`.
+- A data quality report is available with `corepack pnpm report:data-quality`.
+
+## Trust and Data Quality Reality
+
+- Source metadata is currently marked `pending` until manual verification is completed.
+- Prices, ratings, review counts, and some durations are mostly unverified or unknown.
+- Unknown data must remain null, unknown, pending, or explicitly unverified.
+- Certificate information is present where the catalog currently has it, but provider terms may change.
+- Users should verify pricing, duration, certificate terms, enrollment details, and availability on the provider page before deciding.
+
 ## What Works
 
 - Users can search for a skill and land on skill-specific course pages.
 - Skill pages show available courses from the normalized catalog.
 - Course cards expose core decision facts: platform, level, duration, price, certificate, and rating when available.
-- Course detail pages expose summary, CTA, compare action, known learning content, and key facts.
-- Compare supports two-course comparison with outbound CTAs.
-- Normalized course data is validated with `corepack pnpm validate:data`.
-- Production build is validated with `corepack pnpm build`.
-- Outbound click tracking is local-only and does not send data externally.
+- Course detail pages expose summary, provider CTA, compare action, learning content, and key facts.
+- Compare supports two-course comparison with outbound provider CTAs.
+- The compare page is readable on mobile and desktop.
+- Canonical and Open Graph metadata foundations are present for core pages.
+- Data validation runs with `corepack pnpm validate:data`.
+- Production build runs with `corepack pnpm build`.
 
-## What Is Missing
+## What Is Not Implemented
 
-- Catalog coverage is very small.
-- Prices, ratings, and review counts are mostly unverified.
-- No verified ranking or recommendation logic exists.
 - No affiliate program is implemented.
-- No external analytics provider is connected.
-- No sitemap or Open Graph layer exists yet.
-- Course freshness and source verification are limited.
+- No affiliate links or fake affiliate links are present.
+- No ads are implemented beyond existing placeholder behavior.
+- No verified rankings or recommendation algorithm exists.
+- No outcome, employment, partnership, or provider endorsement claims should be made.
+- No user accounts, cookies, database, scraping, external APIs, or new analytics vendors are implemented.
 
-## Phase 1 Progress
+## Validation Workflow
 
-- ✅ Added a per-course source metadata file scaffold at `data/normalized/course-source-metadata.json`.
-- Current entries are intentionally marked `pending` until manual verification is completed.
+Run these before opening or updating a PR:
 
-## Current Limitations
+- `corepack pnpm validate:data`
+- `corepack pnpm report:data-quality`
+- `corepack pnpm exec tsc --noEmit`
+- `corepack pnpm build`
 
-- Skills Compare should not claim a course is best without real ranking criteria.
-- Unknown data must remain pending, unknown, null, or empty.
-- The app is useful for early comparison, not exhaustive discovery.
-- Content bullets are conservative and should be replaced with verified source-backed content over time.
+Do not run `corepack pnpm generate:seo` unless catalog or SEO generation inputs change. Do not run `corepack pnpm lint` until ESLint is configured, because `next lint` currently prompts for setup.
 
-## Next 10 PRs
+## Near-Term Priorities
 
-1. Add verified source metadata for each normalized course.
-2. Expand catalog with a small manually reviewed set per skill.
-3. Add sitemap and canonical metadata.
-4. Add Open Graph metadata for home, skill, and course pages.
-5. Add a lightweight data quality report script.
-6. Add compare persistence that does not require cookies.
-7. Improve mobile compare layout.
-8. Add course freshness display when `lastUpdatedAt` is verified.
-9. Add provider/platform explanation pages.
-10. Replace local outbound tracking with an approved analytics destination when ready.
+1. Manually verify source metadata fields against provider pages.
+2. Expand catalog coverage with a small, reviewable set per skill.
+3. Replace unverified course bullets with source-backed content where available.
+4. Add freshness display only after `lastVerifiedAt` is populated.
+5. Define ranking criteria before making any ranking-style claims.
+6. Add monetized links only when a real and auditable affiliate or referral program exists.

--- a/docs/catalog-phase-1.md
+++ b/docs/catalog-phase-1.md
@@ -38,6 +38,8 @@ Optional data can be present when verified:
 - Every externally sourced record must be traceable to a provider/source URL.
 - Provenance should identify the ingestion or curation source.
 - If provenance cannot be confirmed, the record should not be published as verified catalog data.
+- Per-course source metadata lives in `data/normalized/course-source-metadata.json`.
+- Source metadata should stay separate from the runtime course schema until there is a product need to display it.
 
 ## Data quality rules
 - Do not invent course data.
@@ -56,7 +58,7 @@ Optional data can be present when verified:
 - No fake ratings or review counts
 - No fake affiliate URLs
 - No scraping introduced in this phase
-- No unverifiable claims of “best” ranking
+- No unverifiable claims of "best" ranking
 
 ## Update workflow
 1. Add or update source data in repository-managed source files.
@@ -68,10 +70,12 @@ Optional data can be present when verified:
 ## Validation workflow
 Run:
 - `pnpm validate:data`
+- `pnpm report:data-quality`
 - `pnpm generate:seo` (when SEO templates/catalog changes)
 - `pnpm build`
 
 Validation failures should be fixed at data/source level; do not bypass checks to make CI pass.
+The data quality report is allowed to show unknown prices, ratings, review counts, durations, and certificate values. Unknown data is expected until manual verification is complete.
 
 ## Future affiliate fields (out of scope for Phase 1)
 These are planned but not implemented in this phase:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "validate:data": "tsx scripts/validate-data.ts",
+    "report:data-quality": "node scripts/report-data-quality.ts",
     "ingest:edx": "tsx scripts/ingest-edx.ts",
     "ingest:coursera": "tsx scripts/ingest-coursera.ts",
     "build:catalog": "tsx scripts/build-catalog.ts",

--- a/scripts/report-data-quality.ts
+++ b/scripts/report-data-quality.ts
@@ -1,0 +1,150 @@
+const fs = require("node:fs") as typeof import("node:fs");
+const path = require("node:path") as typeof import("node:path");
+
+type NormalizedCourse = {
+  id: string;
+  platform: string;
+  skillSlug: string;
+  priceAmount: number | null;
+  rating: number | null;
+  reviewCount: number | null;
+  durationHours: number | null;
+  certificate: boolean | null;
+  url: string;
+};
+
+type CourseSourceMetadata = {
+  courseId: string;
+  sourceUrl: string;
+  verificationStatus: string;
+};
+
+const readJsonFile = <T>(filePath: string): T => {
+  const raw = fs.readFileSync(filePath, "utf8");
+  return JSON.parse(raw) as T;
+};
+
+const countBy = <T>(items: T[], getKey: (item: T) => string) => {
+  const counts = new Map<string, number>();
+
+  items.forEach((item) => {
+    const key = getKey(item);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  });
+
+  return Array.from(counts.entries()).sort(([left], [right]) =>
+    left.localeCompare(right)
+  );
+};
+
+const printCountList = (label: string, counts: [string, number][]) => {
+  console.log(`\n${label}`);
+  counts.forEach(([key, count]) => {
+    console.log(`- ${key}: ${count}`);
+  });
+};
+
+const coursesPath = path.join(process.cwd(), "data", "normalized", "courses.json");
+const metadataPath = path.join(
+  process.cwd(),
+  "data",
+  "normalized",
+  "course-source-metadata.json"
+);
+
+try {
+  const courses = readJsonFile<NormalizedCourse[]>(coursesPath);
+  const metadata = fs.existsSync(metadataPath)
+    ? readJsonFile<CourseSourceMetadata[]>(metadataPath)
+    : [];
+
+  const coursesById = new Map(courses.map((course) => [course.id, course]));
+  const metadataByCourseId = new Map<string, CourseSourceMetadata>();
+  const duplicateMetadataIds = new Set<string>();
+
+  metadata.forEach((record) => {
+    if (metadataByCourseId.has(record.courseId)) {
+      duplicateMetadataIds.add(record.courseId);
+    }
+    metadataByCourseId.set(record.courseId, record);
+  });
+
+  const missingSourceMetadata = courses.filter(
+    (course) => !metadataByCourseId.has(course.id)
+  );
+  const metadataWithoutCourse = metadata.filter(
+    (record) => !coursesById.has(record.courseId)
+  );
+  const sourceUrlMismatches = metadata.filter((record) => {
+    const course = coursesById.get(record.courseId);
+    return course ? course.url !== record.sourceUrl : false;
+  });
+
+  console.log("Data quality report");
+  console.log("===================");
+  console.log(`Total courses: ${courses.length}`);
+
+  printCountList("Courses by skillSlug", countBy(courses, (course) => course.skillSlug));
+  printCountList("Courses by platform", countBy(courses, (course) => course.platform));
+  printCountList(
+    "Verification status counts",
+    countBy(metadata, (record) => record.verificationStatus)
+  );
+
+  console.log("\nUnknown or pending course fields");
+  console.log(
+    `- priceAmount unknown/null: ${
+      courses.filter((course) => course.priceAmount == null).length
+    }`
+  );
+  console.log(
+    `- rating null: ${courses.filter((course) => course.rating == null).length}`
+  );
+  console.log(
+    `- reviewCount null: ${
+      courses.filter((course) => course.reviewCount == null).length
+    }`
+  );
+  console.log(
+    `- durationHours null: ${
+      courses.filter((course) => course.durationHours == null).length
+    }`
+  );
+  console.log(
+    `- certificate null: ${
+      courses.filter((course) => course.certificate == null).length
+    }`
+  );
+
+  console.log("\nSource metadata coverage");
+  console.log(`- metadata records: ${metadata.length}`);
+  console.log(`- courses missing source metadata: ${missingSourceMetadata.length}`);
+  console.log(
+    `- source metadata records without matching course: ${metadataWithoutCourse.length}`
+  );
+  console.log(`- source URL mismatches: ${sourceUrlMismatches.length}`);
+  console.log(`- duplicate metadata courseIds: ${duplicateMetadataIds.size}`);
+
+  const structuralIssues = [
+    ...missingSourceMetadata.map((course) => `Missing metadata: ${course.id}`),
+    ...metadataWithoutCourse.map(
+      (record) => `Metadata without course: ${record.courseId}`
+    ),
+    ...sourceUrlMismatches.map(
+      (record) => `Source URL mismatch: ${record.courseId}`
+    ),
+    ...Array.from(duplicateMetadataIds).map(
+      (courseId) => `Duplicate metadata: ${courseId}`
+    )
+  ];
+
+  if (structuralIssues.length > 0) {
+    console.log("\nStructural issues");
+    structuralIssues.forEach((issue) => console.log(`- ${issue}`));
+    process.exitCode = 1;
+  }
+} catch (error) {
+  console.error("Failed to generate data quality report.");
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+}

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -1,1 +1,2 @@
+export const SITE_NAME = "Skills Compare";
 export const SITE_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://skillcompare.dev";

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+import { SITE_NAME, SITE_URL } from "@/config/siteConfig";
+import type { GeneratedSeoPage } from "@/lib/seo/seoTypes";
+
+export const siteBaseUrl = new URL(SITE_URL);
+
+export const getCanonicalUrl = (path: string) =>
+  new URL(path.startsWith("/") ? path : `/${path}`, siteBaseUrl).toString();
+
+type PageMetadataInput = {
+  title: string;
+  description: string;
+  path: string;
+  type?: "website" | "article";
+};
+
+export const buildPageMetadata = ({
+  title,
+  description,
+  path,
+  type = "website"
+}: PageMetadataInput): Metadata => {
+  const canonical = getCanonicalUrl(path);
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical
+    },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      siteName: SITE_NAME,
+      type
+    }
+  };
+};
+
+export const buildSeoPageMetadata = (page: GeneratedSeoPage): Metadata =>
+  buildPageMetadata({
+    title: page.title,
+    description: page.metaDescription,
+    path: `/${page.slug}`
+  });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,9 @@
       "@/contexts/*": [
         "src/contexts/*"
       ],
+      "@/config/*": [
+        "src/config/*"
+      ],
       "@/data/*": [
         "src/data/*"
       ],


### PR DESCRIPTION
## Summary

- Added complete pending source metadata coverage for all 19 normalized courses in `data/normalized/course-source-metadata.json`, using each course's existing direct provider URL as `sourceUrl` and keeping verification fields explicitly unverified.
- Added `scripts/report-data-quality.ts` plus `corepack pnpm report:data-quality` to report catalog coverage, unknown data fields, metadata coverage, metadata mismatches, and verification status counts without treating expected unknown course data as a failure.
- Added a central metadata helper and site config updates for canonical/Open Graph metadata across home, skill pages, course detail pages, blog index/posts, compare, and generated SEO route pages without adding fake OG images or changing route slugs.
- Improved compare readability on mobile by stacking comparison row values with course labels while preserving desktop side-by-side behavior and compare selection semantics.
- Updated MVP readiness and catalog phase docs to reflect English UI, 19 curated courses, generated SEO pages, provider CTA/disclosure foundation, no affiliate program, unverified price/rating/review data, source metadata pending verification, and the new data quality report workflow.

## Commands run

- `corepack pnpm report:data-quality`
- `corepack pnpm validate:data`
- `corepack pnpm exec tsc --noEmit` (verified locally via `node_modules/.bin/tsc.CMD --noEmit` because this shell did not resolve the binary through `pnpm exec`)
- `corepack pnpm build`

## Skipped

- `corepack pnpm lint` was not run because the repository has no ESLint config and `next lint` triggers an interactive setup prompt.
- `corepack pnpm generate:seo` was not run because generated SEO route slugs/data were not regenerated or changed.

## Confirmations

- Branch/PR used: `codex/trust-seo-data-quality-foundation` targets `main`; no direct commit to `main` for this batch.
- No external APIs added.
- No scraping added.
- No affiliate links added.
- No fake affiliate links added.
- No ads added.
- No database added.
- No user accounts added.
- No cookies added.
- No new analytics vendors added.
- No provider URLs replaced.
- No SEO route slug changes.
- No ranking or outcome claims added.
- Compare selection behavior and URL semantics unchanged.