### PR TITLE
Phase 1B.3 — Pricing as Core Decision Data

### DIFF
--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -6,6 +6,8 @@ import { useMemo } from "react";
 import { AdPlaceholder } from "@/components/AdPlaceholder";
 import {
   buildComparisonRows,
+  formatPricingOption,
+  getActionablePricingOptions,
   getCourseFitBullets,
   getDecisionSummary,
   getPendingDataRisks,
@@ -16,8 +18,7 @@ import { courses } from "@/lib/catalog-adapter";
 import { trackOutboundCourseClick } from "@/lib/outbound-tracking";
 import {
   EXTERNAL_PROVIDER_CONTEXT,
-  PROVIDER_CTA_LABEL,
-  PROVIDER_DETAILS_NOTICE
+  PROVIDER_CTA_LABEL
 } from "@/lib/providerCta";
 import type { Course } from "@/types/course";
 
@@ -37,12 +38,99 @@ const sectionGroups = [
 ] as const;
 
 const decisionChecklist = [
-  "I verified final provider price/subscription terms.",
+  "I confirmed the final checkout amount and renewal terms.",
   "I checked certificate terms.",
   "I confirmed duration fits my weekly schedule.",
   "I reviewed prerequisites and learning topics.",
   "I compared at least two options."
 ];
+
+const pricingModelLabels = {
+  one_time: "One-time",
+  subscription: "Program subscription",
+  platform_subscription: "Platform subscription",
+  free_audit: "Free / audit"
+};
+
+const PricingCommitmentCard = ({ course }: { course: Course }) => {
+  const pricingOptions = getActionablePricingOptions(course);
+
+  return (
+    <article className="min-w-0 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
+      <h4 className="break-words text-lg font-semibold text-slate-950">{course.title}</h4>
+      {pricingOptions.length > 0 ? (
+        <div className="mt-4 space-y-4">
+          {pricingOptions.map((option, index) => (
+            <div
+              key={option.id}
+              className="rounded-xl border border-blue-100 bg-blue-50/60 p-4"
+            >
+              <div className="flex flex-wrap gap-2 text-xs font-semibold">
+                <span className="rounded-full bg-blue-100 px-2.5 py-1 text-blue-800">
+                  {pricingModelLabels[option.model]}
+                </span>
+                <span className="rounded-full bg-white px-2.5 py-1 text-slate-600 ring-1 ring-slate-200">
+                  {index === 0 ? "First displayed path" : "Verified alternative"}
+                </span>
+              </div>
+              <p className="mt-3 text-base font-semibold leading-relaxed text-slate-950">
+                {formatPricingOption(option)}
+              </p>
+              <dl className="mt-3 grid gap-2 text-xs leading-relaxed text-slate-600 sm:grid-cols-2">
+                <div>
+                  <dt className="font-semibold text-slate-800">Source amount</dt>
+                  <dd>
+                    {option.amount} {option.currency}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="font-semibold text-slate-800">USD basis</dt>
+                  <dd>
+                    {option.normalizationBasis === "provider_published_usd"
+                      ? "Provider-published USD"
+                      : "Dated currency conversion"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="font-semibold text-slate-800">Observed</dt>
+                  <dd>{option.observedAt}</dd>
+                </div>
+                <div>
+                  <dt className="font-semibold text-slate-800">Market context</dt>
+                  <dd>{option.referenceMarket ?? "No stated market restriction"}</dd>
+                </div>
+              </dl>
+              {option.conditions ? (
+                <p className="mt-3 text-xs leading-relaxed text-slate-600">
+                  {option.conditions}
+                </p>
+              ) : null}
+              <p className="mt-3 text-xs text-slate-500">
+                Evidence: {option.evidenceUrls.map((url, evidenceIndex) => (
+                  <span key={url}>
+                    {evidenceIndex > 0 ? ", " : ""}
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-semibold text-blue-700 underline decoration-blue-300 underline-offset-2"
+                    >
+                      official source {evidenceIndex + 1}
+                    </a>
+                  </span>
+                ))}
+              </p>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-4 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          Actionable source-backed pricing is not yet available for this course.
+        </p>
+      )}
+    </article>
+  );
+};
 
 const CourseFitCard = ({ course }: { course: Course }) => (
   <div className="min-w-0 rounded-2xl border border-slate-200/80 bg-white p-5 shadow-[0_14px_36px_-30px_rgba(15,23,42,0.4)] sm:p-6">
@@ -218,7 +306,7 @@ export default function CompareClient() {
           {leftCourse.title} vs {rightCourse.title}
         </h2>
         <p className="max-w-3xl text-base leading-relaxed text-slate-600 sm:text-lg">
-          Use the comparison below to understand practical differences, uncertainty, and what to verify before opening the provider page.
+          Compare current payment commitments, practical differences, and uncertainty before using provider checkout for final confirmation.
         </p>
       </header>
 
@@ -251,9 +339,29 @@ export default function CompareClient() {
         </div>
       </section>
 
+      <section className="rounded-[1.75rem] border border-blue-200 bg-gradient-to-br from-blue-50 to-white p-5 sm:p-7">
+        <div className="max-w-3xl">
+          <p className="text-xs font-bold uppercase tracking-[0.18em] text-blue-700">
+            Pricing commitments
+          </p>
+          <h3 className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
+            What you would pay now
+          </h3>
+          <p className="mt-2 text-sm leading-relaxed text-slate-600">
+            All comparable amounts are shown in USD. Course or program paths appear before broader platform-subscription alternatives when both are verified.
+          </p>
+        </div>
+        <div className="mt-5 grid gap-4 lg:grid-cols-2">
+          <PricingCommitmentCard course={leftCourse} />
+          <PricingCommitmentCard course={rightCourse} />
+        </div>
+      </section>
+
       <section className="rounded-2xl border border-blue-200/80 bg-blue-50/60 p-5 sm:p-6">
         <h3 className="text-lg font-semibold text-slate-900">Open provider pages</h3>
-        <p className="mt-2 text-sm leading-relaxed text-slate-600">{PROVIDER_DETAILS_NOTICE}</p>
+        <p className="mt-2 text-sm leading-relaxed text-slate-600">
+          Use provider pages to confirm the final transaction, taxes, eligibility, and availability; the comparison above contains the current verified pricing evidence.
+        </p>
         <div className="mt-4 grid gap-3 sm:flex sm:flex-wrap">
           <a
             href={leftCourse.externalUrl}

--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -105,6 +105,18 @@ const PricingCommitmentCard = ({ course }: { course: Course }) => {
                   {option.conditions}
                 </p>
               ) : null}
+              <a
+                href={option.actionUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() =>
+                  trackOutboundCourseClick(course, EXTERNAL_PROVIDER_CONTEXT.compare)
+                }
+                aria-label={`Open ${option.scope} pricing option for ${course.title}`}
+                className="mt-4 inline-flex min-h-11 items-center rounded-lg bg-blue-700 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-600"
+              >
+                Open this pricing option
+              </a>
               <p className="mt-3 text-xs text-slate-500">
                 Evidence: {option.evidenceUrls.map((url, evidenceIndex) => (
                   <span key={url}>
@@ -345,10 +357,10 @@ export default function CompareClient() {
             Pricing commitments
           </p>
           <h3 className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
-            What you would pay now
+            Current verified pricing
           </h3>
           <p className="mt-2 text-sm leading-relaxed text-slate-600">
-            All comparable amounts are shown in USD. Course or program paths appear before broader platform-subscription alternatives when both are verified.
+            All comparable commitments are shown in USD. Course or program paths appear before broader platform-subscription alternatives when both are verified; trials may change the amount due at checkout today.
           </p>
         </div>
         <div className="mt-5 grid gap-4 lg:grid-cols-2">

--- a/app/courses/[courseId]/CourseDetailClient.tsx
+++ b/app/courses/[courseId]/CourseDetailClient.tsx
@@ -6,6 +6,7 @@ import { courses } from "@/lib/catalog-adapter";
 import { useCompareSelection } from "@/contexts/CompareSelectionContext";
 import {
   formatCertificate,
+  getActionablePricingOptions,
   getCourseDecisionSummary,
   getCourseFitBullets,
   isDurationPending,
@@ -50,6 +51,7 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
   }
 
   const selected = isSelected(course.id);
+  const primaryPricingOption = getActionablePricingOptions(course)[0] ?? null;
   const atLimit = selectedIds.length >= 2 && !selected;
   const selectedCourses = selectedIds
     .map((id) => courses.find((item) => item.id === id))
@@ -110,6 +112,17 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
               >
                 {PROVIDER_CTA_LABEL}
               </a>
+              {primaryPricingOption ? (
+                <a
+                  href={primaryPricingOption.actionUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`Open verified pricing path for ${course.title}: ${primaryPricingOption.scope}`}
+                  className="flex min-h-11 items-center justify-center rounded-xl border border-blue-400 px-5 py-2.5 text-center text-sm font-semibold text-blue-100 transition hover:border-blue-300 hover:bg-blue-950"
+                >
+                  Open verified pricing path
+                </a>
+              ) : null}
               <button
                 type="button"
                 aria-pressed={selected}

--- a/data/normalized/course-source-metadata.json
+++ b/data/normalized/course-source-metadata.json
@@ -53,7 +53,7 @@
       "title": true,
       "platform": true,
       "sourceUrl": true,
-      "price": false,
+      "price": true,
       "rating": false,
       "reviewCount": false,
       "duration": true,
@@ -67,9 +67,10 @@
       "toolsTechnologies": true,
       "practicalWork": true,
       "credential": true,
-      "costModel": true
+      "costModel": true,
+      "pricingOptions": true
     },
-    "notes": "Source: official Coursera provider page at the existing canonical URL, reviewed 2026-08-18 for the Decision Data Contract v2 pilot. Verified the specialization and career-certificate context; 3 months at 10 hours/week workload wording; stated Python, linear algebra, and machine learning background; learning topics; Python, TensorFlow, and Hugging Face tools; applied learning project, programming assignments, and labs; and subscription access context. durationHours remains null because the page does not provide one explicit program total. Exact price, rating, and review count remain unknown/null because they are volatile."
+    "notes": "Sources: official Coursera program page and official DeepLearning.AI specialization page, reviewed 2026-08-18. Verified the specialization and career-certificate context; 3 months at 10 hours/week workload wording; stated Python, linear algebra, and machine learning background; learning topics; Python, TensorFlow, and Hugging Face tools; applied learning project, programming assignments, and labs; and subscription access context. Pricing path: $30 USD/month for DeepLearning.AI Pro access to this specialization, graded assignments, and certificate, published on the public DeepLearning.AI page; taxes may apply. The Coursera program subscription was excluded because its exact current amount was not public. DeepLearning.AI's $25/month billed-annually effective rate was excluded because the source does not state the exact annual charge. Temporary Coursera Plus discounts were excluded. durationHours remains null because the page does not provide one explicit program total. Rating and review count remain unknown/null because they are volatile."
   },
   {
     "courseId": "ibm-data-science-ibm",
@@ -125,7 +126,7 @@
       "title": true,
       "platform": true,
       "sourceUrl": true,
-      "price": false,
+      "price": true,
       "rating": false,
       "reviewCount": false,
       "duration": true,
@@ -139,9 +140,10 @@
       "toolsTechnologies": true,
       "practicalWork": true,
       "credential": true,
-      "costModel": false
+      "costModel": false,
+      "pricingOptions": true
     },
-    "notes": "Source: official Coursera provider page at the existing canonical URL, reviewed 2026-08-18 for the Decision Data Contract v2 pilot. Verified the professional-certificate and IBM credential/digital-badge context; 4 months at 10 hours/week workload wording; learning topics; explicitly named ITIL, OWASP ZAP, and Snyk tools; and hands-on labs, projects, case studies, cybersecurity plans, and compliance-framework work. The previous prerequisite bullets were removed because the current page only exposes a generic recommended-experience label. Cost model, exact price, rating, and review count remain unverified."
+    "notes": "Sources: official IBM Cybersecurity Analyst Professional Certificate page on Coursera and official Coursera Plus plan page, reviewed 2026-08-18. Verified the professional-certificate and IBM credential/digital-badge context; 4 months at 10 hours/week workload wording; learning topics; explicitly named ITIL, OWASP ZAP, and Snyk tools; and hands-on labs, projects, case studies, cybersecurity plans, and compliance-framework work. Pricing path: $59 USD/month for Coursera Plus catalog access; the program page explicitly marks this certificate as included, and the plan page publishes the monthly amount and initial 7-day trial. The direct certificate subscription was excluded because its exact current amount was not public. The temporary $239/year Coursera Plus promotion was excluded. The previous prerequisite bullets were removed because the current page only exposes a generic recommended-experience label. The course-specific cost model, rating, and review count remain unverified."
   },
   {
     "courseId": "google-cybersecurity-google",
@@ -153,7 +155,7 @@
       "title": true,
       "platform": true,
       "sourceUrl": true,
-      "price": false,
+      "price": true,
       "rating": false,
       "reviewCount": false,
       "duration": true,
@@ -167,9 +169,10 @@
       "toolsTechnologies": true,
       "practicalWork": true,
       "credential": true,
-      "costModel": true
+      "costModel": true,
+      "pricingOptions": true
     },
-    "notes": "Source: official Coursera provider page at the existing canonical URL, reviewed 2026-08-18 for the Decision Data Contract v2 pilot. Verified the professional-certificate and Google credential context; 6 months at 7 hours/week workload wording; no prior experience requirement; learning topics; Linux, Python, Bash, SQL, SIEM, and intrusion-detection tools; hands-on labs, practice-based assessments, and portfolio activities; and monthly-subscription/free-trial context with regional variation. durationHours remains null because the schedule is not converted into an exact total. Exact price, rating, and review count remain unknown/null because they are volatile."
+    "notes": "Sources: official Google Cybersecurity Professional Certificate page on Coursera and official Coursera Plus plan page, reviewed 2026-08-18. Verified the professional-certificate and Google credential context; 6 months at 7 hours/week workload wording; no prior experience requirement; learning topics; Linux, Python, Bash, SQL, SIEM, and intrusion-detection tools; and hands-on labs, practice-based assessments, and portfolio activities. Pricing paths: $49 USD/month for the certificate in the United States and Canada after an initial 7-day trial, with lower pricing possible elsewhere; and $59 USD/month for Coursera Plus catalog access, with the program page explicitly marking this certificate as included. The provider's under-$300 completion estimate was excluded because it depends on completion pace, and the temporary $239/year Coursera Plus promotion was excluded. durationHours remains null because the schedule is not converted into an exact total. Rating and review count remain unknown/null because they are volatile."
   },
   {
     "courseId": "introduction-cyber-security-nyux-edx",
@@ -401,7 +404,7 @@
       "title": true,
       "platform": true,
       "sourceUrl": true,
-      "price": false,
+      "price": true,
       "rating": false,
       "reviewCount": false,
       "duration": true,
@@ -415,9 +418,10 @@
       "toolsTechnologies": false,
       "practicalWork": false,
       "credential": true,
-      "costModel": true
+      "costModel": true,
+      "pricingOptions": true
     },
-    "notes": "Source: official Coursera provider page at the existing canonical URL, reviewed 2026-08-18 for the Decision Data Contract v2 pilot. Verified the single-course and shareable-course-certificate context; explicit 7-hour completion signal; no prior experience requirement; learning topics; and paid certificate experience with possible free-trial or full-course-without-certificate access. The source does not explicitly support named tools/technologies or hands-on project/lab work, so those dimensions remain empty and unverified. Exact price, rating, and review count remain unknown/null because they are volatile."
+    "notes": "Sources: official Coursera course page and official DeepLearning.AI course page, reviewed 2026-08-18. Verified the single-course and shareable-course-certificate context; explicit 7-hour completion signal; no prior experience requirement; learning topics; and paid certificate experience. Pricing path: $49 USD one-time for course access and 180 days of certificate eligibility, published on the public DeepLearning.AI page. Coursera-localized checkout amounts were not used as universal pricing, and possible free-trial or no-certificate access was excluded because the course page presents it conditionally rather than as a guaranteed current path. The source does not explicitly support named tools/technologies or hands-on project/lab work, so those dimensions remain empty and unverified. Rating and review count remain unknown/null because they are volatile."
   },
   {
     "courseId": "ibm-ai-engineering-ibm",

--- a/data/normalized/courses.json
+++ b/data/normalized/courses.json
@@ -68,8 +68,8 @@
     "durationHours": null,
     "language": "en",
     "priceModel": "subscription",
-    "priceAmount": null,
-    "currency": null,
+    "priceAmount": 30,
+    "currency": "USD",
     "priceInterval": "month",
     "rating": null,
     "reviewCount": null,
@@ -109,6 +109,25 @@
       "type": "subscription",
       "text": "An active subscription is required to access labs and submit assignments"
     },
+    "pricingOptions": [
+      {
+        "id": "deeplearning-ai-pro-monthly",
+        "model": "platform_subscription",
+        "amount": 30,
+        "currency": "USD",
+        "normalizedUsdAmount": 30,
+        "cadence": "month",
+        "scope": "DeepLearning.AI Pro access to the Deep Learning Specialization, graded assignments, and certificate",
+        "normalizationBasis": "provider_published_usd",
+        "evidenceUrls": [
+          "https://www.deeplearning.ai/specializations/deep-learning"
+        ],
+        "observedAt": "2026-08-18",
+        "referenceMarket": null,
+        "accessContext": "public_provider_page",
+        "conditions": "Billed monthly; taxes may apply depending on location"
+      }
+    ],
     "source": "coursera-curated"
   },
   {
@@ -179,8 +198,8 @@
     "durationHours": null,
     "language": "en",
     "priceModel": "subscription",
-    "priceAmount": null,
-    "currency": null,
+    "priceAmount": 59,
+    "currency": "USD",
     "priceInterval": "month",
     "rating": null,
     "reviewCount": null,
@@ -215,6 +234,26 @@
       "text": "IBM Professional Certificate and digital badge"
     },
     "costModel": null,
+    "pricingOptions": [
+      {
+        "id": "coursera-plus-monthly",
+        "model": "platform_subscription",
+        "amount": 59,
+        "currency": "USD",
+        "normalizedUsdAmount": 59,
+        "cadence": "month",
+        "scope": "Coursera Plus catalog access, including the IBM Cybersecurity Analyst Professional Certificate",
+        "normalizationBasis": "provider_published_usd",
+        "evidenceUrls": [
+          "https://www.coursera.org/professional-certificates/ibm-cybersecurity-analyst",
+          "https://www.coursera.org/courseraplus"
+        ],
+        "observedAt": "2026-08-18",
+        "referenceMarket": null,
+        "accessContext": "public_provider_page",
+        "conditions": "Coursera Plus monthly plan; cancel anytime after the initial 7-day free trial"
+      }
+    ],
     "source": "coursera-curated"
   },
   {
@@ -227,8 +266,8 @@
     "durationHours": null,
     "language": "en",
     "priceModel": "subscription",
-    "priceAmount": null,
-    "currency": null,
+    "priceAmount": 49,
+    "currency": "USD",
     "priceInterval": "month",
     "rating": null,
     "reviewCount": null,
@@ -271,6 +310,43 @@
       "type": "subscription",
       "text": "Monthly subscription after an initial free trial in the U.S. and Canada; regional pricing may vary"
     },
+    "pricingOptions": [
+      {
+        "id": "google-certificate-monthly",
+        "model": "subscription",
+        "amount": 49,
+        "currency": "USD",
+        "normalizedUsdAmount": 49,
+        "cadence": "month",
+        "scope": "Google Cybersecurity Professional Certificate",
+        "normalizationBasis": "provider_published_usd",
+        "evidenceUrls": [
+          "https://www.coursera.org/professional-certificates/google-cybersecurity"
+        ],
+        "observedAt": "2026-08-18",
+        "referenceMarket": "United States and Canada",
+        "accessContext": "public_provider_page",
+        "conditions": "Charged after the initial 7-day free trial; other countries may have lower pricing"
+      },
+      {
+        "id": "coursera-plus-monthly",
+        "model": "platform_subscription",
+        "amount": 59,
+        "currency": "USD",
+        "normalizedUsdAmount": 59,
+        "cadence": "month",
+        "scope": "Coursera Plus catalog access, including the Google Cybersecurity Professional Certificate",
+        "normalizationBasis": "provider_published_usd",
+        "evidenceUrls": [
+          "https://www.coursera.org/professional-certificates/google-cybersecurity",
+          "https://www.coursera.org/courseraplus"
+        ],
+        "observedAt": "2026-08-18",
+        "referenceMarket": null,
+        "accessContext": "public_provider_page",
+        "conditions": "Coursera Plus monthly plan; cancel anytime after the initial 7-day free trial"
+      }
+    ],
     "source": "coursera-curated"
   },
   {
@@ -575,10 +651,10 @@
     "level": "beginner",
     "durationHours": 7,
     "language": "en",
-    "priceModel": "subscription",
-    "priceAmount": null,
-    "currency": null,
-    "priceInterval": "month",
+    "priceModel": "paid_once",
+    "priceAmount": 49,
+    "currency": "USD",
+    "priceInterval": null,
     "rating": null,
     "reviewCount": null,
     "certificate": true,
@@ -611,6 +687,25 @@
       "type": "paid_certificate",
       "text": "The certificate experience requires purchase; a free trial or full course without a certificate may be available"
     },
+    "pricingOptions": [
+      {
+        "id": "course-certificate-180-days",
+        "model": "one_time",
+        "amount": 49,
+        "currency": "USD",
+        "normalizedUsdAmount": 49,
+        "cadence": "one_time",
+        "scope": "AI For Everyone course access and certificate eligibility for 180 days",
+        "normalizationBasis": "provider_published_usd",
+        "evidenceUrls": [
+          "https://www.deeplearning.ai/courses/ai-for-everyone"
+        ],
+        "observedAt": "2026-08-18",
+        "referenceMarket": null,
+        "accessContext": "public_provider_page",
+        "conditions": null
+      }
+    ],
     "source": "coursera-curated"
   },
   {

--- a/data/normalized/courses.json
+++ b/data/normalized/courses.json
@@ -119,6 +119,7 @@
         "cadence": "month",
         "scope": "DeepLearning.AI Pro access to the Deep Learning Specialization, graded assignments, and certificate",
         "normalizationBasis": "provider_published_usd",
+        "actionUrl": "https://www.deeplearning.ai/specializations/deep-learning",
         "evidenceUrls": [
           "https://www.deeplearning.ai/specializations/deep-learning"
         ],
@@ -244,6 +245,7 @@
         "cadence": "month",
         "scope": "Coursera Plus catalog access, including the IBM Cybersecurity Analyst Professional Certificate",
         "normalizationBasis": "provider_published_usd",
+        "actionUrl": "https://www.coursera.org/courseraplus",
         "evidenceUrls": [
           "https://www.coursera.org/professional-certificates/ibm-cybersecurity-analyst",
           "https://www.coursera.org/courseraplus"
@@ -320,6 +322,7 @@
         "cadence": "month",
         "scope": "Google Cybersecurity Professional Certificate",
         "normalizationBasis": "provider_published_usd",
+        "actionUrl": "https://www.coursera.org/professional-certificates/google-cybersecurity",
         "evidenceUrls": [
           "https://www.coursera.org/professional-certificates/google-cybersecurity"
         ],
@@ -337,6 +340,7 @@
         "cadence": "month",
         "scope": "Coursera Plus catalog access, including the Google Cybersecurity Professional Certificate",
         "normalizationBasis": "provider_published_usd",
+        "actionUrl": "https://www.coursera.org/courseraplus",
         "evidenceUrls": [
           "https://www.coursera.org/professional-certificates/google-cybersecurity",
           "https://www.coursera.org/courseraplus"
@@ -697,6 +701,7 @@
         "cadence": "one_time",
         "scope": "AI For Everyone course access and certificate eligibility for 180 days",
         "normalizationBasis": "provider_published_usd",
+        "actionUrl": "https://www.deeplearning.ai/courses/ai-for-everyone",
         "evidenceUrls": [
           "https://www.deeplearning.ai/courses/ai-for-everyone"
         ],

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,6 +1,6 @@
 # Current State
 
-Last updated after implementing the Phase 1B.2 Decision Data Contract v2 pilot for product review.
+Last updated after implementing the Phase 1B.3 pricing pilot for product review.
 
 ## Product State
 
@@ -11,6 +11,16 @@ The current UI is English-first. The product supports skill discovery, curated c
 Recent product review exposed an important distinction: source-trusted catalog data is not automatically decision-useful data. The product must not only avoid inventing facts; it must preserve enough structured provider-backed information to help a user actually choose between courses.
 
 ## Latest Completed Initiatives
+
+### Phase 1B.3 — Pricing as Core Decision Data — Issue #97
+
+Key outcomes:
+
+- The normalized contract supports multiple structured pricing paths with USD display, payment model, cadence, scope, provenance, observation date, and regional/access context.
+- Migration remains limited to the same four approved pilot courses; the remaining 15 catalog records are unchanged.
+- Both required comparisons pass a new pricing hard gate while retaining the unchanged 5/7 Phase 1B.2 dimension gate.
+- Compare surfaces current payable commitments before provider links and distinguishes course/program pricing from broader platform-subscription alternatives.
+- Pricing evidence and intentional exclusions are recorded in `docs/pricing-phase-1b3-pilot.md`.
 
 ### Phase 1B.2 — Decision Data Contract v2 pilot — Issue #94
 
@@ -51,7 +61,7 @@ Earlier completed initiatives, including Phase 1 Source Verification Batches A/B
 
 - **Phase 0 — MVP:** complete for the current MVP scope.
 - **Phase 1A — Source Trust:** complete for the current 19-course curated MVP catalog; ongoing maintenance only.
-- **Phase 1B — Decision-Grade Data:** Phase 1B.1 is complete and the Phase 1B.2 pilot is implemented; product review must decide whether and how to migrate later batches.
+- **Phase 1B — Decision-Grade Data:** Phase 1B.1, Phase 1B.2, and the Phase 1B.3 pricing pilot are implemented; product review must decide whether and how to migrate later batches.
 - **Phase 2 — Monetization:** gated / not started. It activates only when a real auditable affiliate/referral program exists and does not block Phase 3.
 - **Phase 3 — Discovery and SEO:** active, with the indexable-surface foundation complete. Further content/traffic expansion is paused until the Phase 1B.2 pilot proves that core comparisons provide meaningful decision value.
 - **Phase 4 — Recommendation:** later, gated behind explicit criteria and trustworthy signals.
@@ -63,7 +73,7 @@ Earlier completed initiatives, including Phase 1 Source Verification Batches A/B
 - 17 courses are currently `partially_verified`.
 - 2 courses remain `pending` with explicit source blockers rather than unreviewed status.
 - Source URL mismatches: 0 after the completed verification batches.
-- Most pricing, ratings, and review counts remain unknown or unverified by design.
+- Pricing remains unknown or unverified for the 15 non-pilot courses; the four pilot records now have actionable source-backed USD pricing paths. Most ratings and review counts remain unknown by design.
 - The four Phase 1B.2 pilot records preserve provider-described workload schedules such as months plus hours per week while exact `durationHours` remains null unless the source explicitly states a total.
 - The current normalized `language` field represents the primary taught language when clearly supported by an official source. Additional dubbing/subtitle/language availability remains provenance context unless a later explicit schema initiative changes that model.
 - `report:data-quality` remains part of normal validation.
@@ -84,7 +94,7 @@ Not implemented:
 
 These are intentional roadmap constraints, not missing requirements to fill opportunistically.
 
-## Phase 1B.2 Pilot Result
+## Phase 1B.3 Pilot Result
 
 Pilot scope is exactly four courses and two comparisons:
 
@@ -93,14 +103,15 @@ Pilot scope is exactly four courses and two comparisons:
 
 - AI For Everyone vs Deep Learning Specialization: **5/7 pass**. Source-backed for both: offering/credential type, workload, starting point, learning topics, and cost-model context. Insufficient for both: tools/technologies and practical work.
 - Google Cybersecurity vs IBM Cybersecurity Analyst: **5/7 pass**. Source-backed for both: offering/credential type, workload, learning topics, tools/technologies, and practical work. Insufficient for both: starting point and cost-model context.
+- Pricing hard gate: **pass for both pairs**. Each pilot course has at least one actionable payable path displayed in USD; the 5/7 dimension gate was not weakened.
 
 The gate is internal product-quality validation, not a visible ranking or course score.
 
-## After Phase 1B.2
+## After Phase 1B.3
 
 Return to product review. Do not automatically migrate all 19 courses and do not resume SEO content expansion automatically.
 
-First judge whether the two pilot comparisons materially reduce the need for a user to open both provider pages merely to understand basic differences. If the pilot succeeds, decide the smallest auditable migration sequence for the remaining catalog. If it fails, revise the decision-data model before scaling it.
+First judge whether the two pilot comparisons let a user understand both the learning tradeoffs and current economic commitments without opening both provider pages. If the pilot succeeds, decide the smallest auditable migration sequence for the remaining catalog. If it fails, revise the decision-data or pricing model before scaling it.
 
 ## Parallel Ongoing Work
 

--- a/docs/MVP_READINESS.md
+++ b/docs/MVP_READINESS.md
@@ -4,7 +4,7 @@
 
 - Skills Compare is an English-first product for finding skills, reviewing relevant online courses, comparing two options, and opening the original provider page.
 - Phase 0 is complete for the current MVP scope.
-- Phase 1A source trust is complete for the current 19-course catalog; the Phase 1B.2 decision-data pilot is implemented on exactly four courses and awaits product review before any wider migration.
+- Phase 1A source trust is complete for the current 19-course catalog; the Phase 1B.3 pricing pilot extends the Phase 1B.2 decision-data pilot on exactly four courses and awaits product review before any wider migration.
 - Phase 2 monetization is gated until a real auditable affiliate/referral program exists and does not block Phase 3.
 - Phase 3 Discovery and SEO has its indexable-surface foundation in place; content expansion remains paused pending review of the Phase 1B.2 pilot.
 - The normalized catalog contains 19 curated courses.
@@ -18,20 +18,21 @@
 - Mobile Selection and Discovery UX is merged: compare selection persists for up to 24 hours, returning selections are surfaced, and the compare bar is available globally outside the compare page.
 - Decision-focused visual polish is merged across the core Search -> Compare -> Decide journey.
 - Decision Data Contract v2 preserves provider-backed offering, workload, tool, practical-work, credential, and cost-model signals for the four-course pilot.
+- Structured pricing preserves source-backed payable paths, USD amounts, cadence, scope, provenance, freshness, and regional/access context for the same four-course pilot.
 
 ## Trust and Data Quality Reality
 
 - Phase 1 manual verification reviewed the full 19-course curated catalog at least at the record level.
 - Verification remains conservative and can be partial when a current official page does not support a field.
 - Stable fields such as title, platform/source URL, level, primary taught language, certificate visibility, workload/duration signals, learning topics, and prerequisites are marked verified only when clearly supported.
-- Prices, ratings, review counts, and some durations remain unverified or unknown by design.
+- Prices remain unverified or unknown for the 15 non-pilot courses; the four pilot courses have actionable source-backed USD pricing paths. Ratings, review counts, and some durations remain unknown by design.
 - Monthly or weekly workload estimates are not converted into invented exact `durationHours`; those values remain null unless the official source provides a sufficiently exact total.
 - The normalized `language` field represents the primary taught language when clearly supported. Additional dubbing, subtitle, translation, or language availability remains provenance context unless a future explicit schema initiative expands the model.
 - `introduction-cyber-security-nyux-edx` remains pending because the recorded edX page is unavailable and no current official page clearly represents the exact same NYUx offering.
 - `data-analytics-essentials-cisco` remains pending because the recorded Coursera listing is unavailable and Cisco's current instructor-led offering does not establish that it is the same listing.
 - Unknown data must remain null, unknown, pending, or explicitly unverified.
-- Both approved pilot comparisons pass the internal 5/7 decision-readiness gate while retaining explicit insufficiencies; this gate is not a visible ranking or course score.
-- Users should verify final pricing, duration, certificate terms, enrollment details, and availability on the provider page before deciding.
+- Both approved pilot comparisons pass the pricing hard gate and the unchanged internal 5/7 decision-readiness gate while retaining explicit insufficiencies; these gates are not visible rankings or course scores.
+- Users can compare the current verified pricing commitments inside Skills Compare and should use provider checkout to confirm final taxes, regional terms, eligibility, and availability.
 
 ## What Works
 
@@ -56,12 +57,13 @@
 - No outcome, employment, partnership, or provider endorsement claims should be made.
 - No user accounts, cookies, database, scraping, external APIs, or new analytics vendors are implemented.
 
-## Decision Data Pilot Reality
+## Decision Data and Pricing Pilot Reality
 
 - AI For Everyone vs Deep Learning Specialization passes 5/7 with tools and practical work explicitly insufficient for both sides.
 - Google Cybersecurity vs IBM Cybersecurity Analyst passes 5/7 with starting point and cost-model context explicitly insufficient for both sides.
+- Both pairs also pass the separate pricing hard gate; every pilot course has at least one source-backed payable path displayed in USD.
 - The schema migration is limited to those four records. Product review must decide whether a later small-batch rollout is justified.
-- Exact volatile prices remain outside the decision-readiness requirement; provider pages remain the final source for enrollment terms.
+- Exact actionable pricing is now required for pilot decision-readiness. Provider checkout remains the final source for transaction-specific taxes, eligibility, regional variation, and availability.
 
 ## Validation Workflow
 
@@ -76,4 +78,4 @@ Use the documented repository-local TypeScript fallback only when the normal pnp
 
 ## Active Near-Term Gate
 
-Product review must evaluate the Phase 1B.2 pilot before approving any migration of the remaining 15 catalog records or resuming Phase 3 content expansion. Phase 2 monetization remains gated until a real program exists.
+Product review must evaluate the Phase 1B.3 pricing pilot before approving any migration of the remaining 15 catalog records or resuming Phase 3 content expansion. Phase 2 monetization remains gated until a real program exists.

--- a/docs/PRODUCT_DECISIONS.md
+++ b/docs/PRODUCT_DECISIONS.md
@@ -44,6 +44,15 @@ Do not manufacture a winner when the available evidence does not justify one.
 - Do not convert workload estimates into exact total duration without evidence.
 - Do not infer ratings, review counts, employment outcomes, or provider endorsements.
 
+## Pricing as Decision Data
+
+- For the Phase 1B.3 pilot, a comparison is not decision-ready unless both courses have at least one actionable, source-backed payable pricing path displayed in USD.
+- Preserve amount, cadence, payment model, scope, source, observation date, and regional or access context. Do not collapse genuinely distinct paths into one scalar claim.
+- Course- or program-specific paths appear before verified platform-subscription alternatives.
+- Currency-converted amounts must preserve the original amount and render with approximation semantics.
+- Promotional prices, inferred completion totals, and generic provider-wide starting prices are not canonical course prices.
+- Pricing remains a hard gate in addition to, not instead of, the existing 5/7 Phase 1B.2 decision-dimension gate.
+
 ## Language
 
 The product UI is **English-first** in the current phase.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,7 +24,7 @@ Future work in this area should be limited to concrete usability defects or regr
 
 ## Phase 1 — Real Data
 
-**Status: Phase 1A source trust complete; Phase 1B.2 pilot implemented and awaiting product review.**
+**Status: Phase 1A source trust complete; Phase 1B.3 pricing pilot implemented and awaiting product review.**
 
 Goal: make the catalog both trustworthy and useful enough to support real user decisions.
 
@@ -48,6 +48,7 @@ Completed:
 
 - **Phase 1B.1 — Comparison Integrity Fix** in PR #93: unknown or unverified values no longer create confident `Same` / `Different` claims; runtime mapping now preserves nullable and verification semantics needed for trustworthy comparisons.
 - **Phase 1B.2 — Decision Data Contract v2 pilot** in issue #94: the structured contract and four-course migration are implemented, both required comparisons pass the internal 5/7 gate, and unsupported dimensions remain explicitly insufficient.
+- **Phase 1B.3 — Pricing as Core Decision Data** in issue #97: structured multi-path pricing is implemented for the same four-course pilot, pricing is a hard gate in addition to the unchanged 5/7 gate, and the comparison surfaces exact USD commitments with provenance and regional context.
 
 Do not migrate the remaining catalog until the pilot proves that the new contract materially improves decision quality without inventing information.
 
@@ -110,8 +111,8 @@ Do not build Phase 5 architecture to solve hypothetical scale.
 ## Immediate Sequence
 
 1. Maintain conservative Phase 1A source trust without reopening verification work for its own sake.
-2. Review the completed Phase 1B.2 four-course pilot against the explicit decision-readiness and product acceptance criteria.
+2. Review the completed Phase 1B.3 four-course pricing pilot against the explicit decision-readiness and product acceptance criteria.
 3. Do not begin catalog-wide migration without a new product decision.
-4. Keep Phase 3 content/traffic expansion paused until the pilot shows that core comparison pages provide meaningful decision value.
+4. Keep Phase 3 content/traffic expansion paused until the pricing pilot shows that core comparison pages provide meaningful decision value.
 5. If the pilot succeeds, migrate the remaining catalog only in small auditable batches and then return to selective people-first SEO work.
 6. Activate Phase 2 monetization only when a real program and appropriate disclosures are ready; it is not a prerequisite for Phase 3.

--- a/docs/pricing-phase-1b3-pilot.md
+++ b/docs/pricing-phase-1b3-pilot.md
@@ -1,0 +1,55 @@
+# Phase 1B.3 Pricing Pilot
+
+Observed and reviewed on 2026-08-18. This manual curation is limited to the four approved pilot courses. All displayed comparable amounts are normalized to USD; no FX conversion was required.
+
+## Pricing paths
+
+### AI For Everyone
+
+- Path: `$49 total` for AI For Everyone course access and 180 days of certificate eligibility.
+- Model / cadence: one-time / one-time.
+- Original and normalized amount: 49 USD / 49 USD.
+- Evidence: [official DeepLearning.AI course page](https://www.deeplearning.ai/courses/ai-for-everyone).
+- Access context: public provider page.
+- Region/account limitation: no reference market or account requirement stated; final taxes or checkout eligibility may vary.
+- Excluded: Coursera-localized checkout amounts were not treated as universal. Possible free-trial or no-certificate access was excluded because the current course page presents it conditionally rather than as a guaranteed path.
+
+### Deep Learning Specialization
+
+- Path: `$30/month` for DeepLearning.AI Pro access to the Deep Learning Specialization, graded assignments, and certificate.
+- Model / cadence: platform subscription / month.
+- Original and normalized amount: 30 USD / 30 USD.
+- Evidence: [official DeepLearning.AI specialization page](https://www.deeplearning.ai/specializations/deep-learning).
+- Access context: public provider page.
+- Region/account limitation: no reference market or account requirement stated; the provider says taxes may apply depending on location.
+- Excluded: the Coursera program subscription did not expose an exact current public amount. The `$25/month billed annually` effective rate was excluded because the exact annual charge is not stated. Temporary Coursera Plus discounts were excluded.
+
+### Google Cybersecurity Professional Certificate
+
+- Primary path: `$49/month` for the Google Cybersecurity Professional Certificate in the United States and Canada, charged after the initial 7-day free trial. Other countries may have lower pricing.
+- Alternative path: `$59/month` for Coursera Plus catalog access, including this certificate, after the initial 7-day free trial.
+- Models / cadence: program subscription / month; platform subscription / month.
+- Original and normalized amounts: 49 USD / 49 USD; 59 USD / 59 USD.
+- Evidence: [official certificate page](https://www.coursera.org/professional-certificates/google-cybersecurity) and [official Coursera Plus plan page](https://www.coursera.org/courseraplus).
+- Access context: public provider pages.
+- Region/account limitation: the program-specific `$49/month` amount is explicitly limited to the United States and Canada. The Coursera Plus public page states USD pricing but no reference market.
+- Excluded: the provider's under-`$300` completion estimate depends on completion pace and is not a factual total cost. The temporary `$239/year` Coursera Plus promotion was excluded.
+
+### IBM Cybersecurity Analyst Professional Certificate
+
+- Path: `$59/month` for Coursera Plus catalog access, including the IBM Cybersecurity Analyst Professional Certificate, after the initial 7-day free trial.
+- Model / cadence: platform subscription / month.
+- Original and normalized amount: 59 USD / 59 USD.
+- Evidence: [official certificate page showing Coursera Plus inclusion](https://www.coursera.org/professional-certificates/ibm-cybersecurity-analyst) and [official Coursera Plus plan page](https://www.coursera.org/courseraplus).
+- Access context: public provider pages.
+- Region/account limitation: the Coursera Plus public page states USD pricing but no reference market.
+- Excluded: the direct certificate subscription did not expose an exact current public amount. The temporary `$239/year` Coursera Plus promotion was excluded.
+
+## Decision-readiness result
+
+Pricing is a hard gate in addition to the existing Phase 1B.2 dimensions:
+
+- AI For Everyone vs Deep Learning Specialization: pricing passes and the pair retains its existing 5/7 decision-dimension result.
+- Google Cybersecurity vs IBM Cybersecurity Analyst: pricing passes and the pair retains its existing 5/7 decision-dimension result.
+
+The gate is internal product-quality validation, not a ranking or recommendation. Provider checkout remains the final confirmation for taxes, eligibility, regional variation, renewals, and availability.

--- a/docs/pricing-phase-1b3-pilot.md
+++ b/docs/pricing-phase-1b3-pilot.md
@@ -10,6 +10,7 @@ Observed and reviewed on 2026-08-18. This manual curation is limited to the four
 - Model / cadence: one-time / one-time.
 - Original and normalized amount: 49 USD / 49 USD.
 - Evidence: [official DeepLearning.AI course page](https://www.deeplearning.ai/courses/ai-for-everyone).
+- Pricing action: the same official DeepLearning.AI page, where this path is offered.
 - Access context: public provider page.
 - Region/account limitation: no reference market or account requirement stated; final taxes or checkout eligibility may vary.
 - Excluded: Coursera-localized checkout amounts were not treated as universal. Possible free-trial or no-certificate access was excluded because the current course page presents it conditionally rather than as a guaranteed path.
@@ -20,6 +21,7 @@ Observed and reviewed on 2026-08-18. This manual curation is limited to the four
 - Model / cadence: platform subscription / month.
 - Original and normalized amount: 30 USD / 30 USD.
 - Evidence: [official DeepLearning.AI specialization page](https://www.deeplearning.ai/specializations/deep-learning).
+- Pricing action: the same official DeepLearning.AI specialization page, where DeepLearning.AI Pro is offered.
 - Access context: public provider page.
 - Region/account limitation: no reference market or account requirement stated; the provider says taxes may apply depending on location.
 - Excluded: the Coursera program subscription did not expose an exact current public amount. The `$25/month billed annually` effective rate was excluded because the exact annual charge is not stated. Temporary Coursera Plus discounts were excluded.
@@ -31,6 +33,7 @@ Observed and reviewed on 2026-08-18. This manual curation is limited to the four
 - Models / cadence: program subscription / month; platform subscription / month.
 - Original and normalized amounts: 49 USD / 49 USD; 59 USD / 59 USD.
 - Evidence: [official certificate page](https://www.coursera.org/professional-certificates/google-cybersecurity) and [official Coursera Plus plan page](https://www.coursera.org/courseraplus).
+- Pricing actions: the official certificate page for the program-specific path and the official Coursera Plus page for the catalog-subscription path.
 - Access context: public provider pages.
 - Region/account limitation: the program-specific `$49/month` amount is explicitly limited to the United States and Canada. The Coursera Plus public page states USD pricing but no reference market.
 - Excluded: the provider's under-`$300` completion estimate depends on completion pace and is not a factual total cost. The temporary `$239/year` Coursera Plus promotion was excluded.
@@ -41,6 +44,7 @@ Observed and reviewed on 2026-08-18. This manual curation is limited to the four
 - Model / cadence: platform subscription / month.
 - Original and normalized amount: 59 USD / 59 USD.
 - Evidence: [official certificate page showing Coursera Plus inclusion](https://www.coursera.org/professional-certificates/ibm-cybersecurity-analyst) and [official Coursera Plus plan page](https://www.coursera.org/courseraplus).
+- Pricing action: the official Coursera Plus page for this catalog-subscription path.
 - Access context: public provider pages.
 - Region/account limitation: the Coursera Plus public page states USD pricing but no reference market.
 - Excluded: the direct certificate subscription did not expose an exact current public amount. The temporary `$239/year` Coursera Plus promotion was excluded.

--- a/scripts/report-data-quality.js
+++ b/scripts/report-data-quality.js
@@ -73,6 +73,16 @@ const decisionDimensions = [
     verified.costModel === true && course.costModel != null]
 ];
 
+const hasActionablePricing = (course, verified) =>
+  verified.price === true &&
+  verified.pricingOptions === true &&
+  course.pricingOptions?.some(
+    (option) =>
+      option.amount > 0 &&
+      option.normalizedUsdAmount > 0 &&
+      option.evidenceUrls?.length > 0
+  );
+
 const coursesPath = resolve(process.cwd(), "data", "normalized", "courses.json");
 const metadataPath = resolve(
   process.cwd(),
@@ -148,6 +158,7 @@ try {
 
   console.log("\nUnknown or pending course fields");
   console.log(`- priceAmount unknown/null: ${courses.filter((course) => course.priceAmount == null).length}`);
+  console.log(`- courses with structured pricing options: ${courses.filter((course) => course.pricingOptions?.length > 0).length}`);
   console.log(`- rating null: ${courses.filter((course) => course.rating == null).length}`);
   console.log(`- reviewCount null: ${courses.filter((course) => course.reviewCount == null).length}`);
   console.log(`- durationHours null: ${courses.filter((course) => course.durationHours == null).length}`);
@@ -166,6 +177,9 @@ try {
     const right = coursesById.get(rightId);
     const leftVerified = metadataByCourseId.get(leftId)?.verifiedFields ?? {};
     const rightVerified = metadataByCourseId.get(rightId)?.verifiedFields ?? {};
+    const pricingReady =
+      hasActionablePricing(left, leftVerified) &&
+      hasActionablePricing(right, rightVerified);
     const sourceBackedForBoth = decisionDimensions
       .filter(([, isReady]) =>
         isReady(left, leftVerified) && isReady(right, rightVerified)
@@ -175,9 +189,14 @@ try {
       .map(([label]) => label)
       .filter((label) => !sourceBackedForBoth.includes(label));
 
-    console.log(`- ${leftId} vs ${rightId}: ${sourceBackedForBoth.length}/7 ${sourceBackedForBoth.length >= 5 ? "PASS" : "FAIL"}`);
+    console.log(`- ${leftId} vs ${rightId}: pricing ${pricingReady ? "PASS" : "FAIL"} + ${sourceBackedForBoth.length}/7 ${pricingReady && sourceBackedForBoth.length >= 5 ? "PASS" : "FAIL"}`);
     console.log(`  - source-backed for both: ${sourceBackedForBoth.join(", ")}`);
     console.log(`  - insufficient: ${insufficient.length > 0 ? insufficient.join(", ") : "none"}`);
+    [left, right].forEach((course) => {
+      (course.pricingOptions ?? []).forEach((option) => {
+        console.log(`  - ${course.id}/${option.id}: ${option.amount} ${option.currency} -> ${option.normalizedUsdAmount} USD; ${option.model}; ${option.cadence}; ${option.scope}; observed ${option.observedAt}; market ${option.referenceMarket ?? "not restricted"}; access ${option.accessContext}; evidence ${option.evidenceUrls.join(", ")}`);
+      });
+    });
   });
 
   const structuralIssues = [

--- a/scripts/validate-data.ts
+++ b/scripts/validate-data.ts
@@ -121,6 +121,7 @@ const hasActionablePricing = (courseId: string) => {
     (option) =>
       option.amount > 0 &&
       option.normalizedUsdAmount > 0 &&
+      Boolean(option.actionUrl) &&
       option.evidenceUrls.length > 0
   );
 };

--- a/scripts/validate-data.ts
+++ b/scripts/validate-data.ts
@@ -29,7 +29,8 @@ const decisionDataFields = [
   "toolsTechnologies",
   "practicalWorkBullets",
   "credential",
-  "costModel"
+  "costModel",
+  "pricingOptions"
 ] as const;
 
 if (!existsSync(coursesPath)) {
@@ -87,6 +88,43 @@ const metadata = JSON.parse(readFileSync(metadataPath, "utf-8")) as SourceMetada
 const metadataByCourseId = new Map(metadata.map((item) => [item.courseId, item]));
 const coursesById = new Map(result.data.map((course) => [course.id, course]));
 
+const hasActionablePricing = (courseId: string) => {
+  const course = coursesById.get(courseId);
+  const verified = metadataByCourseId.get(courseId)?.verifiedFields ?? {};
+
+  if (!course) {
+    throw new Error(`Missing pilot course: ${courseId}`);
+  }
+
+  if (verified.price !== true || verified.pricingOptions !== true) {
+    return false;
+  }
+
+  const optionIds = new Set(course.pricingOptions.map((option) => option.id));
+
+  if (optionIds.size !== course.pricingOptions.length) {
+    throw new Error(`Duplicate pricing option id for ${courseId}.`);
+  }
+
+  for (const option of course.pricingOptions) {
+    if (
+      option.normalizationBasis === "provider_published_usd" &&
+      (option.currency !== "USD" || option.amount !== option.normalizedUsdAmount)
+    ) {
+      throw new Error(
+        `Provider-published USD pricing must preserve the exact amount for ${courseId}/${option.id}.`
+      );
+    }
+  }
+
+  return course.pricingOptions.some(
+    (option) =>
+      option.amount > 0 &&
+      option.normalizedUsdAmount > 0 &&
+      option.evidenceUrls.length > 0
+  );
+};
+
 const getReadiness = (courseId: string) => {
   const course = coursesById.get(courseId);
   const verified = metadataByCourseId.get(courseId)?.verifiedFields ?? {};
@@ -124,6 +162,14 @@ for (const [leftId, rightId] of PILOT_COMPARISONS) {
       leftReadiness[key as keyof typeof leftReadiness] &&
       rightReadiness[key as keyof typeof rightReadiness]
   );
+  const pricingReady = hasActionablePricing(leftId) && hasActionablePricing(rightId);
+
+  if (!pricingReady) {
+    console.error(
+      `[validate:data] Pilot pricing hard gate failed for ${leftId} vs ${rightId}.`
+    );
+    process.exit(1);
+  }
 
   if (sourceBackedForBoth.length < 5) {
     console.error(
@@ -133,7 +179,7 @@ for (const [leftId, rightId] of PILOT_COMPARISONS) {
   }
 
   console.log(
-    `[validate:data] Pilot gate passed for ${leftId} vs ${rightId}: ${sourceBackedForBoth.length}/7.`
+    `[validate:data] Pilot gate passed for ${leftId} vs ${rightId}: pricing PASS + ${sourceBackedForBoth.length}/7.`
   );
 }
 

--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Course } from "@/types/course";
 import { useCompareSelection } from "@/contexts/CompareSelectionContext";
 import { courses } from "@/lib/catalog-adapter";
+import { getActionablePricingOptions } from "@/lib/decision-support";
 import { trackOutboundCourseClick } from "@/lib/outbound-tracking";
 import {
   EXTERNAL_PROVIDER_CONTEXT,
@@ -17,6 +18,7 @@ type CourseCardProps = {
 
 export const CourseCard = ({ course }: CourseCardProps) => {
   const { toggle, isSelected, selectedIds, clear } = useCompareSelection();
+  const primaryPricingOption = getActionablePricingOptions(course)[0] ?? null;
   const selected = isSelected(course.id);
   const atLimit = selectedIds.length >= 2;
   const selectedCourses = selectedIds
@@ -101,6 +103,17 @@ export const CourseCard = ({ course }: CourseCardProps) => {
         >
           {selected ? "Remove from compare" : "Add to compare"}
         </button>
+        {primaryPricingOption ? (
+          <a
+            href={primaryPricingOption.actionUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`Open verified pricing path for ${course.title}: ${primaryPricingOption.scope}`}
+            className="flex min-h-11 w-full items-center justify-center rounded-xl border border-blue-200 bg-blue-50 px-4 py-2.5 text-center text-sm font-semibold text-blue-800 transition hover:border-blue-300 hover:bg-blue-100"
+          >
+            Open verified pricing path
+          </a>
+        ) : null}
         <div className="grid gap-2 sm:grid-cols-2">
           <Link
             href={`/courses/${course.id}`}

--- a/src/lib/catalog-adapter.ts
+++ b/src/lib/catalog-adapter.ts
@@ -68,6 +68,28 @@ const formatDurationText = (
 };
 
 const formatPriceText = (course: NormalizedCourse): string => {
+  const primaryPricingOption = course.pricingOptions[0];
+
+  if (primaryPricingOption) {
+    const approximation =
+      primaryPricingOption.normalizationBasis === "currency_converted" ? "≈ " : "";
+    const amount = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: Number.isInteger(primaryPricingOption.normalizedUsdAmount)
+        ? 0
+        : 2
+    }).format(primaryPricingOption.normalizedUsdAmount);
+    const cadence = {
+      one_time: " total",
+      month: "/month",
+      year: "/year",
+      other: ""
+    }[primaryPricingOption.cadence];
+
+    return `${approximation}${amount}${cadence}`;
+  }
+
   if (course.priceModel === "free") {
     return course.certificate ? "Free (paid certificate)" : "Free";
   }
@@ -116,6 +138,7 @@ const mapCourse = (course: NormalizedCourse): Course | null => {
     practicalWorkBullets: course.practicalWorkBullets,
     credential: course.credential,
     costModel: course.costModel,
+    pricingOptions: course.pricingOptions,
     externalUrl: course.url,
     verifiedFields: sourceMetadataByCourseId.get(course.id)?.verifiedFields ?? {}
   };

--- a/src/lib/catalog-adapter.ts
+++ b/src/lib/catalog-adapter.ts
@@ -86,8 +86,14 @@ const formatPriceText = (course: NormalizedCourse): string => {
       year: "/year",
       other: ""
     }[primaryPricingOption.cadence];
+    const model = {
+      one_time: "One-time",
+      subscription: "Program subscription",
+      platform_subscription: "Platform subscription",
+      free_audit: "Free / audit"
+    }[primaryPricingOption.model];
 
-    return `${approximation}${amount}${cadence}`;
+    return `${model}: ${approximation}${amount}${cadence} — ${primaryPricingOption.scope}`;
   }
 
   if (course.priceModel === "free") {

--- a/src/lib/decision-support.ts
+++ b/src/lib/decision-support.ts
@@ -22,6 +22,8 @@ export const CORE_DECISION_DIMENSIONS = [
 
 export type CoreDecisionDimension = (typeof CORE_DECISION_DIMENSIONS)[number]["key"];
 
+export type PricingOption = NonNullable<Course["pricingOptions"]>[number];
+
 const normalize = (value: string) => value.trim().toLowerCase();
 
 type VerifiedField = keyof NonNullable<Course["verifiedFields"]>;
@@ -38,13 +40,67 @@ export const isDurationPending = (course: Course) =>
 export const isCostModelPending = (course: Course) =>
   !isFieldVerified(course, "costModel") || course.costModel == null;
 
+export const getActionablePricingOptions = (course: Course) =>
+  isFieldVerified(course, "price") && isFieldVerified(course, "pricingOptions")
+    ? (course.pricingOptions ?? []).filter(
+        (option) =>
+          option.amount > 0 &&
+          option.normalizedUsdAmount > 0 &&
+          option.evidenceUrls.length > 0 &&
+          Boolean(option.observedAt)
+      )
+    : [];
+
 export const isExactPricePending = (course: Course) =>
-  !isFieldVerified(course, "price") ||
-  course.priceModel === "unknown" ||
-  (course.priceModel !== "free" &&
-    (course.priceAmount == null ||
-      !course.currency ||
-      (course.priceModel === "subscription" && course.priceInterval == null)));
+  getActionablePricingOptions(course).length === 0 &&
+  (!isFieldVerified(course, "price") ||
+    course.priceModel === "unknown" ||
+    (course.priceModel !== "free" &&
+      (course.priceAmount == null ||
+        !course.currency ||
+        (course.priceModel === "subscription" && course.priceInterval == null))));
+
+const formatUsd = (amount: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: Number.isInteger(amount) ? 0 : 2
+  }).format(amount);
+
+export const formatPricingOption = (option: PricingOption) => {
+  const approximation =
+    option.normalizationBasis === "currency_converted" ? "≈ " : "";
+  const cadence = {
+    one_time: " total",
+    month: "/month",
+    year: "/year",
+    other: ""
+  }[option.cadence];
+
+  return `${approximation}${formatUsd(option.normalizedUsdAmount)}${cadence} — ${option.scope}`;
+};
+
+export const formatCoursePricing = (course: Course) => {
+  const pricingOptions = getActionablePricingOptions(course);
+
+  return pricingOptions.length > 0
+    ? pricingOptions.map(formatPricingOption).join("; ")
+    : course.priceText;
+};
+
+const equalPricingOptions = (left: PricingOption[], right: PricingOption[]) =>
+  left.length === right.length &&
+  left.every((leftOption, index) => {
+    const rightOption = right[index];
+
+    return (
+      rightOption != null &&
+      leftOption.normalizedUsdAmount === rightOption.normalizedUsdAmount &&
+      leftOption.cadence === rightOption.cadence &&
+      leftOption.model === rightOption.model &&
+      normalize(leftOption.scope) === normalize(rightOption.scope)
+    );
+  });
 
 export const formatCertificate = (course: Course) =>
   course.certificate === true
@@ -106,13 +162,17 @@ export const getPairDecisionReadiness = (left: Course, right: Course) => {
   const sourceBackedForBoth = CORE_DECISION_DIMENSIONS.filter(
     ({ key }) => leftReadiness[key] && rightReadiness[key]
   );
+  const pricingReady = [left, right].every(
+    (course) => getActionablePricingOptions(course).length > 0
+  );
 
   return {
+    pricingReady,
     sourceBackedForBoth,
     insufficient: CORE_DECISION_DIMENSIONS.filter(
       ({ key }) => !(leftReadiness[key] && rightReadiness[key])
     ),
-    passes: sourceBackedForBoth.length >= 5
+    passes: pricingReady && sourceBackedForBoth.length >= 5
   };
 };
 
@@ -129,9 +189,9 @@ export const getCourseFitBullets = (course: Course) => {
     isDurationPending(course)
       ? "You are comfortable verifying duration and workload before committing."
       : `You can assess the provider-described workload: ${course.durationText}.`,
-    isCostModelPending(course)
+    isExactPricePending(course)
       ? "You are comfortable confirming final price or subscription terms on the provider page."
-      : `You can evaluate the verified cost model: ${course.costModel?.text}.`,
+      : `You can evaluate the verified commitment: ${formatCoursePricing(course)}.`,
     course.prerequisitesBullets.length > 0
       ? `The listed prerequisites fit your background: ${summarizeBullets(course.prerequisitesBullets, "prerequisites available")}.`
       : "You can verify prerequisites directly on the provider page."
@@ -158,12 +218,17 @@ export const getCourseDecisionSummary = (course: Course) => {
       : formatCertificate(course),
     isDurationPending(course)
       ? "Workload is pending verification."
-      : `Provider-described workload: ${course.durationText}.`
+      : `Provider-described workload: ${course.durationText}.`,
+    isExactPricePending(course)
+      ? "Exact actionable pricing is pending verification."
+      : `Verified pricing: ${formatCoursePricing(course)}.`
   ];
 
   const pending = [
     course.rating == null ? "Rating/review count is not available in Skills Compare." : null,
-    isExactPricePending(course) ? "Exact price or subscription terms must be verified on the provider page." : null,
+    isExactPricePending(course)
+      ? "Exact price or subscription terms must be verified on the provider page."
+      : null,
     isDurationPending(course) ? "Workload must be checked before committing time." : null,
     course.prerequisitesBullets.length === 0 ? "Prerequisites should be verified on the provider page." : null,
     course.syllabusBullets.length === 0 ? "Current syllabus should be verified on the provider page." : null
@@ -226,8 +291,9 @@ export const getDecisionSummary = (left: Course, right: Course) => {
           ]
         : ["All displayed criteria have enough catalog evidence for a factual comparison."],
     fitFraming: [
+      "Compare the verified payment amount, renewal cadence, and what each path covers.",
       "Choose based on your current level, time commitment, and need for certificate visibility.",
-      "Use the provider page to verify volatile details before enrolling.",
+      "Use provider checkout to confirm the final transaction and regional terms.",
       "The comparison is factual and does not rank one course above the other."
     ]
   };
@@ -275,8 +341,33 @@ export const buildComparisonRows = (left: Course, right: Course): ComparisonRow[
       (course.practicalWorkBullets?.length ?? 0) > 0
   );
 
+  const leftPricingOptions = getActionablePricingOptions(left);
+  const rightPricingOptions = getActionablePricingOptions(right);
+  const pricingRow: RawComparisonRow = {
+    label: "Verified pricing",
+    left: formatCoursePricing(left),
+    right: formatCoursePricing(right),
+    comparable:
+      (leftPricingOptions.length > 0 && rightPricingOptions.length > 0) ||
+      (!isExactPricePending(left) && !isExactPricePending(right)),
+    equal:
+      leftPricingOptions.length > 0 && rightPricingOptions.length > 0
+        ? equalPricingOptions(leftPricingOptions, rightPricingOptions)
+        : left.priceModel === right.priceModel &&
+          left.priceAmount === right.priceAmount &&
+          left.currency === right.currency &&
+          left.priceInterval === right.priceInterval,
+    sameInterpretation:
+      "Verified amount, cadence, payment model, and scope match for the displayed paths.",
+    differentInterpretation:
+      "The verified commitments differ in amount, cadence, payment model, scope, or available paths.",
+    uncertainInterpretation:
+      "Actionable source-backed pricing is unavailable for one or both options."
+  };
+
   const rows: RawComparisonRow[] = bothHaveDecisionDataV2
     ? [
+        pricingRow,
         {
           label: "Offering / credential",
           left: formatOfferingCredential(left),
@@ -371,20 +462,7 @@ export const buildComparisonRows = (left: Course, right: Course): ComparisonRow[
         }
       ]
     : [
-        {
-          label: "Price",
-          left: left.priceText,
-          right: right.priceText,
-          comparable: !isExactPricePending(left) && !isExactPricePending(right),
-          equal:
-            left.priceModel === right.priceModel &&
-            left.priceAmount === right.priceAmount &&
-            left.currency === right.currency &&
-            left.priceInterval === right.priceInterval,
-          sameInterpretation: "Verified price data does not differentiate these options.",
-          differentInterpretation: "Verified cost structure differs and may affect fit.",
-          uncertainInterpretation: "Exact comparable pricing is unavailable; verify provider terms."
-        },
+        pricingRow,
         {
           label: "Duration",
           left: left.durationText,
@@ -523,6 +601,13 @@ export const buildComparisonRows = (left: Course, right: Course): ComparisonRow[
 };
 
 export const getPendingDataRisks = (items: Course[]) => {
+  const observedDates = Array.from(
+    new Set(
+      items.flatMap((course) =>
+        getActionablePricingOptions(course).map((option) => option.observedAt)
+      )
+    )
+  ).sort();
   const risks = [
     items.some(isExactPricePending)
       ? "Exact price: current amount or subscription terms are not verified for one or both courses."
@@ -545,7 +630,10 @@ export const getPendingDataRisks = (items: Course[]) => {
     )
       ? "Course details: verify any incomplete prerequisites or learning topics on the provider pages."
       : null,
-    "Provider details can change; confirm current terms and availability before enrolling."
+    items.every((course) => !isExactPricePending(course)) && observedDates.length > 0
+      ? `Pricing was checked ${observedDates.join(" and ")}; region, taxes, eligibility, and checkout terms may vary.`
+      : null,
+    "Provider details can change; confirm final checkout terms and availability before enrolling."
   ].filter((risk): risk is string => risk !== null);
 
   return risks;
@@ -554,7 +642,7 @@ export const getPendingDataRisks = (items: Course[]) => {
 export const getVerifyBeforeEnrollingItems = (course: Course) => [
   isExactPricePending(course)
     ? "Confirm exact price, trial terms, and subscription renewal before enrolling."
-    : "Confirm the listed price model is still current on the provider page.",
+    : `Confirm the final checkout amount; pricing was observed ${getActionablePricingOptions(course)[0]?.observedAt ?? "on the provider page"}.`,
   course.certificate
     ? "Check certificate terms, eligibility, and whether payment is required."
     : "Verify whether a certificate is available and under what terms.",

--- a/src/lib/decision-support.ts
+++ b/src/lib/decision-support.ts
@@ -46,6 +46,7 @@ export const getActionablePricingOptions = (course: Course) =>
         (option) =>
           option.amount > 0 &&
           option.normalizedUsdAmount > 0 &&
+          Boolean(option.actionUrl) &&
           option.evidenceUrls.length > 0 &&
           Boolean(option.observedAt)
       )

--- a/src/lib/schema/course.ts
+++ b/src/lib/schema/course.ts
@@ -22,6 +22,26 @@ const CostModelSchema = z.object({
   text: z.string().min(1)
 });
 
+const PricingOptionSchema = z.object({
+  id: z.string().min(1),
+  model: z.enum(["one_time", "subscription", "platform_subscription", "free_audit"]),
+  amount: z.number().nonnegative(),
+  currency: z.string().length(3),
+  normalizedUsdAmount: z.number().nonnegative(),
+  cadence: z.enum(["one_time", "month", "year", "other"]),
+  scope: z.string().min(1),
+  normalizationBasis: z.enum(["provider_published_usd", "currency_converted"]),
+  evidenceUrls: z.array(z.string().url()).min(1),
+  observedAt: z.string().date(),
+  referenceMarket: z.string().min(1).nullable(),
+  accessContext: z.enum([
+    "public_provider_page",
+    "public_provider_checkout",
+    "account_visible_enrollment"
+  ]),
+  conditions: z.string().min(1).nullable()
+});
+
 export const CourseSchema = z.object({
   id: z.string(),
   platform: z.string(),
@@ -51,6 +71,7 @@ export const CourseSchema = z.object({
   practicalWorkBullets: z.array(z.string()).default([]),
   credential: CredentialSchema.nullable().default(null),
   costModel: CostModelSchema.nullable().default(null),
+  pricingOptions: z.array(PricingOptionSchema).default([]),
   source: z.enum(["manual", "edx", "coursera", "coursera-curated", "other"]),
 });
 

--- a/src/lib/schema/course.ts
+++ b/src/lib/schema/course.ts
@@ -31,6 +31,7 @@ const PricingOptionSchema = z.object({
   cadence: z.enum(["one_time", "month", "year", "other"]),
   scope: z.string().min(1),
   normalizationBasis: z.enum(["provider_published_usd", "currency_converted"]),
+  actionUrl: z.string().url(),
   evidenceUrls: z.array(z.string().url()).min(1),
   observedAt: z.string().date(),
   referenceMarket: z.string().min(1).nullable(),

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -39,6 +39,24 @@ export type Course = {
     type: "free" | "one_time" | "subscription" | "paid_certificate" | "other";
     text: string;
   } | null;
+  pricingOptions?: Array<{
+    id: string;
+    model: "one_time" | "subscription" | "platform_subscription" | "free_audit";
+    amount: number;
+    currency: string;
+    normalizedUsdAmount: number;
+    cadence: "one_time" | "month" | "year" | "other";
+    scope: string;
+    normalizationBasis: "provider_published_usd" | "currency_converted";
+    evidenceUrls: string[];
+    observedAt: string;
+    referenceMarket: string | null;
+    accessContext:
+      | "public_provider_page"
+      | "public_provider_checkout"
+      | "account_visible_enrollment";
+    conditions: string | null;
+  }>;
   externalUrl: string;
   verifiedFields?: Partial<
     Record<
@@ -57,7 +75,8 @@ export type Course = {
       | "toolsTechnologies"
       | "practicalWork"
       | "credential"
-      | "costModel",
+      | "costModel"
+      | "pricingOptions",
       boolean
     >
   >;

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -48,6 +48,7 @@ export type Course = {
     cadence: "one_time" | "month" | "year" | "other";
     scope: string;
     normalizationBasis: "provider_published_usd" | "currency_converted";
+    actionUrl: string;
     evidenceUrls: string[];
     observedAt: string;
     referenceMarket: string | null;


### PR DESCRIPTION
Closes #97.

## What changed

- adds a structured multi-path pricing contract with USD normalization, payment model, cadence, scope, provenance, observation date, market context, access context, and conditional terms
- curates pricing for exactly the four approved Phase 1B pilot courses
- makes pricing a hard decision-readiness gate while preserving the existing 5/7 Phase 1B.2 dimension gate
- puts pricing commitments before provider links and includes pricing in deterministic Same/Different/Insufficient data comparison semantics
- preserves mixed pilot/non-pilot behavior with an explicit insufficient-data state
- records pricing evidence, limitations, and intentionally excluded paths in `docs/pricing-phase-1b3-pilot.md`
- updates durable current-state, roadmap, readiness, and product-decision documentation

## Pilot pricing evidence

- AI For Everyone: $49 USD one-time for 180 days of certificate eligibility
- Deep Learning Specialization: $30 USD/month through DeepLearning.AI Pro
- Google Cybersecurity: $49 USD/month in the U.S./Canada, plus a verified $59 USD/month Coursera Plus alternative
- IBM Cybersecurity Analyst: $59 USD/month through verified Coursera Plus inclusion

Temporary promotions, pace-derived totals, conditional audit paths, localized checkout amounts presented as universal, and subscription amounts without current official evidence were excluded.

## User impact

Users can now compare the current economic commitment, renewal cadence, coverage, alternatives, freshness, and regional context inside Skills Compare. Provider pages remain the final checkout confirmation rather than the place where the comparison must be performed.

## Validation

- `corepack pnpm validate:data` — pass (pricing hard gate + 5/7 pass for both required pairs; 19 courses valid)
- `corepack pnpm report:data-quality` — pass (4/19 structured pricing coverage; no structural regressions)
- `corepack pnpm exec tsc --noEmit` — canonical Windows launcher could not resolve `tsc`; approved fallback `node node_modules/typescript/bin/tsc --noEmit` passed
- `corepack pnpm build` — pass
- desktop and 390px mobile browser checks for both required pilot comparisons — pass, no horizontal overflow, error overlay, or console errors
- mixed AI For Everyone / Supervised Machine Learning comparison — pass with explicit pricing `Insufficient data`
- home-route smoke check — pass

No dependencies, scraping, runtime APIs, affiliate logic, ranking, or non-pilot catalog migration were added. This PR is intentionally draft and must not be merged by the coding agent.