### PR TITLE
Align SEO indexable surface

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -4,23 +4,19 @@ import { courses } from "../src/lib/catalog-adapter";
 import { getSkillSummaries } from "../src/lib/skill-catalog";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const now = new Date();
   const skills = getSkillSummaries();
 
   return [
     {
       url: `${SITE_URL}/`,
-      lastModified: now,
       priority: 1
     },
     ...skills.map((skill) => ({
       url: `${SITE_URL}/skills/${skill.slug}`,
-      lastModified: now,
       priority: 0.8
     })),
     ...courses.map((course) => ({
       url: `${SITE_URL}/courses/${course.id}`,
-      lastModified: now,
       priority: 0.7
     }))
   ];

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,10 +1,11 @@
 import type { MetadataRoute } from "next";
 import { SITE_URL } from "../src/config/siteConfig";
-import { getAllSeoPages } from "../src/lib/seo/seoPages";
+import { courses } from "../src/lib/catalog-adapter";
+import { getSkillSummaries } from "../src/lib/skill-catalog";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date();
-  const seoPages = getAllSeoPages();
+  const skills = getSkillSummaries();
 
   return [
     {
@@ -12,19 +13,15 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: now,
       priority: 1
     },
-    {
-      url: `${SITE_URL}/compare`,
+    ...skills.map((skill) => ({
+      url: `${SITE_URL}/skills/${skill.slug}`,
       lastModified: now,
       priority: 0.8
-    },
-    ...seoPages.map((page) => {
-      const updatedAt = (page as { updatedAt?: string | number | Date }).updatedAt;
-
-      return {
-        url: `${SITE_URL}/${page.slug}`,
-        lastModified: new Date(updatedAt || Date.now()),
-        priority: 0.6
-      };
-    })
+    })),
+    ...courses.map((course) => ({
+      url: `${SITE_URL}/courses/${course.id}`,
+      lastModified: now,
+      priority: 0.7
+    }))
   ];
 }

--- a/src/components/seo/SeoLinks.tsx
+++ b/src/components/seo/SeoLinks.tsx
@@ -1,10 +1,17 @@
 import Link from "next/link";
 import seoPagesData from "@/data/generated/seoPages.json";
+import { resolveSkillSlug } from "@/lib/skill-routing";
 
 export function SeoLinks() {
   const pages = Array.isArray(seoPagesData) ? seoPagesData : [];
   const discoveryPages = pages
     .filter((page) => page?.intent === "course-discovery" && typeof page.slug === "string" && typeof page.skillLabel === "string")
+    .map((page) => ({
+      ...page,
+      skillRouteSlug:
+        resolveSkillSlug(page.skillSlug) ?? resolveSkillSlug(page.skillLabel)
+    }))
+    .filter((page) => page.skillRouteSlug !== null)
     .sort((a, b) => a.skillLabel.localeCompare(b.skillLabel));
 
   return (
@@ -12,7 +19,7 @@ export function SeoLinks() {
       {discoveryPages.map((page) => (
         <li key={page.slug}>
           <Link
-            href={`/${page.slug}`}
+            href={`/skills/${page.skillRouteSlug}`}
             className="block rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 hover:border-slate-300 hover:text-slate-900"
           >
             <span className="font-semibold">{page.skillLabel}</span>

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -38,9 +38,14 @@ export const buildPageMetadata = ({
   };
 };
 
-export const buildSeoPageMetadata = (page: GeneratedSeoPage): Metadata =>
-  buildPageMetadata({
+export const buildSeoPageMetadata = (page: GeneratedSeoPage): Metadata => ({
+  ...buildPageMetadata({
     title: page.title,
     description: page.metaDescription,
     path: `/${page.slug}`
-  });
+  }),
+  robots: {
+    index: false,
+    follow: true
+  }
+});


### PR DESCRIPTION
## What changed

- Rebuilt `/sitemap.xml` from the normalized catalog's canonical product surfaces: the homepage, 8 skill pages, and 19 course-detail pages.
- Removed `/compare` and all 20 generated template SEO routes from the sitemap.
- Marked every generated template SEO route `noindex, follow` through the shared metadata builder while keeping the routes accessible.
- Retargeted the existing homepage guide links from generated template routes to their corresponding canonical skill pages.
- Preserved the existing self-referencing canonical metadata on indexable skill and course pages.

## Why

Phase 3 Batch A requires search engines to be directed toward useful decision pages before any additional SEO content volume is considered. The prior sitemap promoted the functional compare page and repetitive generated templates while omitting canonical skill and course decision pages.

## User and developer impact

Search-facing discovery now favors the core Search → Compare → Decide surfaces backed by the current 19-course catalog. No routes, catalog records, dependencies, or new SEO page types were added or removed.

## Validation

- `corepack pnpm validate:data` — passed (19 courses)
- `corepack pnpm report:data-quality` — passed (17 partially verified, 2 pending, 0 source URL mismatches)
- `corepack pnpm exec tsc --noEmit` — Windows launcher could not resolve `tsc`; approved fallback `node node_modules/typescript/bin/tsc --noEmit` passed
- `corepack pnpm build` — passed
- Built artifact check — 28 sitemap URLs (1 homepage, 8 skills, 19 courses), no compare/generated URLs, and 20/20 generated routes emit `noindex, follow`

Closes #89