### PR TITLE
Deduplicate course card platform metadata

### DIFF
--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -59,7 +59,7 @@ export const CourseCard = ({ course }: CourseCardProps) => {
           <p className="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-blue-700">{course.platform}</p>
           <h3 className="break-words text-xl font-semibold leading-snug tracking-tight text-slate-950">{course.title}</h3>
           <p className="mt-2 text-sm font-medium text-slate-500">
-            {course.platform} / {course.level}
+            {course.level}
           </p>
         </div>
         {course.rating ? (


### PR DESCRIPTION
## What changed

- Removed the repeated platform name from the course card's secondary metadata line.
- Preserved the platform eyebrow, course level signal, and existing card hierarchy.

## Why

The visual-polish update added a platform eyebrow while the secondary metadata line continued to repeat the platform. The card now presents that metadata once in the header while retaining the level beneath the title.

## Impact

This is a one-line UI correction in `src/components/CourseCard.tsx`. It does not change catalog data, SEO, monetization, ranking, dependencies, or architecture.

## Validation

- `corepack pnpm validate:data`
- `corepack pnpm report:data-quality`
- `node node_modules/typescript/bin/tsc --noEmit` (approved Windows launcher-resolution fallback)
- `corepack pnpm build`