### PR TITLE
Update state after Phase 1 verification Batch B

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,6 +1,6 @@
 # Current State
 
-Last updated after Phase 1 Source Verification — Coverage Batch A merged on 2026-08-17.
+Last updated after Phase 1 Source Verification — Coverage Batch B merged in PR #85.
 
 ## Product State
 
@@ -12,30 +12,32 @@ The core journey has a deliberate visual hierarchy across mobile and desktop, wi
 
 ## Latest Completed Initiative
 
-**Phase 1 Source Verification — Coverage Batch A** — merged in PR #82.
+**Phase 1 Source Verification — Coverage Batch B** — merged in PR #85.
 
 Key outcomes:
 
-- Five previously pending catalog records were manually checked against their existing official Coursera provider pages.
-- All five are now `partially_verified` with source-backed field coverage and 2026-08-17 verification dates.
-- `machine-learning-stanford-university` was corrected to the current course title **Supervised Machine Learning: Regression and Classification**, with current provider attribution and unsupported exact duration removed.
-- `ibm-data-science-ibm` and `meta-front-end-developer-meta` received current Professional Certificate titles, source-backed prerequisites, and removal of derived exact-hour duration values.
-- `ibm-cybersecurity-analyst-ibm` gained verified title, level, certificate, English language, workload signal, and learning-topic coverage while unsupported prerequisites remain unverified.
-- `project-management-principles-practices-umci` gained verified English primary taught language, source-backed prerequisites, workload, certificate, level, and learning-topic coverage.
-- Price, rating, and review count remain unknown and unverified for the batch.
-- No source URL mismatches were introduced.
+- All seven records that were pending after Batch A were manually reviewed against current official provider pages.
+- Five records moved to `partially_verified`; two remain `pending` because the exact recorded offering could not be confirmed from a current official source.
+- `deep-learning-specialization-deeplearningai` had the inferred 120-hour total removed, source-backed prerequisites aligned, and English verified as the primary taught language. The provider separately lists additional language availability, which is not represented by the current single `language` field.
+- `introduction-to-cloud-computing-ibm` gained verified stable-field coverage for title/provider, level, English, certificate, workload, and learning topics; its specific prerequisites remain unverified.
+- `introduction-project-management-edx-adelaidex` was updated to the current canonical edX URL, current title/description, certificate availability, and source-backed prerequisites.
+- `google-advanced-data-analytics-google` was corrected from intermediate to advanced and its prerequisites were aligned to the current official page.
+- `ibm-ai-engineering-ibm` gained verified stable-field coverage and source-backed Python, Jupyter Notebook, and mathematics prerequisites.
+- `introduction-cyber-security-nyux-edx` remains pending because the recorded edX page is unavailable and no current official page clearly represents the exact same NYUx offering.
+- `data-analytics-essentials-cisco` remains pending because the recorded Coursera listing is unavailable and Cisco's current instructor-led offering is insufficient to establish that it is the same listing.
+- Price, rating, and review count remain unknown/null and unverified for the batch.
+- Source URL mismatches remain at 0.
 
-The small **Course Card Metadata Deduplication** follow-up was also completed in PR #81, removing the repeated platform label while preserving the platform eyebrow and course-level signal.
-
-The earlier **Decision-focused Visual Polish** and **Mobile Selection and Discovery UX** initiatives remain in place.
+Earlier completed initiatives, including Batch A, Course Card Metadata Deduplication, Decision-focused Visual Polish, and Mobile Selection and Discovery UX, remain in place.
 
 ## Catalog and Trust State
 
 - The normalized catalog contains 19 curated courses.
-- 12 courses are currently `partially_verified`.
-- 7 courses remain `pending`.
-- Source URL mismatches: 0 after Batch A.
-- Most pricing, ratings, review counts, and some duration values remain unknown or unverified.
+- 17 courses are currently `partially_verified`.
+- 2 courses remain `pending`.
+- Source URL mismatches: 0 after Batch B.
+- Most pricing, ratings, and review counts remain unknown or unverified by design; some duration values also remain unknown where providers expose only workload estimates.
+- The current normalized `language` field represents the primary taught language when that is clearly supported by an official source. Additional dubbing/subtitle/language availability is provenance context rather than a second meaning for the same field.
 - `report:data-quality` remains part of normal validation.
 - Official provider pages remain the final source users should verify before enrollment.
 
@@ -58,58 +60,28 @@ These are intentional roadmap constraints, not missing requirements to fill oppo
 
 ## Next Approved Product Initiative
 
-### Phase 1 Source Verification — Coverage Batch B
+No new product implementation initiative is currently approved.
 
-Purpose: complete a manual source review of the seven catalog records that remain `pending`, increasing trustworthy comparison coverage without expanding the catalog or inventing precision.
+The approved Phase 1 Source Verification — Coverage Batch B initiative is complete. Coding agents must not automatically begin another verification batch, SEO expansion, monetization, recommendation, infrastructure, catalog expansion, language-schema expansion, or visual initiative.
 
-Review exactly these records against their official provider pages already recorded in source metadata:
+The next initiative must be chosen through product review and recorded here before implementation begins.
 
-1. `deep-learning-specialization-deeplearningai` — AI — Coursera
-2. `introduction-cyber-security-nyux-edx` — Cybersecurity — edX
-3. `introduction-to-cloud-computing-ibm` — Cloud Computing — Coursera
-4. `introduction-project-management-edx-adelaidex` — Project Management — edX
-5. `google-advanced-data-analytics-google` — Data Analysis — Coursera
-6. `data-analytics-essentials-cisco` — Data Analysis — Coursera
-7. `ibm-ai-engineering-ibm` — AI — Coursera
+## Product Review Focus
 
-For each record, attempt to verify these stable fields when the current official page clearly supports them:
+Phase 1 now has high verification coverage across the curated catalog: 17 of 19 records are partially verified and the remaining two have explicit source blockers rather than unreviewed status.
 
-- current title and provider/platform attribution
-- canonical official source URL
-- level
-- primary taught language
-- certificate availability
-- workload or duration signal
-- learning topics / syllabus coverage
-- prerequisites or recommended experience
+Before approving more implementation work, product review should decide whether the highest-value next move is:
 
-Verification rules:
+- resolving or replacing the two blocked pending records,
+- moving to Phase 3 discovery/SEO work on the now-better-trusted catalog,
+- preparing a real Phase 2 monetization path only if an actual affiliate/referral program is available,
+- or another narrowly defined user-decision improvement supported by observed product needs.
 
-- Use official provider pages only.
-- Review all seven records, but do not force a record to `partially_verified` if the official page is unavailable or does not support enough fields.
-- If an official URL redirects, has moved, or is no longer available, use a current canonical official provider page only when it clearly represents the same offering; otherwise keep the uncertainty documented.
-- Correct normalized catalog fields only when the current official source clearly contradicts the existing value.
-- Workload statements may be recorded as source evidence without converting months/weeks at a weekly pace into invented exact `durationHours` values.
-- Exact duration hours may remain or be added only when the official source itself provides a sufficiently exact hour total.
-- Do not add or infer price, rating, or review-count values. These remain unknown/null and unverified in this batch.
-- Do not infer certificate, language, prerequisites, level, or availability from generic platform behavior.
-- Unknown or unsupported facts remain null, unknown, pending, or unverified as appropriate.
-- No scraping, provider API, new dependency, catalog expansion, SEO expansion, ranking, recommendation, monetization, or unrelated UI work.
-- Keep the change small and auditable in the existing normalized catalog/source metadata files.
-
-Success means all seven pending records have been manually reviewed and their provenance/status accurately reflects what the official sources support. The target is better trust coverage, not a forced zero-pending metric.
-
-After implementation, run the full required repository validation sequence, using the documented narrow Windows TypeScript launcher fallback only if the normal pnpm launcher hits that exact executable-resolution issue.
-
-The implementation must use one dedicated branch and PR and must not be merged by the coding agent.
-
-## After Batch B
-
-Do not automatically start another product implementation initiative. After Batch B is reviewed and merged, update this file with the resulting verification coverage and return to product review before approving SEO expansion, another data initiative, monetization, recommendation, infrastructure, catalog expansion, or further visual work.
+Do not treat zero pending records as a goal by itself.
 
 ## Parallel Ongoing Work
 
-Phase 1 data verification remains the active roadmap area. SEO expansion follows only after the core experience remains stable and the catalog is sufficiently trustworthy. Monetization remains gated behind a real program and disclosure design.
+Phase 1 data quality remains an active product concern even though the planned Batch A and Batch B verification passes are complete. Future verification should remain small, explicit, source-backed, and auditable. Monetization remains gated behind a real program and disclosure design, and recommendation remains gated behind trustworthy signals and explicit criteria.
 
 ## Operational Note
 

--- a/docs/PRODUCT_DECISIONS.md
+++ b/docs/PRODUCT_DECISIONS.md
@@ -50,6 +50,13 @@ The product UI is **English-first** in the current phase.
 
 Do not introduce mixed-language UI incidentally. Localization can be considered as an explicit future initiative.
 
+For course catalog data, the current normalized `language` field means the **primary taught language**, not every language in which the provider may offer dubbing, subtitles, translations, or other presentation options.
+
+- Mark `language` verified only when the current official provider source clearly supports the primary taught language, for example with an explicit `Taught in English` statement.
+- Additional available languages, AI dubbing, subtitles, or translated presentation options should be documented in source metadata/provenance when useful, but they do not change the meaning of the current single `language` field.
+- Do not overload `language` with a list of every available presentation language.
+- Do not expand the runtime schema solely for an isolated multi-language case. If repeated user/product need emerges, consider a separate initiative for fields such as `availableLanguages`, audio languages, or subtitle languages.
+
 ## Mobile UX
 
 Mobile is a first-class product surface, not a compressed desktop layout.

--- a/docs/catalog-phase-1.md
+++ b/docs/catalog-phase-1.md
@@ -40,8 +40,10 @@ Optional data can be present when verified:
 - If provenance cannot be confirmed, the record should not be published as verified catalog data.
 - Per-course source metadata lives in `data/normalized/course-source-metadata.json`.
 - Source metadata should stay separate from the runtime course schema until there is a product need to display it.
-- Verification can be partial. Stable fields such as title, platform, source URL, level, language, duration signals, certificate visibility, syllabus topics, and prerequisites can be marked verified while volatile fields such as price, rating, and review count remain unknown/null.
-- Seven priority courses currently have partial verification from official Coursera provider pages: Google Data Analytics, Google Cybersecurity, Google Project Management, AI For Everyone, AWS Cloud Technical Essentials, Google Cloud Fundamentals: Core Infrastructure, and IBM Data Analyst.
+- Verification can be partial. Stable fields such as title, platform, source URL, level, primary taught language, duration signals, certificate visibility, syllabus topics, and prerequisites can be marked verified while volatile fields such as price, rating, and review count remain unknown/null.
+- After the Batch A and Batch B manual verification passes, 17 of 19 curated courses are `partially_verified`; 2 remain `pending` because their exact recorded offerings could not be confirmed from a current official provider page.
+- The two pending records are `introduction-cyber-security-nyux-edx` and `data-analytics-essentials-cisco`. Their pending state reflects explicit source uncertainty rather than an unreviewed backlog.
+- The normalized `language` field represents the primary taught language when the official provider source clearly identifies it. Additional dubbing, subtitles, translations, or available presentation languages should remain provenance context unless a future product initiative expands the runtime schema.
 - Workload statements such as months at a weekly pace can be verified in source metadata without converting them into an exact `durationHours` value.
 
 ## Data quality rules
@@ -51,6 +53,7 @@ Optional data can be present when verified:
 - Treat pricing, certificate terms, and availability as volatile.
 - Use explicit unverified wording where needed.
 - Unknown price, rating, review count, duration, and certificate terms are expected during phase 1 and should be surfaced as decision risk, not hidden.
+- Do not force a record out of `pending` merely to improve a coverage metric when the exact offering cannot be confirmed from an official source.
 
 ## Allowed source types
 - Official provider course pages


### PR DESCRIPTION
Updates durable repository context after merging Phase 1 Source Verification — Coverage Batch B (#85).

Scope:
- Updates `docs/CURRENT_STATE.md` with the resulting catalog trust state: 17 partially verified, 2 pending, 0 source URL mismatches.
- Records the two remaining pending records as explicit source blockers rather than an unreviewed backlog.
- Returns the product to review with no new implementation initiative approved.
- Documents the current course-language semantics: `language` means primary taught language; additional dubbing/subtitle/translation availability stays in provenance unless a future explicit schema initiative is approved.
- Updates `docs/catalog-phase-1.md` to remove stale verification counts.

Documentation only. No runtime, catalog data, SEO, monetization, ranking, recommendation, dependency, or build-tooling changes.