### PR TITLE
Sync MVP readiness after Batch B

### DIFF
--- a/docs/MVP_READINESS.md
+++ b/docs/MVP_READINESS.md
@@ -2,28 +2,30 @@
 
 ## Current State
 
-- Skills Compare is an English UI for finding skills, reviewing relevant online courses, comparing two options, and opening the original provider page.
-- The normalized catalog currently contains 19 curated courses.
-- Generated SEO pages, sitemap support, and internal SEO links are present.
+- Skills Compare is an English-first product for finding skills, reviewing relevant online courses, comparing two options, and opening the original provider page.
+- The normalized catalog contains 19 curated courses.
+- 17 courses are `partially_verified`; 2 remain `pending` because the exact recorded offering could not be confirmed from a current official source.
+- Source URL mismatches are 0 after Phase 1 Source Verification — Coverage Batch B.
+- Generated SEO pages, sitemap support, and internal SEO links are present as a foundation.
 - Provider CTA copy and external-link disclosure copy are centralized.
 - Provider URLs are direct official provider URLs only.
 - Outbound tracking is local-only and does not send data to an external analytics vendor.
-- Source metadata exists for normalized courses in `data/normalized/course-source-metadata.json`, with seven priority courses marked `partially_verified`.
 - A data quality report is available with `corepack pnpm report:data-quality` and includes verification-status counts, verified-field coverage, fully pending courses, partially verified courses, and unknown field counts.
 - Mobile Selection and Discovery UX is merged: compare selection persists for up to 24 hours, returning selections are surfaced, and the compare bar is available globally outside the compare page.
+- Decision-focused visual polish is merged across the core Search -> Compare -> Decide journey.
 
 ## Trust and Data Quality Reality
 
-- Most source metadata is still marked `pending` until manual verification is completed.
-- Priority verification has started using official provider pages.
-- Source verification remains a separate, conservative data-quality task.
-- The partially verified priority courses are Google Data Analytics, Google Cybersecurity, Google Project Management, AI For Everyone, AWS Cloud Technical Essentials, Google Cloud Fundamentals: Core Infrastructure, and IBM Data Analyst.
-- Verified fields include stable catalog facts such as title, platform/source URL, level, language, certificate visibility, workload/duration signals, learning topics, and prerequisites where clearly shown.
-- Prices, ratings, review counts, and some durations are mostly unverified or unknown.
-- Monthly workload estimates are not converted into exact `durationHours`; those values remain null where an exact total is not clearly shown.
+- Phase 1 manual verification has now reviewed the full 19-course curated catalog at least at the record level.
+- Verification remains conservative and can be partial when a current official page does not support a field.
+- Stable fields such as title, platform/source URL, level, primary taught language, certificate visibility, workload/duration signals, learning topics, and prerequisites are marked verified only when clearly supported.
+- Prices, ratings, review counts, and some durations remain unverified or unknown by design.
+- Monthly or weekly workload estimates are not converted into invented exact `durationHours`; those values remain null unless the official source provides a sufficiently exact total.
+- The normalized `language` field represents the primary taught language when clearly supported. Additional dubbing, subtitle, translation, or language availability remains provenance context unless a future explicit schema initiative expands the model.
+- `introduction-cyber-security-nyux-edx` remains pending because the recorded edX page is unavailable and no current official page clearly represents the exact same NYUx offering.
+- `data-analytics-essentials-cisco` remains pending because the recorded Coursera listing is unavailable and Cisco's current instructor-led offering does not establish that it is the same listing.
 - Unknown data must remain null, unknown, pending, or explicitly unverified.
-- Certificate information is present where the catalog currently has it, but provider terms may change.
-- Users should verify pricing, duration, certificate terms, enrollment details, and availability on the provider page before deciding.
+- Users should verify final pricing, duration, certificate terms, enrollment details, and availability on the provider page before deciding.
 
 ## What Works
 
@@ -57,15 +59,17 @@ Run these before opening or updating a normal product PR:
 - `corepack pnpm exec tsc --noEmit`
 - `corepack pnpm build`
 
-Do not run `corepack pnpm generate:seo` unless catalog or SEO generation inputs change. Do not initialize ESLint configuration just to run lint; `next lint` may currently prompt for setup.
+Use the documented repository-local TypeScript fallback only when the normal pnpm command fails solely because Windows cannot resolve the local `tsc` executable. Do not run `corepack pnpm generate:seo` unless catalog or SEO generation inputs change. Do not initialize ESLint configuration just to run lint; `next lint` may currently prompt for setup.
 
-## Near-Term Priorities
+## Near-Term Product Review
 
-1. Execute decision-focused visual polish across the core Search -> Compare -> Decide journey.
-2. Continue Phase 1 manual verification of source metadata against provider pages.
-3. Keep visual polish lightweight and consistent rather than introducing a broad design system.
-4. Validate mobile and desktop usability after each polish batch before widening scope.
-5. Continue SEO expansion after the core experience remains stable and useful.
-6. Add freshness display only after there is enough `lastVerifiedAt` coverage to avoid implying full-catalog verification.
-7. Define explicit ranking criteria before making any ranking-style claims.
-8. Add monetized links only when a real and auditable affiliate or referral program exists.
+The planned Phase 1 Batch A and Batch B verification passes are complete. The two remaining pending records are explicit source blockers, not an unreviewed backlog, and zero pending records is not a product goal by itself.
+
+No new implementation initiative is automatically approved. Product review should choose the next move based on user and business value. The strongest current candidates are:
+
+1. Begin a narrow Phase 3 discovery/SEO initiative now that the core experience is stable and catalog trust coverage is high enough to support useful pages.
+2. Resolve or replace one of the two blocked records only if doing so materially improves an important skill page or comparison path.
+3. Prepare Phase 2 monetization only when a real, auditable affiliate or referral program is available.
+4. Prioritize another narrowly defined decision-UX improvement only if review or usage evidence identifies a concrete problem.
+
+Do not expand the catalog, language schema, ranking, recommendation, infrastructure, or visual scope opportunistically.


### PR DESCRIPTION
Documentation-only cleanup after Phase 1 Source Verification — Coverage Batch B.

Scope:
- Aligns `docs/MVP_READINESS.md` with the current 19-course trust state: 17 partially verified, 2 pending, 0 source URL mismatches.
- Records the two remaining pending records as explicit source blockers rather than an unreviewed backlog.
- Documents current `language` semantics as primary taught language, with additional dubbing/subtitle/translation availability kept as provenance unless a future explicit schema initiative expands the model.
- Removes stale near-term priorities that predated the completed visual polish and verification batches.
- Returns the document to product review with no new implementation initiative automatically approved.

No runtime, catalog data, SEO generation, monetization, ranking, recommendation, dependency, or build-tooling changes.