### PR TITLE
Phase 1B.2 — Decision Data Contract v2 pilot

### DIFF
--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -116,7 +116,7 @@ const CourseDecisionDetails = ({ course }: { course: Course }) => (
           </ul>
         ) : (
           <p className="mt-3 text-sm text-slate-600">
-            Named tools are not explicitly supported by the current source.
+            Named tools are not verified in the current catalog.
           </p>
         )}
       </div>
@@ -130,7 +130,7 @@ const CourseDecisionDetails = ({ course }: { course: Course }) => (
           </ul>
         ) : (
           <p className="mt-3 text-sm text-slate-600">
-            Projects, labs, or hands-on work are not explicitly supported by the current source.
+            Projects, labs, or hands-on work are not verified in the current catalog.
           </p>
         )}
       </div>

--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -12,7 +12,6 @@ import {
   isDurationPending,
   isExactPricePending
 } from "@/lib/decision-support";
-import { formatCoursePrice } from "@/lib/formatPrice";
 import { courses } from "@/lib/catalog-adapter";
 import { trackOutboundCourseClick } from "@/lib/outbound-tracking";
 import {
@@ -66,6 +65,16 @@ const CourseDecisionDetails = ({ course }: { course: Course }) => (
       <p className="text-sm leading-relaxed text-slate-600">
         {course.shortDescription ?? "Description unavailable."}
       </p>
+      <div className="flex flex-wrap gap-2 pt-2 text-xs font-semibold text-slate-700">
+        {course.offeringType ? (
+          <span className="rounded-full bg-blue-50 px-3 py-1.5 capitalize text-blue-700">
+            {course.offeringType.replaceAll("_", " ")}
+          </span>
+        ) : null}
+        {course.workload ? (
+          <span className="rounded-full bg-slate-100 px-3 py-1.5">{course.workload.text}</span>
+        ) : null}
+      </div>
     </div>
 
     <div className="mt-5 grid gap-5 md:grid-cols-2">
@@ -84,7 +93,7 @@ const CourseDecisionDetails = ({ course }: { course: Course }) => (
         )}
       </div>
       <div>
-        <h4 className="text-sm font-semibold text-slate-900">Prerequisites</h4>
+        <h4 className="text-sm font-semibold text-slate-900">Starting point</h4>
         {course.prerequisitesBullets.length > 0 ? (
           <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed text-slate-600">
             {course.prerequisitesBullets.slice(0, 4).map((item) => (
@@ -93,7 +102,35 @@ const CourseDecisionDetails = ({ course }: { course: Course }) => (
           </ul>
         ) : (
           <p className="mt-3 text-sm text-slate-600">
-            Prerequisites are not available in the current catalog.
+            Starting-point requirements are not verified in the current catalog.
+          </p>
+        )}
+      </div>
+      <div>
+        <h4 className="text-sm font-semibold text-slate-900">Tools / technologies</h4>
+        {(course.toolsTechnologies?.length ?? 0) > 0 ? (
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed text-slate-600">
+            {course.toolsTechnologies?.slice(0, 5).map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-3 text-sm text-slate-600">
+            Named tools are not explicitly supported by the current source.
+          </p>
+        )}
+      </div>
+      <div>
+        <h4 className="text-sm font-semibold text-slate-900">Practical work</h4>
+        {(course.practicalWorkBullets?.length ?? 0) > 0 ? (
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed text-slate-600">
+            {course.practicalWorkBullets?.slice(0, 4).map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-3 text-sm text-slate-600">
+            Projects, labs, or hands-on work are not explicitly supported by the current source.
           </p>
         )}
       </div>
@@ -167,10 +204,8 @@ export default function CompareClient() {
     );
   }
 
-  const leftPrice = formatCoursePrice(leftCourse);
-  const rightPrice = formatCoursePrice(rightCourse);
-  const decisionSummary = getDecisionSummary(leftCourse, rightCourse, leftPrice, rightPrice);
-  const comparisonRows = buildComparisonRows(leftCourse, rightCourse, leftPrice, rightPrice);
+  const decisionSummary = getDecisionSummary(leftCourse, rightCourse);
+  const comparisonRows = buildComparisonRows(leftCourse, rightCourse);
   const pendingRisks = getPendingDataRisks([leftCourse, rightCourse]);
 
   return (

--- a/data/normalized/course-source-metadata.json
+++ b/data/normalized/course-source-metadata.json
@@ -48,7 +48,7 @@
     "sourceUrl": "https://www.coursera.org/specializations/deep-learning",
     "sourceType": "official_provider_page",
     "verificationStatus": "partially_verified",
-    "lastVerifiedAt": "2026-08-17",
+    "lastVerifiedAt": "2026-08-18",
     "verifiedFields": {
       "title": true,
       "platform": true,
@@ -61,9 +61,15 @@
       "language": true,
       "level": true,
       "syllabus": true,
-      "prerequisites": true
+      "prerequisites": true,
+      "offeringType": true,
+      "workload": true,
+      "toolsTechnologies": true,
+      "practicalWork": true,
+      "credential": true,
+      "costModel": true
     },
-    "notes": "Source: official Coursera provider page at the existing canonical URL. Verified the Deep Learning Specialization title, Coursera platform/source URL, DeepLearning.AI attribution, intermediate level, English as the primary taught language, shareable certificate, 3 months at 10 hours/week workload signal, learning topics, and stated Python, linear algebra, and machine learning background. durationHours changed from 120 to null because the page does not provide an exact program total. The page separately lists 27 available languages; this does not change the verified English primary taught language. Price, rating, and review count intentionally remain unknown/null because they are volatile."
+    "notes": "Source: official Coursera provider page at the existing canonical URL, reviewed 2026-08-18 for the Decision Data Contract v2 pilot. Verified the specialization and career-certificate context; 3 months at 10 hours/week workload wording; stated Python, linear algebra, and machine learning background; learning topics; Python, TensorFlow, and Hugging Face tools; applied learning project, programming assignments, and labs; and subscription access context. durationHours remains null because the page does not provide one explicit program total. Exact price, rating, and review count remain unknown/null because they are volatile."
   },
   {
     "courseId": "ibm-data-science-ibm",
@@ -114,7 +120,7 @@
     "sourceUrl": "https://www.coursera.org/professional-certificates/ibm-cybersecurity-analyst",
     "sourceType": "official_provider_page",
     "verificationStatus": "partially_verified",
-    "lastVerifiedAt": "2026-08-17",
+    "lastVerifiedAt": "2026-08-18",
     "verifiedFields": {
       "title": true,
       "platform": true,
@@ -127,16 +133,22 @@
       "language": true,
       "level": true,
       "syllabus": true,
-      "prerequisites": false
+      "prerequisites": false,
+      "offeringType": true,
+      "workload": true,
+      "toolsTechnologies": true,
+      "practicalWork": true,
+      "credential": true,
+      "costModel": false
     },
-    "notes": "Source: official Coursera provider page at the existing canonical URL. Verified title, platform/source URL, beginner level, English language, shareable certificate, 4 months at 10 hours/week workload signal, and learning topics covering cybersecurity fundamentals, network security, incident response, penetration testing, and forensics. durationHours remains null. Prerequisites remain unverified because the page exposes only a generic recommended-experience label without supporting the catalog's specific statements. Price, rating, and review count intentionally remain unknown/null because they are volatile."
+    "notes": "Source: official Coursera provider page at the existing canonical URL, reviewed 2026-08-18 for the Decision Data Contract v2 pilot. Verified the professional-certificate and IBM credential/digital-badge context; 4 months at 10 hours/week workload wording; learning topics; explicitly named ITIL, OWASP ZAP, and Snyk tools; and hands-on labs, projects, case studies, cybersecurity plans, and compliance-framework work. The previous prerequisite bullets were removed because the current page only exposes a generic recommended-experience label. Cost model, exact price, rating, and review count remain unverified."
   },
   {
     "courseId": "google-cybersecurity-google",
     "sourceUrl": "https://www.coursera.org/professional-certificates/google-cybersecurity",
     "sourceType": "official_provider_page",
     "verificationStatus": "partially_verified",
-    "lastVerifiedAt": "2026-06-06",
+    "lastVerifiedAt": "2026-08-18",
     "verifiedFields": {
       "title": true,
       "platform": true,
@@ -149,9 +161,15 @@
       "language": true,
       "level": true,
       "syllabus": true,
-      "prerequisites": true
+      "prerequisites": true,
+      "offeringType": true,
+      "workload": true,
+      "toolsTechnologies": true,
+      "practicalWork": true,
+      "credential": true,
+      "costModel": true
     },
-    "notes": "Source: official Coursera provider page. Verified title, platform/source URL, beginner level, English language, shareable certificate, 6 months at 7 hours/week workload signal, learning topics, and no prior experience requirement. durationHours remains null because converting a monthly schedule to exact hours would be an estimate. Price, rating, and review count intentionally remain unknown/null because they are volatile."
+    "notes": "Source: official Coursera provider page at the existing canonical URL, reviewed 2026-08-18 for the Decision Data Contract v2 pilot. Verified the professional-certificate and Google credential context; 6 months at 7 hours/week workload wording; no prior experience requirement; learning topics; Linux, Python, Bash, SQL, SIEM, and intrusion-detection tools; hands-on labs, practice-based assessments, and portfolio activities; and monthly-subscription/free-trial context with regional variation. durationHours remains null because the schedule is not converted into an exact total. Exact price, rating, and review count remain unknown/null because they are volatile."
   },
   {
     "courseId": "introduction-cyber-security-nyux-edx",
@@ -378,7 +396,7 @@
     "sourceUrl": "https://www.coursera.org/learn/ai-for-everyone",
     "sourceType": "official_provider_page",
     "verificationStatus": "partially_verified",
-    "lastVerifiedAt": "2026-06-06",
+    "lastVerifiedAt": "2026-08-18",
     "verifiedFields": {
       "title": true,
       "platform": true,
@@ -391,9 +409,15 @@
       "language": true,
       "level": true,
       "syllabus": true,
-      "prerequisites": true
+      "prerequisites": true,
+      "offeringType": true,
+      "workload": true,
+      "toolsTechnologies": false,
+      "practicalWork": false,
+      "credential": true,
+      "costModel": true
     },
-    "notes": "Source: official Coursera provider page. Verified title, platform/source URL, beginner level, English language, shareable certificate, 7-hour duration signal, learning topics, and no prior experience requirement. Price, rating, and review count intentionally remain unknown/null because they are volatile."
+    "notes": "Source: official Coursera provider page at the existing canonical URL, reviewed 2026-08-18 for the Decision Data Contract v2 pilot. Verified the single-course and shareable-course-certificate context; explicit 7-hour completion signal; no prior experience requirement; learning topics; and paid certificate experience with possible free-trial or full-course-without-certificate access. The source does not explicitly support named tools/technologies or hands-on project/lab work, so those dimensions remain empty and unverified. Exact price, rating, and review count remain unknown/null because they are volatile."
   },
   {
     "courseId": "ibm-ai-engineering-ibm",

--- a/data/normalized/courses.json
+++ b/data/normalized/courses.json
@@ -85,6 +85,30 @@
       "Intermediate Python experience, including basic programming, control flow, lists, and dictionaries",
       "Basic linear algebra and machine learning knowledge recommended"
     ],
+    "offeringType": "specialization",
+    "workload": {
+      "durationQuantity": 3,
+      "durationUnit": "month",
+      "hoursPerWeek": 10,
+      "text": "3 months at 10 hours a week"
+    },
+    "toolsTechnologies": [
+      "Python",
+      "TensorFlow",
+      "Hugging Face"
+    ],
+    "practicalWorkBullets": [
+      "Applied learning project building and training deep neural networks",
+      "Programming assignments and labs using TensorFlow"
+    ],
+    "credential": {
+      "type": "specialization_certificate",
+      "text": "Career certificate for the five-course specialization"
+    },
+    "costModel": {
+      "type": "subscription",
+      "text": "An active subscription is required to access labs and submit assignments"
+    },
     "source": "coursera-curated"
   },
   {
@@ -168,10 +192,29 @@
       "Network security and endpoint protection basics",
       "Incident response and SOC-oriented practices"
     ],
-    "prerequisitesBullets": [
-      "No prior cybersecurity experience required",
-      "Basic computer literacy"
+    "prerequisitesBullets": [],
+    "offeringType": "professional_certificate",
+    "workload": {
+      "durationQuantity": 4,
+      "durationUnit": "month",
+      "hoursPerWeek": 10,
+      "text": "4 months at 10 hours a week"
+    },
+    "toolsTechnologies": [
+      "Information Technology Infrastructure Library (ITIL)",
+      "OWASP ZAP",
+      "Snyk"
     ],
+    "practicalWorkBullets": [
+      "Hands-on labs and projects using industry-specific security tools",
+      "Real-world incident response and forensics case studies",
+      "Projects developing cybersecurity plans and compliance frameworks"
+    ],
+    "credential": {
+      "type": "professional_certificate",
+      "text": "IBM Professional Certificate and digital badge"
+    },
+    "costModel": null,
     "source": "coursera-curated"
   },
   {
@@ -202,6 +245,32 @@
       "No prior experience required",
       "Beginner-level orientation"
     ],
+    "offeringType": "professional_certificate",
+    "workload": {
+      "durationQuantity": 6,
+      "durationUnit": "month",
+      "hoursPerWeek": 7,
+      "text": "6 months at 7 hours a week"
+    },
+    "toolsTechnologies": [
+      "Linux",
+      "Python",
+      "Bash",
+      "SQL",
+      "SIEM and intrusion detection tools"
+    ],
+    "practicalWorkBullets": [
+      "Hands-on labs and practice-based assessments simulating cybersecurity scenarios",
+      "Portfolio activities in each course"
+    ],
+    "credential": {
+      "type": "professional_certificate",
+      "text": "Google Professional Certificate"
+    },
+    "costModel": {
+      "type": "subscription",
+      "text": "Monthly subscription after an initial free trial in the U.S. and Canada; regional pricing may vary"
+    },
     "source": "coursera-curated"
   },
   {
@@ -525,6 +594,23 @@
       "No prior experience required",
       "Designed for non-technical and broad audiences"
     ],
+    "offeringType": "course",
+    "workload": {
+      "durationQuantity": 7,
+      "durationUnit": "hour",
+      "hoursPerWeek": null,
+      "text": "7 hours to complete"
+    },
+    "toolsTechnologies": [],
+    "practicalWorkBullets": [],
+    "credential": {
+      "type": "course_certificate",
+      "text": "Shareable course certificate"
+    },
+    "costModel": {
+      "type": "paid_certificate",
+      "text": "The certificate experience requires purchase; a free trial or full course without a certificate may be available"
+    },
     "source": "coursera-curated"
   },
   {

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,6 +1,6 @@
 # Current State
 
-Last updated after merging the Phase 3 Indexable Surface Foundation and Phase 1B.1 Comparison Integrity Fix, and after approving the Phase 1B.2 Decision Data Contract v2 pilot.
+Last updated after implementing the Phase 1B.2 Decision Data Contract v2 pilot for product review.
 
 ## Product State
 
@@ -11,6 +11,17 @@ The current UI is English-first. The product supports skill discovery, curated c
 Recent product review exposed an important distinction: source-trusted catalog data is not automatically decision-useful data. The product must not only avoid inventing facts; it must preserve enough structured provider-backed information to help a user actually choose between courses.
 
 ## Latest Completed Initiatives
+
+### Phase 1B.2 — Decision Data Contract v2 pilot — Issue #94
+
+Key outcomes:
+
+- The normalized contract now preserves offering type, provider-described workload, tools/technologies, practical work, credential context, and cost-model context without display-string parsing.
+- Migration is limited to exactly four approved pilot courses; the remaining 15 catalog records are unchanged.
+- Provenance metadata carries explicit per-field verification for every new dimension.
+- Both required comparisons pass the internal 5/7 decision-readiness gate without inferred totals or unsupported facts.
+- Desktop and mobile acceptance checks confirm that the seven dimensions, their differences, and their insufficiencies remain readable without horizontal overflow.
+- Exact prices, volatile ratings/review counts, IBM prerequisite details, IBM cost context, and AI For Everyone tools/practical work remain unknown or unverified where the official source does not support them.
 
 ### Phase 1B.1 — Comparison Integrity Fix — PR #93
 
@@ -40,7 +51,7 @@ Earlier completed initiatives, including Phase 1 Source Verification Batches A/B
 
 - **Phase 0 — MVP:** complete for the current MVP scope.
 - **Phase 1A — Source Trust:** complete for the current 19-course curated MVP catalog; ongoing maintenance only.
-- **Phase 1B — Decision-Grade Data:** active corrective work. Phase 1B.1 is complete; Phase 1B.2 is the next approved initiative.
+- **Phase 1B — Decision-Grade Data:** Phase 1B.1 is complete and the Phase 1B.2 pilot is implemented; product review must decide whether and how to migrate later batches.
 - **Phase 2 — Monetization:** gated / not started. It activates only when a real auditable affiliate/referral program exists and does not block Phase 3.
 - **Phase 3 — Discovery and SEO:** active, with the indexable-surface foundation complete. Further content/traffic expansion is paused until the Phase 1B.2 pilot proves that core comparisons provide meaningful decision value.
 - **Phase 4 — Recommendation:** later, gated behind explicit criteria and trustworthy signals.
@@ -53,7 +64,7 @@ Earlier completed initiatives, including Phase 1 Source Verification Batches A/B
 - 2 courses remain `pending` with explicit source blockers rather than unreviewed status.
 - Source URL mismatches: 0 after the completed verification batches.
 - Most pricing, ratings, and review counts remain unknown or unverified by design.
-- Some exact total duration values remain unknown even where the provider exposes useful workload schedules such as months/weeks plus hours per week. Phase 1B.2 exists specifically to preserve those useful signals without inventing exact totals.
+- The four Phase 1B.2 pilot records preserve provider-described workload schedules such as months plus hours per week while exact `durationHours` remains null unless the source explicitly states a total.
 - The current normalized `language` field represents the primary taught language when clearly supported by an official source. Additional dubbing/subtitle/language availability remains provenance context unless a later explicit schema initiative changes that model.
 - `report:data-quality` remains part of normal validation.
 - Official provider pages remain the final source for volatile enrollment terms, but Skills Compare should perform the basic comparison work rather than merely redirecting users to two provider pages.
@@ -73,33 +84,17 @@ Not implemented:
 
 These are intentional roadmap constraints, not missing requirements to fill opportunistically.
 
-## Next Approved Product Initiative
-
-### Phase 1B.2 — Decision Data Contract v2 + pilot — Issue #94
-
-Purpose: evolve the smallest structured data contract needed to preserve provider-backed signals that materially help a user choose, then validate that contract before migrating the rest of the catalog.
+## Phase 1B.2 Pilot Result
 
 Pilot scope is exactly four courses and two comparisons:
 
 1. AI For Everyone vs Deep Learning Specialization.
 2. Google Cybersecurity Professional Certificate vs IBM Cybersecurity Analyst Professional Certificate.
 
-The approved contract should support, where official sources actually expose the information:
+- AI For Everyone vs Deep Learning Specialization: **5/7 pass**. Source-backed for both: offering/credential type, workload, starting point, learning topics, and cost-model context. Insufficient for both: tools/technologies and practical work.
+- Google Cybersecurity vs IBM Cybersecurity Analyst: **5/7 pass**. Source-backed for both: offering/credential type, workload, learning topics, tools/technologies, and practical work. Insufficient for both: starting point and cost-model context.
 
-- offering/program type,
-- workload/time commitment without invented exact totals,
-- prerequisites/starting point,
-- learning topics,
-- tools/technologies,
-- practical work/projects/labs,
-- credential context,
-- known cost-model context.
-
-The internal decision-readiness gate is defined in issue #94. A pilot comparison should have source-backed useful information for both courses in at least 5 of 7 core decision dimensions. This is a product-quality gate, not a visible ranking or score.
-
-If the official sources cannot support the gate without inference, the implementation must report the blocker rather than weakening the standard or inventing data.
-
-Implementation must stay limited to the four pilot courses, use official provider pages for new facts, preserve provenance and verification semantics, use one dedicated branch and PR, run the full required validation sequence, and must not be merged by the coding agent.
+The gate is internal product-quality validation, not a visible ranking or course score.
 
 ## After Phase 1B.2
 

--- a/docs/MVP_READINESS.md
+++ b/docs/MVP_READINESS.md
@@ -4,9 +4,9 @@
 
 - Skills Compare is an English-first product for finding skills, reviewing relevant online courses, comparing two options, and opening the original provider page.
 - Phase 0 is complete for the current MVP scope.
-- Phase 1 is complete for the current 19-course curated MVP catalog and now continues as data-quality maintenance rather than a blocking execution phase.
+- Phase 1A source trust is complete for the current 19-course catalog; the Phase 1B.2 decision-data pilot is implemented on exactly four courses and awaits product review before any wider migration.
 - Phase 2 monetization is gated until a real auditable affiliate/referral program exists and does not block Phase 3.
-- Phase 3 Discovery and SEO is active.
+- Phase 3 Discovery and SEO has its indexable-surface foundation in place; content expansion remains paused pending review of the Phase 1B.2 pilot.
 - The normalized catalog contains 19 curated courses.
 - 17 courses are `partially_verified`; 2 remain `pending` because the exact recorded offering could not be confirmed from a current official source.
 - Source URL mismatches are 0 after Phase 1 Source Verification — Coverage Batch B.
@@ -17,6 +17,7 @@
 - A data quality report is available with `corepack pnpm report:data-quality` and includes verification-status counts, verified-field coverage, fully pending courses, partially verified courses, and unknown field counts.
 - Mobile Selection and Discovery UX is merged: compare selection persists for up to 24 hours, returning selections are surfaced, and the compare bar is available globally outside the compare page.
 - Decision-focused visual polish is merged across the core Search -> Compare -> Decide journey.
+- Decision Data Contract v2 preserves provider-backed offering, workload, tool, practical-work, credential, and cost-model signals for the four-course pilot.
 
 ## Trust and Data Quality Reality
 
@@ -29,6 +30,7 @@
 - `introduction-cyber-security-nyux-edx` remains pending because the recorded edX page is unavailable and no current official page clearly represents the exact same NYUx offering.
 - `data-analytics-essentials-cisco` remains pending because the recorded Coursera listing is unavailable and Cisco's current instructor-led offering does not establish that it is the same listing.
 - Unknown data must remain null, unknown, pending, or explicitly unverified.
+- Both approved pilot comparisons pass the internal 5/7 decision-readiness gate while retaining explicit insufficiencies; this gate is not a visible ranking or course score.
 - Users should verify final pricing, duration, certificate terms, enrollment details, and availability on the provider page before deciding.
 
 ## What Works
@@ -37,7 +39,7 @@
 - Skill pages show available courses from the normalized catalog.
 - Course cards expose core decision facts and prioritize compare selection over outbound provider clicks.
 - Course detail pages are decision-support pages with fit framing, verify-before-enrolling checks, provider CTA, compare action, learning content, and key facts.
-- Compare supports two-course comparison with deterministic decision summary, verification risks, fit context, deep comparison details, checklist, and outbound provider CTAs.
+- Compare supports two-course comparison with deterministic decision summary, verification risks, fit context, deep comparison details, checklist, and outbound provider CTAs. Pilot comparisons additionally expose the seven approved decision dimensions.
 - The compare page uses mobile-friendly stacked content instead of relying on a cramped desktop table.
 - Compare selection persists across navigation and recent visits for up to 24 hours, with an explicit returning-selection state and clear action.
 - Canonical and Open Graph metadata foundations are present for core pages.
@@ -54,16 +56,12 @@
 - No outcome, employment, partnership, or provider endorsement claims should be made.
 - No user accounts, cookies, database, scraping, external APIs, or new analytics vendors are implemented.
 
-## Phase 3 Foundation Reality
+## Decision Data Pilot Reality
 
-Repository review before the first Phase 3 batch found:
-
-- Canonical skill pages already generate page metadata and self-referencing canonical URLs.
-- Canonical course detail pages already generate page metadata and self-referencing canonical URLs.
-- The current sitemap includes the homepage, `/compare`, and every generated SEO page, but does not currently include the canonical skill/course decision surfaces.
-- The generated SEO system creates several intent variants per configured skill from shared course lists and mostly reusable template intros/FAQ copy.
-
-The first Phase 3 initiative therefore focuses on indexable-surface quality rather than generating more pages.
+- AI For Everyone vs Deep Learning Specialization passes 5/7 with tools and practical work explicitly insufficient for both sides.
+- Google Cybersecurity vs IBM Cybersecurity Analyst passes 5/7 with starting point and cost-model context explicitly insufficient for both sides.
+- The schema migration is limited to those four records. Product review must decide whether a later small-batch rollout is justified.
+- Exact volatile prices remain outside the decision-readiness requirement; provider pages remain the final source for enrollment terms.
 
 ## Validation Workflow
 
@@ -76,10 +74,6 @@ Run these before opening or updating a normal product PR:
 
 Use the documented repository-local TypeScript fallback only when the normal pnpm command fails solely because Windows cannot resolve the local `tsc` executable. Run `corepack pnpm generate:seo` only when SEO generation inputs actually change. Do not initialize ESLint configuration just to run lint; `next lint` may currently prompt for setup.
 
-## Active Near-Term Initiative
+## Active Near-Term Gate
 
-**Phase 3 Discovery/SEO — Indexable Surface Foundation (Batch A)** is approved in `docs/CURRENT_STATE.md`.
-
-The implementation should make the sitemap and indexing directives favor useful canonical skill/course decision pages, stop actively promoting the generic generated SEO variants for indexing, and avoid adding any new SEO page volume.
-
-After this batch, return to product review before strengthening or creating any additional skill/intent pages. Phase 2 monetization remains gated until a real program exists and is not a prerequisite for this work.
+Product review must evaluate the Phase 1B.2 pilot before approving any migration of the remaining 15 catalog records or resuming Phase 3 content expansion. Phase 2 monetization remains gated until a real program exists.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,7 +24,7 @@ Future work in this area should be limited to concrete usability defects or regr
 
 ## Phase 1 — Real Data
 
-**Status: Phase 1A source trust complete for the current curated MVP catalog; Phase 1B decision-grade data corrective work active.**
+**Status: Phase 1A source trust complete; Phase 1B.2 pilot implemented and awaiting product review.**
 
 Goal: make the catalog both trustworthy and useful enough to support real user decisions.
 
@@ -47,10 +47,7 @@ Product review showed that source-trusted data is not automatically decision-use
 Completed:
 
 - **Phase 1B.1 — Comparison Integrity Fix** in PR #93: unknown or unverified values no longer create confident `Same` / `Different` claims; runtime mapping now preserves nullable and verification semantics needed for trustworthy comparisons.
-
-Active approved initiative:
-
-- **Phase 1B.2 — Decision Data Contract v2 + pilot** in issue #94: evolve the smallest structured contract needed to preserve decision-useful provider signals, then validate it on exactly two pilot comparisons covering four courses.
+- **Phase 1B.2 — Decision Data Contract v2 pilot** in issue #94: the structured contract and four-course migration are implemented, both required comparisons pass the internal 5/7 gate, and unsupported dimensions remain explicitly insufficient.
 
 Do not migrate the remaining catalog until the pilot proves that the new contract materially improves decision quality without inventing information.
 
@@ -72,7 +69,7 @@ Do not implement speculative affiliate parameters, fake discounts, paid ranking,
 
 ## Phase 3 — Discovery and SEO
 
-**Status: active; indexable-surface foundation complete, content expansion paused pending the Phase 1B.2 pilot.**
+**Status: active; indexable-surface foundation complete, content expansion paused pending product review of the Phase 1B.2 pilot.**
 
 Goal: grow qualified organic traffic by making useful decision surfaces discoverable and by adding genuinely differentiated content only when the catalog supports it.
 
@@ -113,8 +110,8 @@ Do not build Phase 5 architecture to solve hypothetical scale.
 ## Immediate Sequence
 
 1. Maintain conservative Phase 1A source trust without reopening verification work for its own sake.
-2. Execute issue #94, Phase 1B.2 — Decision Data Contract v2 + pilot, on exactly the four approved pilot courses.
-3. Judge the pilot against the explicit decision-readiness gate before any catalog-wide migration.
+2. Review the completed Phase 1B.2 four-course pilot against the explicit decision-readiness and product acceptance criteria.
+3. Do not begin catalog-wide migration without a new product decision.
 4. Keep Phase 3 content/traffic expansion paused until the pilot shows that core comparison pages provide meaningful decision value.
 5. If the pilot succeeds, migrate the remaining catalog only in small auditable batches and then return to selective people-first SEO work.
 6. Activate Phase 2 monetization only when a real program and appropriate disclosures are ready; it is not a prerequisite for Phase 3.

--- a/scripts/report-data-quality.js
+++ b/scripts/report-data-quality.js
@@ -45,6 +45,31 @@ const getVerifiedFieldCoverage = (metadata) => {
   );
 };
 
+const pilotComparisons = [
+  ["ai-for-everyone-deeplearningai", "deep-learning-specialization-deeplearningai"],
+  ["google-cybersecurity-google", "ibm-cybersecurity-analyst-ibm"]
+];
+
+const decisionDimensions = [
+  ["offering / credential type", (course, verified) =>
+    verified.offeringType === true &&
+    verified.credential === true &&
+    course.offeringType != null &&
+    course.credential != null],
+  ["workload / time commitment", (course, verified) =>
+    verified.workload === true && course.workload != null],
+  ["prerequisites / starting point", (course, verified) =>
+    verified.prerequisites === true && course.prerequisitesBullets.length > 0],
+  ["learning topics", (course, verified) =>
+    verified.syllabus === true && course.syllabusBullets.length > 0],
+  ["tools / technologies", (course, verified) =>
+    verified.toolsTechnologies === true && course.toolsTechnologies?.length > 0],
+  ["practical work / projects / labs", (course, verified) =>
+    verified.practicalWork === true && course.practicalWorkBullets?.length > 0],
+  ["cost model context", (course, verified) =>
+    verified.costModel === true && course.costModel != null]
+];
+
 const coursesPath = resolve(process.cwd(), "data", "normalized", "courses.json");
 const metadataPath = resolve(
   process.cwd(),
@@ -131,6 +156,26 @@ try {
   console.log(`- source metadata records without matching course: ${metadataWithoutCourse.length}`);
   console.log(`- source URL mismatches: ${sourceUrlMismatches.length}`);
   console.log(`- duplicate metadata courseIds: ${duplicateMetadataIds.size}`);
+
+  console.log("\nDecision Data Contract v2 pilot gate");
+  pilotComparisons.forEach(([leftId, rightId]) => {
+    const left = coursesById.get(leftId);
+    const right = coursesById.get(rightId);
+    const leftVerified = metadataByCourseId.get(leftId)?.verifiedFields ?? {};
+    const rightVerified = metadataByCourseId.get(rightId)?.verifiedFields ?? {};
+    const sourceBackedForBoth = decisionDimensions
+      .filter(([, isReady]) =>
+        isReady(left, leftVerified) && isReady(right, rightVerified)
+      )
+      .map(([label]) => label);
+    const insufficient = decisionDimensions
+      .map(([label]) => label)
+      .filter((label) => !sourceBackedForBoth.includes(label));
+
+    console.log(`- ${leftId} vs ${rightId}: ${sourceBackedForBoth.length}/7 ${sourceBackedForBoth.length >= 5 ? "PASS" : "FAIL"}`);
+    console.log(`  - source-backed for both: ${sourceBackedForBoth.join(", ")}`);
+    console.log(`  - insufficient: ${insufficient.length > 0 ? insufficient.join(", ") : "none"}`);
+  });
 
   const structuralIssues = [
     ...missingSourceMetadata.map((course) => `Missing metadata: ${course.id}`),

--- a/scripts/report-data-quality.js
+++ b/scripts/report-data-quality.js
@@ -59,7 +59,10 @@ const decisionDimensions = [
   ["workload / time commitment", (course, verified) =>
     verified.workload === true && course.workload != null],
   ["prerequisites / starting point", (course, verified) =>
-    verified.prerequisites === true && course.prerequisitesBullets.length > 0],
+    verified.level === true &&
+    course.level !== "unknown" &&
+    verified.prerequisites === true &&
+    course.prerequisitesBullets.length > 0],
   ["learning topics", (course, verified) =>
     verified.syllabus === true && course.syllabusBullets.length > 0],
   ["tools / technologies", (course, verified) =>

--- a/scripts/validate-data.ts
+++ b/scripts/validate-data.ts
@@ -103,7 +103,10 @@ const getReadiness = (courseId: string) => {
       course.credential != null,
     workload: verified.workload === true && course.workload != null,
     startingPoint:
-      verified.prerequisites === true && course.prerequisitesBullets.length > 0,
+      verified.level === true &&
+      course.level !== "unknown" &&
+      verified.prerequisites === true &&
+      course.prerequisitesBullets.length > 0,
     learningTopics: verified.syllabus === true && course.syllabusBullets.length > 0,
     toolsTechnologies:
       verified.toolsTechnologies === true && course.toolsTechnologies.length > 0,

--- a/scripts/validate-data.ts
+++ b/scripts/validate-data.ts
@@ -4,6 +4,33 @@ import { resolve } from "node:path";
 import { CourseSchema } from "../src/lib/schema/course";
 
 const coursesPath = resolve(process.cwd(), "data", "normalized", "courses.json");
+const metadataPath = resolve(
+  process.cwd(),
+  "data",
+  "normalized",
+  "course-source-metadata.json"
+);
+
+const PILOT_COURSE_IDS = [
+  "ai-for-everyone-deeplearningai",
+  "deep-learning-specialization-deeplearningai",
+  "google-cybersecurity-google",
+  "ibm-cybersecurity-analyst-ibm"
+] as const;
+
+const PILOT_COMPARISONS = [
+  ["ai-for-everyone-deeplearningai", "deep-learning-specialization-deeplearningai"],
+  ["google-cybersecurity-google", "ibm-cybersecurity-analyst-ibm"]
+] as const;
+
+const decisionDataFields = [
+  "offeringType",
+  "workload",
+  "toolsTechnologies",
+  "practicalWorkBullets",
+  "credential",
+  "costModel"
+] as const;
 
 if (!existsSync(coursesPath)) {
   console.warn(
@@ -30,6 +57,81 @@ if (!result.success) {
   console.error("[validate:data] Course schema validation failed.");
   console.error(result.error.format());
   process.exit(1);
+}
+
+type SourceMetadata = {
+  courseId: string;
+  verifiedFields?: Record<string, boolean>;
+};
+
+const rawCourses = parsedData as Array<Record<string, unknown>>;
+const migratedCourseIds = rawCourses
+  .filter((course) => decisionDataFields.some((field) => Object.hasOwn(course, field)))
+  .map((course) => course.id)
+  .sort();
+const expectedPilotIds = [...PILOT_COURSE_IDS].sort();
+
+if (JSON.stringify(migratedCourseIds) !== JSON.stringify(expectedPilotIds)) {
+  console.error(
+    `[validate:data] Decision Data Contract v2 must be limited to the four pilot courses. Found: ${migratedCourseIds.join(", ")}`
+  );
+  process.exit(1);
+}
+
+if (!existsSync(metadataPath)) {
+  console.error("[validate:data] course-source-metadata.json is required for the pilot gate.");
+  process.exit(1);
+}
+
+const metadata = JSON.parse(readFileSync(metadataPath, "utf-8")) as SourceMetadata[];
+const metadataByCourseId = new Map(metadata.map((item) => [item.courseId, item]));
+const coursesById = new Map(result.data.map((course) => [course.id, course]));
+
+const getReadiness = (courseId: string) => {
+  const course = coursesById.get(courseId);
+  const verified = metadataByCourseId.get(courseId)?.verifiedFields ?? {};
+
+  if (!course) {
+    throw new Error(`Missing pilot course: ${courseId}`);
+  }
+
+  return {
+    offeringCredential:
+      verified.offeringType === true &&
+      verified.credential === true &&
+      course.offeringType != null &&
+      course.credential != null,
+    workload: verified.workload === true && course.workload != null,
+    startingPoint:
+      verified.prerequisites === true && course.prerequisitesBullets.length > 0,
+    learningTopics: verified.syllabus === true && course.syllabusBullets.length > 0,
+    toolsTechnologies:
+      verified.toolsTechnologies === true && course.toolsTechnologies.length > 0,
+    practicalWork:
+      verified.practicalWork === true && course.practicalWorkBullets.length > 0,
+    costModel: verified.costModel === true && course.costModel != null
+  };
+};
+
+for (const [leftId, rightId] of PILOT_COMPARISONS) {
+  const leftReadiness = getReadiness(leftId);
+  const rightReadiness = getReadiness(rightId);
+  const sourceBackedForBoth = Object.keys(leftReadiness).filter(
+    (key) =>
+      leftReadiness[key as keyof typeof leftReadiness] &&
+      rightReadiness[key as keyof typeof rightReadiness]
+  );
+
+  if (sourceBackedForBoth.length < 5) {
+    console.error(
+      `[validate:data] Pilot decision-readiness gate failed for ${leftId} vs ${rightId}: ${sourceBackedForBoth.length}/7.`
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `[validate:data] Pilot gate passed for ${leftId} vs ${rightId}: ${sourceBackedForBoth.length}/7.`
+  );
 }
 
 console.log(

--- a/src/lib/catalog-adapter.ts
+++ b/src/lib/catalog-adapter.ts
@@ -52,7 +52,14 @@ const sourceMetadataByCourseId = new Map(
   (sourceMetadata as SourceMetadata[]).map((metadata) => [metadata.courseId, metadata])
 );
 
-const formatDurationText = (durationHours: number | null): string => {
+const formatDurationText = (
+  durationHours: number | null,
+  workload: NormalizedCourse["workload"]
+): string => {
+  if (workload) {
+    return workload.text;
+  }
+
   if (durationHours == null) {
     return "Duration pending verification";
   }
@@ -95,7 +102,7 @@ const mapCourse = (course: NormalizedCourse): Course | null => {
     priceInterval: course.priceInterval,
     priceText: formatPriceText(course),
     durationHours: course.durationHours,
-    durationText: formatDurationText(course.durationHours),
+    durationText: formatDurationText(course.durationHours, course.workload),
     rating: course.rating,
     reviewCount: course.reviewCount,
     language: course.language,
@@ -103,6 +110,12 @@ const mapCourse = (course: NormalizedCourse): Course | null => {
     shortDescription: course.shortDescription,
     syllabusBullets: course.syllabusBullets,
     prerequisitesBullets: course.prerequisitesBullets,
+    offeringType: course.offeringType,
+    workload: course.workload,
+    toolsTechnologies: course.toolsTechnologies,
+    practicalWorkBullets: course.practicalWorkBullets,
+    credential: course.credential,
+    costModel: course.costModel,
     externalUrl: course.url,
     verifiedFields: sourceMetadataByCourseId.get(course.id)?.verifiedFields ?? {}
   };

--- a/src/lib/decision-support.ts
+++ b/src/lib/decision-support.ts
@@ -86,7 +86,10 @@ export const getDecisionReadiness = (course: Course): Record<CoreDecisionDimensi
     course.credential != null,
   workload: !isDurationPending(course),
   startingPoint:
-    isFieldVerified(course, "prerequisites") && course.prerequisitesBullets.length > 0,
+    isFieldVerified(course, "level") &&
+    course.level !== "Unknown" &&
+    isFieldVerified(course, "prerequisites") &&
+    course.prerequisitesBullets.length > 0,
   learningTopics: isFieldVerified(course, "syllabus") && course.syllabusBullets.length > 0,
   toolsTechnologies:
     isFieldVerified(course, "toolsTechnologies") &&
@@ -262,7 +265,7 @@ type RawComparisonRow = Omit<ComparisonRow, "status" | "interpretation"> & {
 };
 
 export const buildComparisonRows = (left: Course, right: Course): ComparisonRow[] => {
-  const hasDecisionDataV2 = [left, right].some(
+  const bothHaveDecisionDataV2 = [left, right].every(
     (course) =>
       course.offeringType != null ||
       course.workload != null ||
@@ -272,7 +275,7 @@ export const buildComparisonRows = (left: Course, right: Course): ComparisonRow[
       (course.practicalWorkBullets?.length ?? 0) > 0
   );
 
-  const rows: RawComparisonRow[] = hasDecisionDataV2
+  const rows: RawComparisonRow[] = bothHaveDecisionDataV2
     ? [
         {
           label: "Offering / credential",
@@ -283,7 +286,9 @@ export const buildComparisonRows = (left: Course, right: Course): ComparisonRow[
             getDecisionReadiness(right).offeringCredential,
           equal:
             left.offeringType === right.offeringType &&
-            left.credential?.type === right.credential?.type,
+            left.credential?.type === right.credential?.type &&
+            normalize(left.credential?.text ?? "") ===
+              normalize(right.credential?.text ?? ""),
           sameInterpretation: "The verified offering and credential formats are equivalent.",
           differentInterpretation: "You are choosing different program or credential formats.",
           uncertainInterpretation: "Offering or credential context is not verified for both options."
@@ -337,7 +342,7 @@ export const buildComparisonRows = (left: Course, right: Course): ComparisonRow[
           ),
           sameInterpretation: "Verified named tools substantially overlap.",
           differentInterpretation: "The verified tool exposure differs between these options.",
-          uncertainInterpretation: "Named tools are not explicitly supported for both options."
+          uncertainInterpretation: "Named tools are not verified for both options."
         },
         {
           label: "Practical work",
@@ -352,7 +357,7 @@ export const buildComparisonRows = (left: Course, right: Course): ComparisonRow[
           ),
           sameInterpretation: "Verified practical work substantially overlaps.",
           differentInterpretation: "The explicitly stated projects, labs, or applied work differ.",
-          uncertainInterpretation: "Practical work is not explicitly supported for both options."
+          uncertainInterpretation: "Practical work is not verified for both options."
         },
         {
           label: "Cost model",
@@ -417,6 +422,34 @@ export const buildComparisonRows = (left: Course, right: Course): ComparisonRow[
           sameInterpretation: "Verified prerequisites do not differentiate these options.",
           differentInterpretation: "Check which verified prerequisites fit your starting point.",
           uncertainInterpretation: "Prerequisites are not verified for both courses."
+        },
+        {
+          label: "Level",
+          left: left.level,
+          right: right.level,
+          comparable:
+            isFieldVerified(left, "level") &&
+            isFieldVerified(right, "level") &&
+            left.level !== "Unknown" &&
+            right.level !== "Unknown",
+          equal: left.level === right.level,
+          sameInterpretation: "Both courses target the same learner level.",
+          differentInterpretation: "Choose the verified level that matches your background.",
+          uncertainInterpretation: "Learner level is not verified for both courses."
+        },
+        {
+          label: "Certificate",
+          left: formatCertificate(left),
+          right: formatCertificate(right),
+          comparable:
+            isFieldVerified(left, "certificate") &&
+            isFieldVerified(right, "certificate") &&
+            left.certificate != null &&
+            right.certificate != null,
+          equal: left.certificate === right.certificate,
+          sameInterpretation: "Verified certificate availability is the same, but terms may change.",
+          differentInterpretation: "Verified certificate availability differs; check provider terms.",
+          uncertainInterpretation: "Certificate availability is not verified for both courses."
         }
       ];
 

--- a/src/lib/decision-support.ts
+++ b/src/lib/decision-support.ts
@@ -10,6 +10,18 @@ export type ComparisonRow = {
   interpretation: string;
 };
 
+export const CORE_DECISION_DIMENSIONS = [
+  { key: "offeringCredential", label: "Offering / credential type" },
+  { key: "workload", label: "Workload / time commitment" },
+  { key: "startingPoint", label: "Prerequisites / starting point" },
+  { key: "learningTopics", label: "Learning topics" },
+  { key: "toolsTechnologies", label: "Tools / technologies" },
+  { key: "practicalWork", label: "Practical work / projects / labs" },
+  { key: "costModel", label: "Cost model context" }
+] as const;
+
+export type CoreDecisionDimension = (typeof CORE_DECISION_DIMENSIONS)[number]["key"];
+
 const normalize = (value: string) => value.trim().toLowerCase();
 
 type VerifiedField = keyof NonNullable<Course["verifiedFields"]>;
@@ -18,7 +30,13 @@ const isFieldVerified = (course: Course, field: VerifiedField) =>
   course.verifiedFields?.[field] === true;
 
 export const isDurationPending = (course: Course) =>
-  !isFieldVerified(course, "duration") || course.durationHours == null;
+  !(
+    (isFieldVerified(course, "workload") && course.workload != null) ||
+    (isFieldVerified(course, "duration") && course.durationHours != null)
+  );
+
+export const isCostModelPending = (course: Course) =>
+  !isFieldVerified(course, "costModel") || course.costModel == null;
 
 export const isExactPricePending = (course: Course) =>
   !isFieldVerified(course, "price") ||
@@ -38,20 +56,79 @@ export const formatCertificate = (course: Course) =>
 export const summarizeBullets = (items: string[], fallback: string) =>
   items.length > 0 ? items.slice(0, 3).join("; ") : fallback;
 
+const formatOfferingType = (course: Course) => {
+  const labels = {
+    course: "Course",
+    specialization: "Specialization",
+    professional_certificate: "Professional Certificate",
+    other: "Other provider-described format"
+  } as const;
+
+  return course.offeringType ? labels[course.offeringType] : "Offering type not verified";
+};
+
+const formatOfferingCredential = (course: Course) =>
+  course.credential
+    ? `${formatOfferingType(course)} · ${course.credential.text}`
+    : `${formatOfferingType(course)} · Credential context not verified`;
+
+const formatStartingPoint = (course: Course) =>
+  `${course.level} level · ${summarizeBullets(
+    course.prerequisitesBullets,
+    "Starting point not verified"
+  )}`;
+
+export const getDecisionReadiness = (course: Course): Record<CoreDecisionDimension, boolean> => ({
+  offeringCredential:
+    isFieldVerified(course, "offeringType") &&
+    isFieldVerified(course, "credential") &&
+    course.offeringType != null &&
+    course.credential != null,
+  workload: !isDurationPending(course),
+  startingPoint:
+    isFieldVerified(course, "prerequisites") && course.prerequisitesBullets.length > 0,
+  learningTopics: isFieldVerified(course, "syllabus") && course.syllabusBullets.length > 0,
+  toolsTechnologies:
+    isFieldVerified(course, "toolsTechnologies") &&
+    (course.toolsTechnologies?.length ?? 0) > 0,
+  practicalWork:
+    isFieldVerified(course, "practicalWork") &&
+    (course.practicalWorkBullets?.length ?? 0) > 0,
+  costModel: !isCostModelPending(course)
+});
+
+export const getPairDecisionReadiness = (left: Course, right: Course) => {
+  const leftReadiness = getDecisionReadiness(left);
+  const rightReadiness = getDecisionReadiness(right);
+  const sourceBackedForBoth = CORE_DECISION_DIMENSIONS.filter(
+    ({ key }) => leftReadiness[key] && rightReadiness[key]
+  );
+
+  return {
+    sourceBackedForBoth,
+    insufficient: CORE_DECISION_DIMENSIONS.filter(
+      ({ key }) => !(leftReadiness[key] && rightReadiness[key])
+    ),
+    passes: sourceBackedForBoth.length >= 5
+  };
+};
+
 export const getCourseFitBullets = (course: Course) => {
   const bullets = [
     course.level === "Unknown"
       ? "You are comfortable verifying the intended learner level."
       : `You want a ${course.level}-level course.`,
-    course.certificate === true
-      ? "You want certificate availability to be visible before opening the provider page."
+    course.credential && isFieldVerified(course, "credential")
+      ? `You want this credential context: ${course.credential.text}.`
+      : course.certificate === true
+        ? "You want certificate availability to be visible before opening the provider page."
       : "You are comfortable verifying certificate availability on the provider page.",
     isDurationPending(course)
       ? "You are comfortable verifying duration and workload before committing."
-      : "You can assess time commitment because duration is available in the catalog.",
-    isExactPricePending(course)
+      : `You can assess the provider-described workload: ${course.durationText}.`,
+    isCostModelPending(course)
       ? "You are comfortable confirming final price or subscription terms on the provider page."
-      : `You can evaluate the listed price model: ${course.priceText}.`,
+      : `You can evaluate the verified cost model: ${course.costModel?.text}.`,
     course.prerequisitesBullets.length > 0
       ? `The listed prerequisites fit your background: ${summarizeBullets(course.prerequisitesBullets, "prerequisites available")}.`
       : "You can verify prerequisites directly on the provider page."
@@ -73,16 +150,18 @@ export const getCourseDecisionSummary = (course: Course) => {
       ? "Level is pending verification."
       : `Level: ${course.level}.`,
     `Language: ${course.language}.`,
-    formatCertificate(course),
+    course.credential && isFieldVerified(course, "credential")
+      ? `Credential: ${course.credential.text}.`
+      : formatCertificate(course),
     isDurationPending(course)
-      ? "Duration is pending verification."
-      : `Catalog duration: ${course.durationText}.`
+      ? "Workload is pending verification."
+      : `Provider-described workload: ${course.durationText}.`
   ];
 
   const pending = [
     course.rating == null ? "Rating/review count is not available in Skills Compare." : null,
     isExactPricePending(course) ? "Exact price or subscription terms must be verified on the provider page." : null,
-    isDurationPending(course) ? "Duration/workload must be checked before committing time." : null,
+    isDurationPending(course) ? "Workload must be checked before committing time." : null,
     course.prerequisitesBullets.length === 0 ? "Prerequisites should be verified on the provider page." : null,
     course.syllabusBullets.length === 0 ? "Current syllabus should be verified on the provider page." : null
   ].filter((item): item is string => item !== null);
@@ -101,7 +180,7 @@ export const getPendingDataImpact = (course: Course) => {
       ? "Exact price pending: confirm total cost, trial terms, and subscription renewal before enrolling."
       : null,
     isDurationPending(course)
-      ? "Duration pending: check weekly workload and total time commitment on the provider page."
+      ? "Workload pending: check weekly workload and total time commitment on the provider page."
       : null,
     course.certificate == null || !isFieldVerified(course, "certificate")
       ? "Certificate status pending: verify whether a certificate is available and under what terms."
@@ -113,13 +192,8 @@ export const getPendingDataImpact = (course: Course) => {
     : ["No major pending catalog fields are currently flagged, but provider details may still change."];
 };
 
-export const getDecisionSummary = (
-  left: Course,
-  right: Course,
-  leftPrice: string,
-  rightPrice: string
-) => {
-  const rows = buildComparisonRows(left, right, leftPrice, rightPrice);
+export const getDecisionSummary = (left: Course, right: Course) => {
+  const rows = buildComparisonRows(left, right);
   const similarities = rows
     .filter((row) => row.status === "Same")
     .slice(0, 3)
@@ -179,27 +253,174 @@ const formatSocialProof = (course: Course) => {
   return parts.length > 0 ? parts.join(" · ") : "Not available";
 };
 
-export const buildComparisonRows = (
-  left: Course,
-  right: Course,
-  leftPrice: string,
-  rightPrice: string
-): ComparisonRow[] => {
-  const rows = [
-    {
-      label: "Price",
-      left: leftPrice,
-      right: rightPrice,
-      comparable: !isExactPricePending(left) && !isExactPricePending(right),
-      equal:
-        left.priceModel === right.priceModel &&
-        left.priceAmount === right.priceAmount &&
-        left.currency === right.currency &&
-        left.priceInterval === right.priceInterval,
-      sameInterpretation: "Verified price data does not differentiate these options.",
-      differentInterpretation: "Verified cost structure differs and may affect fit.",
-      uncertainInterpretation: "Exact comparable pricing is unavailable; verify provider terms."
-    },
+type RawComparisonRow = Omit<ComparisonRow, "status" | "interpretation"> & {
+  comparable: boolean;
+  equal: boolean;
+  sameInterpretation: string;
+  differentInterpretation: string;
+  uncertainInterpretation: string;
+};
+
+export const buildComparisonRows = (left: Course, right: Course): ComparisonRow[] => {
+  const hasDecisionDataV2 = [left, right].some(
+    (course) =>
+      course.offeringType != null ||
+      course.workload != null ||
+      course.credential != null ||
+      course.costModel != null ||
+      (course.toolsTechnologies?.length ?? 0) > 0 ||
+      (course.practicalWorkBullets?.length ?? 0) > 0
+  );
+
+  const rows: RawComparisonRow[] = hasDecisionDataV2
+    ? [
+        {
+          label: "Offering / credential",
+          left: formatOfferingCredential(left),
+          right: formatOfferingCredential(right),
+          comparable:
+            getDecisionReadiness(left).offeringCredential &&
+            getDecisionReadiness(right).offeringCredential,
+          equal:
+            left.offeringType === right.offeringType &&
+            left.credential?.type === right.credential?.type,
+          sameInterpretation: "The verified offering and credential formats are equivalent.",
+          differentInterpretation: "You are choosing different program or credential formats.",
+          uncertainInterpretation: "Offering or credential context is not verified for both options."
+        },
+        {
+          label: "Workload",
+          left: left.durationText,
+          right: right.durationText,
+          comparable: !isDurationPending(left) && !isDurationPending(right),
+          equal: normalize(left.durationText) === normalize(right.durationText),
+          sameInterpretation: "Provider-described workload does not differentiate these options.",
+          differentInterpretation: "Provider-described pace or time commitment differs.",
+          uncertainInterpretation: "Comparable provider-described workload is unavailable."
+        },
+        {
+          label: "Starting point",
+          left: formatStartingPoint(left),
+          right: formatStartingPoint(right),
+          comparable:
+            getDecisionReadiness(left).startingPoint &&
+            getDecisionReadiness(right).startingPoint,
+          equal:
+            left.level === right.level &&
+            equalStringArrays(left.prerequisitesBullets, right.prerequisitesBullets),
+          sameInterpretation: "Verified starting-point requirements substantially match.",
+          differentInterpretation: "Choose the verified starting point that matches your background.",
+          uncertainInterpretation: "Prerequisites or no-experience guidance is not verified for both options."
+        },
+        {
+          label: "Learning topics",
+          left: summarizeBullets(left.syllabusBullets, "Learning topics not available"),
+          right: summarizeBullets(right.syllabusBullets, "Learning topics not available"),
+          comparable:
+            getDecisionReadiness(left).learningTopics &&
+            getDecisionReadiness(right).learningTopics,
+          equal: equalStringArrays(left.syllabusBullets, right.syllabusBullets),
+          sameInterpretation: "Verified learning topics substantially overlap in the catalog.",
+          differentInterpretation: "Compare which verified topics match what you want to learn.",
+          uncertainInterpretation: "Learning topics are not verified for both options."
+        },
+        {
+          label: "Tools / technologies",
+          left: summarizeBullets(left.toolsTechnologies ?? [], "Tools not verified"),
+          right: summarizeBullets(right.toolsTechnologies ?? [], "Tools not verified"),
+          comparable:
+            getDecisionReadiness(left).toolsTechnologies &&
+            getDecisionReadiness(right).toolsTechnologies,
+          equal: equalStringArrays(
+            left.toolsTechnologies ?? [],
+            right.toolsTechnologies ?? []
+          ),
+          sameInterpretation: "Verified named tools substantially overlap.",
+          differentInterpretation: "The verified tool exposure differs between these options.",
+          uncertainInterpretation: "Named tools are not explicitly supported for both options."
+        },
+        {
+          label: "Practical work",
+          left: summarizeBullets(left.practicalWorkBullets ?? [], "Practical work not verified"),
+          right: summarizeBullets(right.practicalWorkBullets ?? [], "Practical work not verified"),
+          comparable:
+            getDecisionReadiness(left).practicalWork &&
+            getDecisionReadiness(right).practicalWork,
+          equal: equalStringArrays(
+            left.practicalWorkBullets ?? [],
+            right.practicalWorkBullets ?? []
+          ),
+          sameInterpretation: "Verified practical work substantially overlaps.",
+          differentInterpretation: "The explicitly stated projects, labs, or applied work differ.",
+          uncertainInterpretation: "Practical work is not explicitly supported for both options."
+        },
+        {
+          label: "Cost model",
+          left: left.costModel?.text ?? "Cost model not verified",
+          right: right.costModel?.text ?? "Cost model not verified",
+          comparable: !isCostModelPending(left) && !isCostModelPending(right),
+          equal: left.costModel?.type === right.costModel?.type,
+          sameInterpretation: "The verified cost model is the same; exact current prices may still vary.",
+          differentInterpretation: "The verified payment or access terms differ.",
+          uncertainInterpretation: "Cost-model context is not verified for both options."
+        }
+      ]
+    : [
+        {
+          label: "Price",
+          left: left.priceText,
+          right: right.priceText,
+          comparable: !isExactPricePending(left) && !isExactPricePending(right),
+          equal:
+            left.priceModel === right.priceModel &&
+            left.priceAmount === right.priceAmount &&
+            left.currency === right.currency &&
+            left.priceInterval === right.priceInterval,
+          sameInterpretation: "Verified price data does not differentiate these options.",
+          differentInterpretation: "Verified cost structure differs and may affect fit.",
+          uncertainInterpretation: "Exact comparable pricing is unavailable; verify provider terms."
+        },
+        {
+          label: "Duration",
+          left: left.durationText,
+          right: right.durationText,
+          comparable: !isDurationPending(left) && !isDurationPending(right),
+          equal: left.durationHours === right.durationHours,
+          sameInterpretation: "Verified total duration does not differentiate these options.",
+          differentInterpretation: "Verified time commitment differs and may affect fit.",
+          uncertainInterpretation: "Comparable total duration is unavailable; verify workload."
+        },
+        {
+          label: "Learning topics",
+          left: summarizeBullets(left.syllabusBullets, "Learning topics not available"),
+          right: summarizeBullets(right.syllabusBullets, "Learning topics not available"),
+          comparable:
+            isFieldVerified(left, "syllabus") &&
+            isFieldVerified(right, "syllabus") &&
+            left.syllabusBullets.length > 0 &&
+            right.syllabusBullets.length > 0,
+          equal: equalStringArrays(left.syllabusBullets, right.syllabusBullets),
+          sameInterpretation: "Verified learning topics substantially overlap in the catalog.",
+          differentInterpretation: "Compare which verified topics match what you want to learn.",
+          uncertainInterpretation: "Learning topics are not verified for both courses."
+        },
+        {
+          label: "Prerequisites",
+          left: summarizeBullets(left.prerequisitesBullets, "Prerequisites not available"),
+          right: summarizeBullets(right.prerequisitesBullets, "Prerequisites not available"),
+          comparable:
+            isFieldVerified(left, "prerequisites") &&
+            isFieldVerified(right, "prerequisites") &&
+            left.prerequisitesBullets.length > 0 &&
+            right.prerequisitesBullets.length > 0,
+          equal: equalStringArrays(left.prerequisitesBullets, right.prerequisitesBullets),
+          sameInterpretation: "Verified prerequisites do not differentiate these options.",
+          differentInterpretation: "Check which verified prerequisites fit your starting point.",
+          uncertainInterpretation: "Prerequisites are not verified for both courses."
+        }
+      ];
+
+  rows.push(
     {
       label: "Platform",
       left: left.platform,
@@ -209,30 +430,6 @@ export const buildComparisonRows = (
       sameInterpretation: "Both courses are delivered on the same platform experience.",
       differentInterpretation: "Platform preference, account access, and certificate handling may differ.",
       uncertainInterpretation: "Platform information is not verified for both courses."
-    },
-    {
-      label: "Duration",
-      left: left.durationText,
-      right: right.durationText,
-      comparable: !isDurationPending(left) && !isDurationPending(right),
-      equal: left.durationHours === right.durationHours,
-      sameInterpretation: "Verified total duration does not differentiate these options.",
-      differentInterpretation: "Verified time commitment differs and may affect fit.",
-      uncertainInterpretation: "Comparable total duration is unavailable; verify workload."
-    },
-    {
-      label: "Level",
-      left: left.level,
-      right: right.level,
-      comparable:
-        isFieldVerified(left, "level") &&
-        isFieldVerified(right, "level") &&
-        left.level !== "Unknown" &&
-        right.level !== "Unknown",
-      equal: left.level === right.level,
-      sameInterpretation: "Both courses target the same learner level.",
-      differentInterpretation: "Choose the verified level that matches your background.",
-      uncertainInterpretation: "Learner level is not verified for both courses."
     },
     {
       label: "Language",
@@ -247,50 +444,8 @@ export const buildComparisonRows = (
       sameInterpretation: "Language does not differentiate these options.",
       differentInterpretation: "Language may affect accessibility and completion.",
       uncertainInterpretation: "Primary taught language is not verified for both courses."
-    },
-    {
-      label: "Certificate",
-      left: formatCertificate(left),
-      right: formatCertificate(right),
-      comparable:
-        isFieldVerified(left, "certificate") &&
-        isFieldVerified(right, "certificate") &&
-        left.certificate != null &&
-        right.certificate != null,
-      equal: left.certificate === right.certificate,
-      sameInterpretation: "Verified certificate availability is the same, but terms may change.",
-      differentInterpretation: "Verified certificate availability differs; check provider terms.",
-      uncertainInterpretation: "Certificate availability is not verified for both courses."
-    },
-    {
-      label: "Learning topics",
-      left: summarizeBullets(left.syllabusBullets, "Learning topics not available"),
-      right: summarizeBullets(right.syllabusBullets, "Learning topics not available"),
-      comparable:
-        isFieldVerified(left, "syllabus") &&
-        isFieldVerified(right, "syllabus") &&
-        left.syllabusBullets.length > 0 &&
-        right.syllabusBullets.length > 0,
-      equal: equalStringArrays(left.syllabusBullets, right.syllabusBullets),
-      sameInterpretation: "Verified learning topics substantially overlap in the catalog.",
-      differentInterpretation: "Compare which verified topics match what you want to learn.",
-      uncertainInterpretation: "Learning topics are not verified for both courses."
-    },
-    {
-      label: "Prerequisites",
-      left: summarizeBullets(left.prerequisitesBullets, "Prerequisites not available"),
-      right: summarizeBullets(right.prerequisitesBullets, "Prerequisites not available"),
-      comparable:
-        isFieldVerified(left, "prerequisites") &&
-        isFieldVerified(right, "prerequisites") &&
-        left.prerequisitesBullets.length > 0 &&
-        right.prerequisitesBullets.length > 0,
-      equal: equalStringArrays(left.prerequisitesBullets, right.prerequisitesBullets),
-      sameInterpretation: "Verified prerequisites do not differentiate these options.",
-      differentInterpretation: "Check which verified prerequisites fit your starting point.",
-      uncertainInterpretation: "Prerequisites are not verified for both courses."
     }
-  ];
+  );
 
   const hasSocialProof = [left.rating, left.reviewCount, right.rating, right.reviewCount].some(
     (value) => value != null
@@ -306,7 +461,7 @@ export const buildComparisonRows = (
       (left.reviewCount == null ||
         (isFieldVerified(left, "reviewCount") && isFieldVerified(right, "reviewCount")));
 
-    rows.splice(6, 0, {
+    rows.push({
       label: "Rating / reviews",
       left: formatSocialProof(left),
       right: formatSocialProof(right),
@@ -337,10 +492,10 @@ export const buildComparisonRows = (
 export const getPendingDataRisks = (items: Course[]) => {
   const risks = [
     items.some(isExactPricePending)
-      ? "Price: exact cost or subscription terms are not verified for one or both courses."
+      ? "Exact price: current amount or subscription terms are not verified for one or both courses."
       : null,
     items.some(isDurationPending)
-      ? "Duration: comparable total duration is unavailable for one or both courses."
+      ? "Workload: provider-described time commitment is unavailable for one or both courses."
       : null,
     items.some(
       (course) =>

--- a/src/lib/schema/course.ts
+++ b/src/lib/schema/course.ts
@@ -1,5 +1,27 @@
 import { z } from "zod";
 
+const WorkloadSchema = z.object({
+  durationQuantity: z.number().positive().nullable(),
+  durationUnit: z.enum(["hour", "day", "week", "month"]).nullable(),
+  hoursPerWeek: z.number().positive().nullable(),
+  text: z.string().min(1)
+});
+
+const CredentialSchema = z.object({
+  type: z.enum([
+    "course_certificate",
+    "specialization_certificate",
+    "professional_certificate",
+    "other"
+  ]),
+  text: z.string().min(1)
+});
+
+const CostModelSchema = z.object({
+  type: z.enum(["free", "one_time", "subscription", "paid_certificate", "other"]),
+  text: z.string().min(1)
+});
+
 export const CourseSchema = z.object({
   id: z.string(),
   platform: z.string(),
@@ -20,6 +42,15 @@ export const CourseSchema = z.object({
   shortDescription: z.string().nullable(),
   syllabusBullets: z.array(z.string()).default([]),
   prerequisitesBullets: z.array(z.string()).default([]),
+  offeringType: z
+    .enum(["course", "specialization", "professional_certificate", "other"])
+    .nullable()
+    .default(null),
+  workload: WorkloadSchema.nullable().default(null),
+  toolsTechnologies: z.array(z.string()).default([]),
+  practicalWorkBullets: z.array(z.string()).default([]),
+  credential: CredentialSchema.nullable().default(null),
+  costModel: CostModelSchema.nullable().default(null),
   source: z.enum(["manual", "edx", "coursera", "coursera-curated", "other"]),
 });
 

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -18,6 +18,27 @@ export type Course = {
   shortDescription: string | null;
   syllabusBullets: string[];
   prerequisitesBullets: string[];
+  offeringType?: "course" | "specialization" | "professional_certificate" | "other" | null;
+  workload?: {
+    durationQuantity: number | null;
+    durationUnit: "hour" | "day" | "week" | "month" | null;
+    hoursPerWeek: number | null;
+    text: string;
+  } | null;
+  toolsTechnologies?: string[];
+  practicalWorkBullets?: string[];
+  credential?: {
+    type:
+      | "course_certificate"
+      | "specialization_certificate"
+      | "professional_certificate"
+      | "other";
+    text: string;
+  } | null;
+  costModel?: {
+    type: "free" | "one_time" | "subscription" | "paid_certificate" | "other";
+    text: string;
+  } | null;
   externalUrl: string;
   verifiedFields?: Partial<
     Record<
@@ -30,7 +51,13 @@ export type Course = {
       | "language"
       | "level"
       | "syllabus"
-      | "prerequisites",
+      | "prerequisites"
+      | "offeringType"
+      | "workload"
+      | "toolsTechnologies"
+      | "practicalWork"
+      | "credential"
+      | "costModel",
       boolean
     >
   >;


### PR DESCRIPTION
## Summary

Implements #94 exactly within the approved four-course pilot.

- adds a narrow structured Decision Data Contract v2 for offering type, provider-described workload, tools/technologies, practical work, credential context, and cost-model context
- migrates exactly these four courses:
  - `ai-for-everyone-deeplearningai`
  - `deep-learning-specialization-deeplearningai`
  - `google-cybersecurity-google`
  - `ibm-cybersecurity-analyst-ibm`
- preserves source provenance and per-field verification semantics
- updates comparison rows and course evidence cards to expose the seven approved dimensions without rankings, recommendations, synthetic scores, or inferred totals
- adds an executable internal 5/7 gate to data validation and an auditable pilot section to the data-quality report
- updates durable current-state/readiness/roadmap documentation
- adds no dependencies, monetization, analytics, generated SEO routes, or catalog-wide migration

## Source and uncertainty decisions

All new facts were reviewed against the current official Coursera provider pages on 2026-08-18.

- AI For Everyone: tools/technologies and practical work remain empty/unverified because the source does not explicitly support those dimensions.
- IBM Cybersecurity Analyst: unsupported prerequisite bullets were removed; prerequisite/starting-point and cost-model context remain unverified.
- Exact total hours were not calculated from month/week schedules.
- Exact prices, ratings, and review counts remain unknown/unverified where volatile.

## Decision-readiness acceptance

### AI For Everyone vs Deep Learning Specialization — 5/7 PASS

Source-backed for both:
- offering / credential type
- workload / time commitment
- prerequisites / starting point
- learning topics
- cost model context

Insufficient:
- tools / technologies
- practical work / projects / labs

Visible decision differences now include a single course vs five-course specialization, 7 hours vs 3 months at 10 hours/week, beginner/non-technical vs intermediate Python/math/ML starting point, conceptual/organizational AI vs technical deep-learning topics, and paid certificate experience vs active subscription access for labs/assignments.

### Google Cybersecurity vs IBM Cybersecurity Analyst — 5/7 PASS

Source-backed for both:
- offering / credential type
- workload / time commitment
- learning topics
- tools / technologies
- practical work / projects / labs

Insufficient:
- prerequisites / starting point
- cost model context

Visible decision differences now include 6 months at 7 hours/week vs 4 months at 10 hours/week, Google’s Linux/Python/Bash/SQL/SIEM/IDS exposure vs IBM’s ITIL/OWASP ZAP/Snyk exposure, and Google’s simulated labs/portfolio activities vs IBM’s security-tool labs, incident-response/forensics case studies, and plan/framework projects.

## Manual product acceptance

Inspected both required comparisons at 1440×1000 desktop and 390×844 mobile.

- no Next.js error overlay or browser console errors
- all seven core decision rows render
- long titles and evidence copy wrap correctly
- mobile criteria use readable stacked cards
- no horizontal overflow
- home-route navigation check passes

## Product-review amendment

Commit `10f24c4` addresses all four blockers from the current product review.

- Decision Data v2 rows now require both selected courses to be migrated; mixed pairs retain the complete legacy comparison, including verified Level and Certificate rows.
- Starting-point readiness now requires both a verified, non-unknown learner level and verified prerequisite guidance in the UI, validation gate, and quality report.
- Offering/credential equality now includes verified credential context text; Google vs IBM correctly reports `Different` because IBM includes a digital badge.
- Empty tools and practical-work states now use neutral “not verified in the current catalog” language, including uncertainty interpretations.

Manual mixed-pair regression: AI For Everyone vs IBM AI Engineering passed at 1440×1000 and 390×844. Price, Duration, Learning topics, Prerequisites, Level, Certificate, Platform, and Language remained visible; v2-only rows were absent; there was no horizontal overflow, framework overlay, or browser console error.

## Validation

- `corepack pnpm validate:data` — pass; both pilot pairs 5/7
- `corepack pnpm report:data-quality` — pass; zero source metadata mismatches, missing/orphaned metadata, or duplicate IDs
- `node node_modules/typescript/bin/tsc --noEmit` — pass; used the documented repository-local fallback because the Windows pnpm launcher could not resolve `tsc`
- `corepack pnpm build` — pass
- `generate:seo` not run because no SEO generation inputs changed

Changed files: 12

Closes #94