### PR TITLE
Clarify GitHub CLI is optional for publishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,8 @@ For local or cloud coding agents that use Git, before implementation:
 
 If fetch, checkout, authentication, permissions, proxy, history, or the initial push fails, **stop before implementation**. Do not create local-only work that cannot be published.
 
+GitHub CLI (`gh`) is optional. It is not a publishing-preflight requirement and must not be installed merely to execute an approved task. Standard `git` authentication and the configured `origin` remote are sufficient for fetch, branch creation, and push. If the branch can be pushed but a local agent cannot open a PR because `gh` is unavailable, continue the implementation, push the completed branch, report that PR creation was unavailable locally, and leave PR creation to the connected GitHub workflow or product owner.
+
 ## Validation Before PR Completion
 
 Run the validations defined in `docs/ENGINEERING_RULES.md`. At minimum for normal product changes:

--- a/docs/ENGINEERING_RULES.md
+++ b/docs/ENGINEERING_RULES.md
@@ -16,6 +16,8 @@ Before implementation, local or cloud coding agents using Git must:
 
 If any fetch, authentication, checkout, permissions, proxy, history, or push step fails, stop before implementation.
 
+GitHub CLI (`gh`) is optional and is not part of the mandatory publishing preflight. Do not install or authenticate `gh` merely to execute an approved task. Standard `git` authentication through the configured remote is sufficient for fetch and push. If the implementation branch can be pushed but the local agent cannot create a pull request because `gh` is unavailable, that is not an implementation blocker: finish the approved work, push the branch, report the limitation, and let the connected GitHub workflow or product owner create the PR.
+
 Do not reuse unrelated-history commits, synthetic-root history, stale workspaces, or unpublished local-only work.
 
 ## Scope Discipline


### PR DESCRIPTION
Documentation-only clarification of the publishing preflight.

Scope:
- Explicitly states that GitHub CLI (`gh`) is optional and not a publishing-preflight requirement.
- Confirms standard `git` authentication and the configured remote are sufficient for fetch/branch/push.
- Clarifies that inability to create a PR locally solely because `gh` is unavailable is not an implementation blocker after the branch can be pushed.
- Prevents coding agents from installing or authenticating `gh` unnecessarily.

No runtime, product, data, SEO, dependency, build-tooling, monetization, ranking, or recommendation changes.