### PR TITLE
Fix live UX SEO course rendering

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -4,35 +4,40 @@ import Link from "next/link";
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { SearchBar } from "@/components/SearchBar";
-import { getSkillOptions, resolveSkillSlug, searchSkillOptions } from "@/lib/skill-routing";
+import { getSkillOptions, resolveSkillSlug, searchSkillOptions, type SkillOption } from "@/lib/skill-routing";
 
 export default function HomeClient() {
   const router = useRouter();
   const suggestions = useMemo(() => getSkillOptions(), []);
   const [searchFeedback, setSearchFeedback] = useState<string | null>(null);
+  const [searchSuggestions, setSearchSuggestions] = useState<SkillOption[]>([]);
 
   const handleSearch = (value: string) => {
     const trimmed = value.trim();
 
     if (!trimmed) {
       setSearchFeedback("Enter a skill to search the current catalog.");
+      setSearchSuggestions(suggestions.slice(0, 4));
       return;
     }
 
     const skillSlug = resolveSkillSlug(trimmed);
     if (skillSlug) {
       setSearchFeedback(null);
+      setSearchSuggestions([]);
       router.push(`/skills/${skillSlug}`);
       return;
     }
 
-    const topSuggestions = searchSkillOptions(trimmed, 3);
+    const topSuggestions = searchSkillOptions(trimmed, 4);
     if (topSuggestions.length > 0) {
-      setSearchFeedback(`No exact match for "${trimmed}". Try: ${topSuggestions.map((skill) => skill.title).join(", ")}.`);
+      setSearchFeedback(`No exact match for "${trimmed}". Try one of these available skills.`);
+      setSearchSuggestions(topSuggestions);
       return;
     }
 
     setSearchFeedback("No matching skill found yet. Try one of the available skills below.");
+    setSearchSuggestions(suggestions.slice(0, 4));
   };
 
   return (
@@ -52,6 +57,19 @@ export default function HomeClient() {
         onSearch={handleSearch}
         feedback={searchFeedback}
       />
+      {searchSuggestions.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {searchSuggestions.map((skill) => (
+            <Link
+              key={skill.slug}
+              href={`/skills/${skill.slug}`}
+              className="rounded-full border border-slate-200 bg-white px-3 py-1 text-sm font-semibold text-slate-700 hover:border-slate-300"
+            >
+              {skill.title}
+            </Link>
+          ))}
+        </div>
+      ) : null}
 
       <div className="space-y-3">
         <p className="text-sm font-semibold uppercase tracking-[0.16em] text-slate-500">
@@ -66,7 +84,7 @@ export default function HomeClient() {
             >
               <p className="font-semibold text-slate-900">{skill.title}</p>
               <p className="mt-1 text-sm text-slate-600">{skill.courseCount} courses available</p>
-              <p className="mt-1 text-xs text-slate-500">Compare course options</p>
+              <p className="mt-1 text-xs font-semibold text-blue-700">Compare course options</p>
             </Link>
           ))}
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,7 +16,12 @@ export default function HomePage() {
       <HomeClient />
 
       <section className="space-y-4">
-        <h2 className="text-2xl font-semibold text-slate-900">Explore courses by skill</h2>
+        <div className="space-y-2">
+          <h2 className="text-2xl font-semibold text-slate-900">Guides and comparison pages</h2>
+          <p className="text-sm text-slate-600">
+            Browse generated guide pages for specific course comparison searches.
+          </p>
+        </div>
         <SeoLinks />
       </section>
     </div>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "validate:data": "tsx scripts/validate-data.ts",
-    "report:data-quality": "node scripts/report-data-quality.ts",
+    "report:data-quality": "node scripts/report-data-quality.js",
     "ingest:edx": "tsx scripts/ingest-edx.ts",
     "ingest:coursera": "tsx scripts/ingest-coursera.ts",
     "build:catalog": "tsx scripts/build-catalog.ts",

--- a/scripts/report-data-quality.js
+++ b/scripts/report-data-quality.js
@@ -1,31 +1,13 @@
-const fs = require("node:fs") as typeof import("node:fs");
-const path = require("node:path") as typeof import("node:path");
+const { existsSync, readFileSync } = require("node:fs");
+const { resolve } = require("node:path");
 
-type NormalizedCourse = {
-  id: string;
-  platform: string;
-  skillSlug: string;
-  priceAmount: number | null;
-  rating: number | null;
-  reviewCount: number | null;
-  durationHours: number | null;
-  certificate: boolean | null;
-  url: string;
+const readJsonFile = (filePath) => {
+  const raw = readFileSync(filePath, "utf8");
+  return JSON.parse(raw);
 };
 
-type CourseSourceMetadata = {
-  courseId: string;
-  sourceUrl: string;
-  verificationStatus: string;
-};
-
-const readJsonFile = <T>(filePath: string): T => {
-  const raw = fs.readFileSync(filePath, "utf8");
-  return JSON.parse(raw) as T;
-};
-
-const countBy = <T>(items: T[], getKey: (item: T) => string) => {
-  const counts = new Map<string, number>();
+const countBy = (items, getKey) => {
+  const counts = new Map();
 
   items.forEach((item) => {
     const key = getKey(item);
@@ -37,15 +19,15 @@ const countBy = <T>(items: T[], getKey: (item: T) => string) => {
   );
 };
 
-const printCountList = (label: string, counts: [string, number][]) => {
+const printCountList = (label, counts) => {
   console.log(`\n${label}`);
   counts.forEach(([key, count]) => {
     console.log(`- ${key}: ${count}`);
   });
 };
 
-const coursesPath = path.join(process.cwd(), "data", "normalized", "courses.json");
-const metadataPath = path.join(
+const coursesPath = resolve(process.cwd(), "data", "normalized", "courses.json");
+const metadataPath = resolve(
   process.cwd(),
   "data",
   "normalized",
@@ -53,14 +35,12 @@ const metadataPath = path.join(
 );
 
 try {
-  const courses = readJsonFile<NormalizedCourse[]>(coursesPath);
-  const metadata = fs.existsSync(metadataPath)
-    ? readJsonFile<CourseSourceMetadata[]>(metadataPath)
-    : [];
+  const courses = readJsonFile(coursesPath);
+  const metadata = existsSync(metadataPath) ? readJsonFile(metadataPath) : [];
 
   const coursesById = new Map(courses.map((course) => [course.id, course]));
-  const metadataByCourseId = new Map<string, CourseSourceMetadata>();
-  const duplicateMetadataIds = new Set<string>();
+  const metadataByCourseId = new Map();
+  const duplicateMetadataIds = new Set();
 
   metadata.forEach((record) => {
     if (metadataByCourseId.has(record.courseId)) {
@@ -92,36 +72,16 @@ try {
   );
 
   console.log("\nUnknown or pending course fields");
-  console.log(
-    `- priceAmount unknown/null: ${
-      courses.filter((course) => course.priceAmount == null).length
-    }`
-  );
-  console.log(
-    `- rating null: ${courses.filter((course) => course.rating == null).length}`
-  );
-  console.log(
-    `- reviewCount null: ${
-      courses.filter((course) => course.reviewCount == null).length
-    }`
-  );
-  console.log(
-    `- durationHours null: ${
-      courses.filter((course) => course.durationHours == null).length
-    }`
-  );
-  console.log(
-    `- certificate null: ${
-      courses.filter((course) => course.certificate == null).length
-    }`
-  );
+  console.log(`- priceAmount unknown/null: ${courses.filter((course) => course.priceAmount == null).length}`);
+  console.log(`- rating null: ${courses.filter((course) => course.rating == null).length}`);
+  console.log(`- reviewCount null: ${courses.filter((course) => course.reviewCount == null).length}`);
+  console.log(`- durationHours null: ${courses.filter((course) => course.durationHours == null).length}`);
+  console.log(`- certificate null: ${courses.filter((course) => course.certificate == null).length}`);
 
   console.log("\nSource metadata coverage");
   console.log(`- metadata records: ${metadata.length}`);
   console.log(`- courses missing source metadata: ${missingSourceMetadata.length}`);
-  console.log(
-    `- source metadata records without matching course: ${metadataWithoutCourse.length}`
-  );
+  console.log(`- source metadata records without matching course: ${metadataWithoutCourse.length}`);
   console.log(`- source URL mismatches: ${sourceUrlMismatches.length}`);
   console.log(`- duplicate metadata courseIds: ${duplicateMetadataIds.size}`);
 

--- a/src/components/AdPlaceholder.tsx
+++ b/src/components/AdPlaceholder.tsx
@@ -5,15 +5,12 @@ type AdPlaceholderProps = {
 export function AdPlaceholder({ className = "" }: AdPlaceholderProps) {
   return (
     <aside
-      aria-label="Publicidad"
-      className={`rounded-xl border border-slate-300 bg-slate-100/80 px-4 py-5 ${className}`}
+      aria-label="Ad space"
+      className={`rounded-xl border border-slate-200 bg-slate-50/80 px-4 py-4 ${className}`}
     >
-      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
-        Publicidad
-      </p>
-      <div className="mt-2 flex h-20 items-center justify-center rounded-lg border border-dashed border-slate-400 bg-slate-200 text-sm font-medium text-slate-600">
+      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
         Ad space
-      </div>
+      </p>
     </aside>
   );
 }

--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useCompareSelection } from "@/contexts/CompareSelectionContext";
+import { courses } from "@/lib/catalog-adapter";
 
 export const CompareBar = () => {
   const router = useRouter();
@@ -9,6 +10,9 @@ export const CompareBar = () => {
     useCompareSelection();
   const enabled = selectedIds.length === 2;
   const visibleCount = Math.min(selectedIds.length, 2);
+  const selectedCourseLabels = selectedIds.map(
+    (id) => courses.find((course) => course.id === id)?.title ?? id
+  );
 
   return (
     <div className="fixed inset-x-0 bottom-0 z-20 border-t border-slate-200 bg-white/95 backdrop-blur">
@@ -18,8 +22,13 @@ export const CompareBar = () => {
             {visibleCount} of 2 courses selected
           </p>
           <p className="text-xs text-slate-500">
-            {visibleCount === 1 ? "Select 1 more course to compare." : "Select 2 courses to compare."}
+            {visibleCount === 0
+              ? "Select 2 courses to compare."
+              : selectedCourseLabels.join(" + ")}
           </p>
+          {visibleCount === 1 ? (
+            <p className="mt-1 text-xs text-slate-500">Select 1 more course to compare.</p>
+          ) : null}
           {notice ? (
             <p className="mt-2 text-xs font-semibold text-amber-600">{notice}</p>
           ) : null}

--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -15,7 +15,7 @@ type CourseCardProps = {
 };
 
 export const CourseCard = ({ course }: CourseCardProps) => {
-  const { toggle, isSelected, selectedIds } = useCompareSelection();
+  const { toggle, isSelected, selectedIds, clear } = useCompareSelection();
   const selected = isSelected(course.id);
   const atLimit = selectedIds.length >= 2;
   const hasKnownDuration = !course.durationText
@@ -99,9 +99,12 @@ export const CourseCard = ({ course }: CourseCardProps) => {
       </div>
       <p className="text-xs text-slate-500">{PROVIDER_DETAILS_NOTICE}</p>
       {atLimit && !selected ? (
-        <p className="text-xs text-amber-600">
-          Limit reached: remove a course to add another.
-        </p>
+        <div className="flex flex-wrap items-center gap-2 text-xs text-amber-700">
+          <span>Two courses are already selected. Clear the compare bar selection to add this course.</span>
+          <button type="button" onClick={clear} className="font-semibold underline">
+            Clear selection
+          </button>
+        </div>
       ) : null}
     </div>
   );

--- a/src/components/seo/SeoCourseList.tsx
+++ b/src/components/seo/SeoCourseList.tsx
@@ -4,29 +4,53 @@ import { Course } from "@/types/course";
 
 type SeoCourseListProps = {
   courses: Course[];
+  skillSlug: string;
+  skillLabel: string;
 };
 
-export const SeoCourseList = ({ courses }: SeoCourseListProps) => (
-  <section className="space-y-4">
-    <div className="space-y-2">
-      <h2 className="text-2xl font-semibold text-slate-900">Available courses</h2>
-      <p className="text-sm text-slate-600">{PROVIDER_DETAILS_NOTICE}</p>
-    </div>
-    <div className="grid gap-4">
-      {courses.map((course) => (
-        <article key={course.id} className="rounded-xl border border-slate-200 bg-white p-4">
-          <h3 className="text-lg font-semibold text-slate-900">{course.title}</h3>
-          <p className="text-sm text-slate-600">{course.platform} · {course.level} · {course.priceText}</p>
-          <div className="mt-3 flex gap-3">
-            <Link href={`/courses/${course.id}`} className="text-sm font-semibold text-blue-700 underline">
-              View course details
-            </Link>
-            <a href={course.externalUrl} target="_blank" rel="noopener noreferrer" className="text-sm text-slate-700 underline">
-              {PROVIDER_CTA_LABEL}
-            </a>
-          </div>
-        </article>
-      ))}
-    </div>
-  </section>
-);
+export const SeoCourseList = ({ courses, skillSlug, skillLabel }: SeoCourseListProps) => {
+  const skillHref = `/skills/${skillSlug}`;
+
+  return (
+    <section className="space-y-4">
+      <div className="space-y-2">
+        <h2 className="text-2xl font-semibold text-slate-900">Course options</h2>
+        <p className="text-sm text-slate-600">{PROVIDER_DETAILS_NOTICE}</p>
+      </div>
+
+      {courses.length === 0 ? (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-5">
+          <p className="font-semibold text-amber-900">No course cards are available for this guide yet.</p>
+          <p className="mt-2 text-sm text-amber-800">
+            Browse the {skillLabel} skill page to see current catalog options while this guide is refreshed.
+          </p>
+          <Link href={skillHref} className="mt-3 inline-flex text-sm font-semibold text-amber-900 underline">
+            View {skillLabel} courses
+          </Link>
+        </div>
+      ) : (
+        <div className="grid gap-4">
+          {courses.map((course) => (
+            <article key={course.id} className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="text-lg font-semibold text-slate-900">{course.title}</h3>
+              <p className="mt-1 text-sm text-slate-600">
+                {course.platform} | {course.level} | {course.priceText}
+              </p>
+              {course.shortDescription ? (
+                <p className="mt-3 text-sm leading-relaxed text-slate-600">{course.shortDescription}</p>
+              ) : null}
+              <div className="mt-4 flex flex-wrap gap-3">
+                <Link href={`/courses/${course.id}`} className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:border-slate-300">
+                  View course details
+                </Link>
+                <a href={course.externalUrl} target="_blank" rel="noopener noreferrer" className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500">
+                  {PROVIDER_CTA_LABEL}
+                </a>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};

--- a/src/components/seo/SeoPageTemplate.tsx
+++ b/src/components/seo/SeoPageTemplate.tsx
@@ -2,6 +2,7 @@ import { getCoursesForSeoPage } from "@/lib/seo/seoPages";
 import { GeneratedSeoPage } from "@/lib/seo/seoTypes";
 import { SeoCourseList } from "@/components/seo/SeoCourseList";
 import { SeoFAQ } from "@/components/seo/SeoFAQ";
+import { resolveSkillSlug } from "@/lib/skill-routing";
 
 type SeoPageTemplateProps = {
   page: GeneratedSeoPage;
@@ -9,6 +10,8 @@ type SeoPageTemplateProps = {
 
 export const SeoPageTemplate = ({ page }: SeoPageTemplateProps) => {
   const pageCourses = getCoursesForSeoPage(page);
+  const skillRouteSlug =
+    resolveSkillSlug(page.skillSlug) ?? resolveSkillSlug(page.skillLabel) ?? page.skillSlug;
 
   return (
     <main className="mx-auto max-w-4xl space-y-8 px-4 py-10">
@@ -19,7 +22,7 @@ export const SeoPageTemplate = ({ page }: SeoPageTemplateProps) => {
           Course information may change. Verify pricing, duration, certificate terms, and enrollment details on the provider website.
         </p>
       </header>
-      <SeoCourseList courses={pageCourses} />
+      <SeoCourseList courses={pageCourses} skillSlug={skillRouteSlug} skillLabel={page.skillLabel} />
       <SeoFAQ faq={page.faq} />
     </main>
   );

--- a/src/lib/seo/seoPages.ts
+++ b/src/lib/seo/seoPages.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { courses } from "@/data/courses";
+import { courses } from "@/lib/catalog-adapter";
 import { Course } from "@/types/course";
 import { GeneratedSeoPage } from "@/lib/seo/seoTypes";
 

--- a/src/lib/skill-routing.ts
+++ b/src/lib/skill-routing.ts
@@ -4,22 +4,25 @@ import { slugify, titleFromSlug } from "@/utils/slugify";
 const SKILL_ALIASES: Record<string, string> = {
   ai: "ai",
   "artificial-intelligence": "ai",
-  "artificial-inteligence": "ai",
-  "inteligencia-artificial": "ai",
+  "artificial-intelligence-courses": "ai",
   ia: "ai",
   llm: "ai",
   llms: "ai",
-  ml: "ai",
-  "machine-learning": "ai",
-  "machine-learning-ai": "ai",
-  "ai-fundamentals": "ai",
-  "prompt-engineering": "ai",
-  analytics: "data-analysis",
+  data: "data-analysis",
+  "data-analysis": "data-analysis",
   "data-analytics": "data-analysis",
   "data-analyst": "data-analysis",
-  "analisis-de-datos": "data-analysis",
-  "data-science": "data-science",
-  "ciencia-de-datos": "data-science",
+  analytics: "data-analysis",
+  ml: "machine-learning",
+  "machine-learning": "machine-learning",
+  project: "project-management",
+  pm: "project-management",
+  "project-management": "project-management",
+  cyber: "cybersecurity",
+  cybersecurity: "cybersecurity",
+  security: "cybersecurity",
+  cloud: "cloud-computing",
+  "cloud-computing": "cloud-computing",
   frontend: "frontend",
   "front-end": "frontend",
   "web-development": "frontend",
@@ -34,6 +37,8 @@ export type SkillOption = {
 
 const stripRoutePrefix = (value: string) =>
   value.replace(/^\/?skills\/?/, "").replace(/^skills-?/, "");
+
+const normalizeSearchValue = (value: string) => slugify(stripRoutePrefix(value.trim()));
 
 export const getSkillOptions = (): SkillOption[] => {
   const counts = new Map<string, number>();
@@ -59,39 +64,51 @@ export const getSkillOptions = (): SkillOption[] => {
 };
 
 export const resolveSkillSlug = (value: string): string | null => {
-  const normalized = slugify(stripRoutePrefix(value));
+  const normalized = normalizeSearchValue(value);
 
   if (!normalized) {
     return null;
   }
 
-  const candidate = SKILL_ALIASES[normalized] ?? normalized;
   const validSlugs = new Set(getSkillOptions().map((skill) => skill.slug));
+  const candidate = SKILL_ALIASES[normalized] ?? normalized;
 
-  return validSlugs.has(candidate) ? candidate : null;
+  if (validSlugs.has(candidate)) {
+    return candidate;
+  }
+
+  const partialMatch = getSkillOptions().find((option) => {
+    const titleSlug = slugify(option.title);
+    return option.slug.includes(normalized) || titleSlug.includes(normalized);
+  });
+
+  return partialMatch?.slug ?? null;
 };
 
 export const getSkillSuggestions = (limit = 4): SkillOption[] =>
   getSkillOptions().slice(0, limit);
 
-
 export const searchSkillOptions = (query: string, limit = 5): SkillOption[] => {
-  const normalizedQuery = slugify(stripRoutePrefix(query));
+  const normalizedQuery = normalizeSearchValue(query);
   if (!normalizedQuery) {
     return [];
   }
 
   const options = getSkillOptions();
-  const exactSlug = options.find((option) => option.slug === normalizedQuery);
-  if (exactSlug) {
-    return [exactSlug];
-  }
+  const resolvedSlug = resolveSkillSlug(query);
+  const matches = options.filter((option) => {
+    const titleSlug = slugify(option.title);
+    const aliasMatchesOption = Object.entries(SKILL_ALIASES).some(
+      ([alias, slug]) => slug === option.slug && alias.includes(normalizedQuery)
+    );
 
-  return options
-    .filter((option) =>
-      option.title.toLowerCase().includes(query.toLowerCase().trim()) ||
-      option.slug.includes(query.toLowerCase().trim()) ||
-      option.slug.includes(normalizedQuery)
-    )
-    .slice(0, limit);
+    return (
+      option.slug === resolvedSlug ||
+      option.slug.includes(normalizedQuery) ||
+      titleSlug.includes(normalizedQuery) ||
+      aliasMatchesOption
+    );
+  });
+
+  return matches.slice(0, limit);
 };


### PR DESCRIPTION
## Summary
- Fixed generated SEO page course rendering by resolving SEO `courseIds` against the normalized catalog adapter instead of the legacy fallback catalog.
- Kept SEO route/page binding slug-based and added a useful empty state that links back to the resolved skill page if a future generated page has no matching courses.
- Reworked SEO course cards so generated landing pages visibly show course options, descriptions, details links, and provider CTAs.
- Replaced Spanish ad placeholder copy with subtle English `Ad space` copy and removed redundant inner placeholder text.
- Improved stale compare-selection UX by showing selected course titles in the compare bar and adding clear-selection recovery copy/action on course cards when the two-course limit is already reached.
- Improved homepage search with trimmed input, exact/partial matching, alias support, and clickable available-skill suggestions.
- Consolidated homepage discovery by keeping `Available skills` primary and renaming SEO links to `Guides and comparison pages`.
- Switched the data-quality report script to plain Node JS so `report:data-quality` does not depend on `tsx`/esbuild startup.

## Validation
- `corepack pnpm report:data-quality` passed.
- `corepack pnpm validate:data` passed: 19 courses validated successfully.
- `corepack pnpm exec tsc --noEmit` was attempted but this Windows shell could not resolve the `tsc` shim via `pnpm exec`; direct local compiler invocation `./node_modules/.bin/tsc.CMD --noEmit` passed.
- `corepack pnpm build` was attempted but local sandbox blocked Next.js worker process spawn with `spawn EPERM` before app compilation could complete.
- `corepack pnpm generate:seo` was attempted because SEO templates changed, but local sandbox blocked `tsx`/esbuild spawn with `spawn EPERM` before generation could run.
- Additional checks passed: SEO route folder slugs matched route slug constants; required SEO pages resolved expected course counts; no `PUBLICIDAD`/`Publicidad` strings remain.
- `lint` not run because it was not requested and this repo's `next lint` can trigger setup when ESLint is not configured.

## Confirmations
- No direct commit to `main`; PR targets `main` from `codex/fix-live-ux-seo-course-rendering`.
- No external APIs added.
- No scraping added.
- No affiliate links or fake affiliate links added.
- No ads or ad scripts added.
- No database added.
- No cookies added.
- No analytics vendors added.
- No provider URLs replaced.
- No SEO route slugs changed.
- No ranking or outcome claims added.
- Compare selection behavior preserved: persisted selections remain, and exactly 2 selected courses enable compare.