### PR TITLE
Phase 1B.4 — Rework compare decision hierarchy

### DIFF
--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -8,7 +8,7 @@ import {
   buildComparisonRows,
   formatPricingOption,
   getActionablePricingOptions,
-  getCourseFitBullets,
+  getCourseSnapshot,
   getDecisionSummary,
   getPendingDataRisks,
   isDurationPending,
@@ -17,8 +17,7 @@ import {
 import { courses } from "@/lib/catalog-adapter";
 import { trackOutboundCourseClick } from "@/lib/outbound-tracking";
 import {
-  EXTERNAL_PROVIDER_CONTEXT,
-  PROVIDER_CTA_LABEL
+  EXTERNAL_PROVIDER_CONTEXT
 } from "@/lib/providerCta";
 import type { Course } from "@/types/course";
 
@@ -29,13 +28,6 @@ const statusClasses = {
   Different: "bg-blue-50 text-blue-700 ring-blue-100",
   "Insufficient data": "bg-amber-50 text-amber-800 ring-amber-100"
 };
-
-const sectionGroups = [
-  { title: "Key similarities", key: "similarities" },
-  { title: "Key differences", key: "differences" },
-  { title: "What remains uncertain", key: "uncertainty" },
-  { title: "Practical fit framing", key: "fitFraming" }
-] as const;
 
 const decisionChecklist = [
   "I confirmed the final checkout amount and renewal terms.",
@@ -144,38 +136,73 @@ const PricingCommitmentCard = ({ course }: { course: Course }) => {
   );
 };
 
-const CourseFitCard = ({ course }: { course: Course }) => (
-  <div className="min-w-0 rounded-2xl border border-slate-200/80 bg-white p-5 shadow-[0_14px_36px_-30px_rgba(15,23,42,0.4)] sm:p-6">
-    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-      May fit you if
-    </p>
-    <h3 className="mt-2 break-words text-xl font-semibold tracking-tight text-slate-950">{course.title}</h3>
-    <ul className="mt-4 list-disc space-y-2 pl-5 text-sm leading-relaxed text-slate-600">
-      {getCourseFitBullets(course).map((bullet) => (
-        <li key={bullet}>{bullet}</li>
-      ))}
-    </ul>
-  </div>
-);
+const CourseSnapshotCard = ({ course }: { course: Course }) => {
+  const snapshot = getCourseSnapshot(course);
+
+  return (
+    <article className="min-w-0 rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_18px_45px_-36px_rgba(15,23,42,0.45)] sm:p-6">
+      <div className="flex min-w-0 flex-col gap-3 border-b border-slate-100 pb-5">
+        <h4 className="break-words text-xl font-semibold tracking-tight text-slate-950">
+          {course.title}
+        </h4>
+        <div className="flex flex-wrap gap-2 text-xs font-semibold">
+          <span className="rounded-full bg-blue-50 px-3 py-1.5 text-blue-700">
+            {snapshot.offeringType}
+          </span>
+        </div>
+        <div className="rounded-xl bg-slate-950 px-4 py-3 text-white">
+          <p className="text-[0.7rem] font-bold uppercase tracking-[0.16em] text-blue-300">
+            Price status
+          </p>
+          <ul className="mt-2 space-y-1 text-sm font-semibold leading-relaxed">
+            {snapshot.pricing.map((pricingPath) => (
+              <li key={pricingPath}>{pricingPath}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <dl className="mt-5 grid gap-4 text-sm sm:grid-cols-2">
+        <div>
+          <dt className="font-semibold text-slate-900">Workload</dt>
+          <dd className="mt-1 leading-relaxed text-slate-600">{snapshot.workload}</dd>
+        </div>
+        <div>
+          <dt className="font-semibold text-slate-900">Credential</dt>
+          <dd className="mt-1 leading-relaxed text-slate-600">{snapshot.credential}</dd>
+        </div>
+        <div className="sm:col-span-2">
+          <dt className="font-semibold text-slate-900">Starting point</dt>
+          <dd className="mt-1 leading-relaxed text-slate-600">{snapshot.startingPoint}</dd>
+        </div>
+        <div>
+          <dt className="font-semibold text-slate-900">Learning focus</dt>
+          <dd className="mt-1 leading-relaxed text-slate-600">{snapshot.learningFocus}</dd>
+        </div>
+        <div>
+          <dt className="font-semibold text-slate-900">Practical signal</dt>
+          <dd className="mt-1 leading-relaxed text-slate-600">{snapshot.practicalSignal}</dd>
+        </div>
+        <div className="sm:col-span-2">
+          <dt className="font-semibold text-slate-900">Important prerequisites</dt>
+          <dd className="mt-1 leading-relaxed text-slate-600">
+            {snapshot.prerequisiteSignal}
+          </dd>
+        </div>
+      </dl>
+
+      <p className="mt-5 rounded-xl border border-emerald-100 bg-emerald-50 px-4 py-3 text-sm font-medium leading-relaxed text-emerald-950">
+        {snapshot.fitSummary}
+      </p>
+    </article>
+  );
+};
 
 const CourseDecisionDetails = ({ course }: { course: Course }) => (
   <article className="min-w-0 rounded-2xl border border-slate-200/80 bg-white p-5 shadow-[0_14px_36px_-30px_rgba(15,23,42,0.4)] sm:p-6">
-    <div className="space-y-2">
-      <h3 className="break-words text-xl font-semibold tracking-tight text-slate-950">{course.title}</h3>
-      <p className="text-sm leading-relaxed text-slate-600">
-        {course.shortDescription ?? "Description unavailable."}
-      </p>
-      <div className="flex flex-wrap gap-2 pt-2 text-xs font-semibold text-slate-700">
-        {course.offeringType ? (
-          <span className="rounded-full bg-blue-50 px-3 py-1.5 capitalize text-blue-700">
-            {course.offeringType.replaceAll("_", " ")}
-          </span>
-        ) : null}
-        {course.workload ? (
-          <span className="rounded-full bg-slate-100 px-3 py-1.5">{course.workload.text}</span>
-        ) : null}
-      </div>
-    </div>
+    <h3 className="break-words text-xl font-semibold tracking-tight text-slate-950">
+      {course.title}
+    </h3>
 
     <div className="mt-5 grid gap-5 md:grid-cols-2">
       <div>
@@ -236,19 +263,10 @@ const CourseDecisionDetails = ({ course }: { course: Course }) => (
       </div>
     </div>
 
-    <div className="mt-5 grid gap-3 sm:flex sm:flex-wrap">
-      <a
-        href={course.externalUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={() => trackOutboundCourseClick(course, EXTERNAL_PROVIDER_CONTEXT.compare)}
-        className="min-h-11 rounded-lg bg-blue-600 px-4 py-2 text-center text-sm font-semibold text-white hover:bg-blue-500"
-      >
-        {PROVIDER_CTA_LABEL}
-      </a>
+    <div className="mt-5">
       <Link
         href={`/courses/${course.id}`}
-        className="min-h-11 rounded-lg border border-slate-200 px-4 py-2 text-center text-sm font-semibold text-slate-700 hover:border-slate-300"
+        className="inline-flex min-h-11 items-center rounded-lg border border-slate-200 px-4 py-2 text-center text-sm font-semibold text-slate-700 hover:border-slate-300"
       >
         View course details
       </Link>
@@ -337,17 +355,54 @@ export default function CompareClient() {
           </p>
         </div>
 
-        <div className="mt-6 grid gap-3 md:grid-cols-2 sm:mt-8 sm:gap-4">
-          {sectionGroups.map((group) => (
-            <div key={group.key} className="rounded-2xl border border-white/10 bg-white/[0.06] p-4 sm:p-5">
-              <h4 className="font-semibold text-white">{group.title}</h4>
-              <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed text-slate-300 marker:text-blue-300">
-                {decisionSummary[group.key].map((item) => (
-                  <li key={item}>{item}</li>
-                ))}
-              </ul>
-            </div>
-          ))}
+        <div className="mt-6 grid gap-3 sm:mt-8 sm:gap-4 lg:grid-cols-[1.45fr_0.8fr]">
+          <div className="rounded-2xl border border-blue-400/30 bg-blue-400/[0.11] p-4 sm:p-6 lg:row-span-2">
+            <p className="text-xs font-bold uppercase tracking-[0.16em] text-blue-300">
+              Highest-value differences
+            </p>
+            <ul className="mt-4 list-disc space-y-3 pl-5 text-base leading-relaxed text-white marker:text-blue-300">
+              {decisionSummary.differences.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/[0.05] p-4 sm:p-5">
+            <h4 className="font-semibold text-white">What remains uncertain</h4>
+            <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed text-slate-300 marker:text-amber-300">
+              {decisionSummary.uncertainty.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/[0.05] p-4 sm:p-5">
+            <h4 className="font-semibold text-white">Shared context</h4>
+            <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed text-slate-400 marker:text-slate-500">
+              {decisionSummary.similarities.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section aria-labelledby="course-snapshot-heading">
+        <div className="max-w-3xl">
+          <p className="text-xs font-bold uppercase tracking-[0.18em] text-blue-700">
+            At a glance
+          </p>
+          <h3
+            id="course-snapshot-heading"
+            className="mt-2 text-2xl font-semibold tracking-tight text-slate-950 sm:text-3xl"
+          >
+            Course snapshot
+          </h3>
+          <p className="mt-2 text-sm leading-relaxed text-slate-600">
+            Start with the verified facts most likely to shape the choice, then inspect the evidence and detailed criteria below.
+          </p>
+        </div>
+        <div className="mt-5 grid min-w-0 gap-4 lg:grid-cols-2">
+          <CourseSnapshotCard course={leftCourse} />
+          <CourseSnapshotCard course={rightCourse} />
         </div>
       </section>
 
@@ -367,51 +422,6 @@ export default function CompareClient() {
           <PricingCommitmentCard course={leftCourse} />
           <PricingCommitmentCard course={rightCourse} />
         </div>
-      </section>
-
-      <section className="rounded-2xl border border-blue-200/80 bg-blue-50/60 p-5 sm:p-6">
-        <h3 className="text-lg font-semibold text-slate-900">Open provider pages</h3>
-        <p className="mt-2 text-sm leading-relaxed text-slate-600">
-          Use provider pages to confirm the final transaction, taxes, eligibility, and availability; the comparison above contains the current verified pricing evidence.
-        </p>
-        <div className="mt-4 grid gap-3 sm:flex sm:flex-wrap">
-          <a
-            href={leftCourse.externalUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => trackOutboundCourseClick(leftCourse, EXTERNAL_PROVIDER_CONTEXT.compare)}
-            aria-label={`Open provider page for ${leftCourse.title}`}
-            className="min-h-11 rounded-lg bg-blue-600 px-5 py-2 text-center text-sm font-semibold text-white hover:bg-blue-500"
-          >
-            Open first provider
-          </a>
-          <a
-            href={rightCourse.externalUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => trackOutboundCourseClick(rightCourse, EXTERNAL_PROVIDER_CONTEXT.compare)}
-            aria-label={`Open provider page for ${rightCourse.title}`}
-            className="min-h-11 rounded-lg bg-blue-600 px-5 py-2 text-center text-sm font-semibold text-white hover:bg-blue-500"
-          >
-            Open second provider
-          </a>
-          <button
-            type="button"
-            onClick={handleChangeCourses}
-            className="min-h-11 rounded-lg border border-slate-200 px-5 py-2 text-sm font-semibold text-slate-700 hover:border-slate-300"
-          >
-            Change courses
-          </button>
-        </div>
-      </section>
-
-      <section className="rounded-2xl border border-amber-200 bg-amber-50 p-4 sm:p-5">
-        <h3 className="text-lg font-semibold text-amber-950">Data to verify before enrolling</h3>
-        <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed text-amber-900">
-          {pendingRisks.map((risk) => (
-            <li key={risk}>{risk}</li>
-          ))}
-        </ul>
       </section>
 
       <section className="overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-[0_18px_45px_-36px_rgba(15,23,42,0.45)]">
@@ -444,29 +454,94 @@ export default function CompareClient() {
         </div>
       </section>
 
-      <section className="grid gap-4 lg:grid-cols-2">
-        <CourseFitCard course={leftCourse} />
-        <CourseFitCard course={rightCourse} />
-      </section>
-
-      <section className="grid gap-4 lg:grid-cols-2">
-        <CourseDecisionDetails course={leftCourse} />
-        <CourseDecisionDetails course={rightCourse} />
-      </section>
-
-      <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5">
-        <h3 className="text-lg font-semibold text-slate-900">Before you choose</h3>
-        <div className="mt-4 grid gap-3 md:grid-cols-2">
-          {decisionChecklist.map((item) => (
-            <div key={item} className="flex gap-3 rounded-xl border border-slate-100 bg-slate-50/80 p-3.5 text-sm text-slate-700">
-              <span aria-hidden="true" className="mt-0.5 h-5 w-5 shrink-0 rounded-md border border-slate-300 bg-white" />
-              <span>{item}</span>
-            </div>
-          ))}
+      <section aria-labelledby="course-content-heading">
+        <div className="max-w-3xl">
+          <p className="text-xs font-bold uppercase tracking-[0.18em] text-blue-700">
+            Detailed course content
+          </p>
+          <h3
+            id="course-content-heading"
+            className="mt-2 text-2xl font-semibold tracking-tight text-slate-950"
+          >
+            Inspect what each course covers
+          </h3>
+          <p className="mt-2 text-sm leading-relaxed text-slate-600">
+            Review curriculum, starting-point detail, named tools, and practical work after the decision-level comparison.
+          </p>
+        </div>
+        <div className="mt-5 grid gap-4 lg:grid-cols-2">
+          <CourseDecisionDetails course={leftCourse} />
+          <CourseDecisionDetails course={rightCourse} />
         </div>
       </section>
 
       <AdPlaceholder />
+
+      <section className="rounded-[1.75rem] border border-slate-200 bg-white p-5 shadow-[0_18px_45px_-36px_rgba(15,23,42,0.45)] sm:p-7">
+        <div className="max-w-3xl">
+          <p className="text-xs font-bold uppercase tracking-[0.18em] text-blue-700">
+            Final verification
+          </p>
+          <h3 className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
+            Verify current terms, then act
+          </h3>
+          <p className="mt-2 text-sm leading-relaxed text-slate-600">
+            Provider pages are the final source for checkout totals, taxes, eligibility, regional terms, and availability.
+          </p>
+        </div>
+
+        <div className="mt-5 rounded-2xl border border-amber-200 bg-amber-50 p-4 sm:p-5">
+          <h4 className="text-lg font-semibold text-amber-950">Data to verify before enrolling</h4>
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed text-amber-900">
+            {pendingRisks.map((risk) => (
+              <li key={risk}>{risk}</li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="mt-5 rounded-2xl border border-slate-200 bg-slate-50/70 p-4 sm:p-5">
+          <h4 className="text-lg font-semibold text-slate-900">Before you choose</h4>
+          <div className="mt-4 grid gap-3 md:grid-cols-2">
+            {decisionChecklist.map((item) => (
+              <div key={item} className="flex gap-3 rounded-xl border border-slate-100 bg-white p-3.5 text-sm text-slate-700">
+                <span aria-hidden="true" className="mt-0.5 h-5 w-5 shrink-0 rounded-md border border-slate-300 bg-white" />
+                <span>{item}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-5 grid gap-3 sm:flex sm:flex-wrap">
+          <a
+            href={leftCourse.externalUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => trackOutboundCourseClick(leftCourse, EXTERNAL_PROVIDER_CONTEXT.compare)}
+            aria-label={`Open provider page for ${leftCourse.title}`}
+            className="min-h-11 rounded-lg bg-blue-600 px-5 py-2 text-center text-sm font-semibold text-white hover:bg-blue-500"
+          >
+            Open first provider
+          </a>
+          <a
+            href={rightCourse.externalUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => trackOutboundCourseClick(rightCourse, EXTERNAL_PROVIDER_CONTEXT.compare)}
+            aria-label={`Open provider page for ${rightCourse.title}`}
+            className="min-h-11 rounded-lg bg-blue-600 px-5 py-2 text-center text-sm font-semibold text-white hover:bg-blue-500"
+          >
+            Open second provider
+          </a>
+          <button
+            type="button"
+            onClick={handleChangeCourses}
+            className="min-h-11 rounded-lg border border-slate-200 px-5 py-2 text-sm font-semibold text-slate-700 hover:border-slate-300"
+          >
+            Change courses
+          </button>
+        </div>
+      </section>
+
     </section>
   );
 }

--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -475,8 +475,6 @@ export default function CompareClient() {
         </div>
       </section>
 
-      <AdPlaceholder />
-
       <section className="rounded-[1.75rem] border border-slate-200 bg-white p-5 shadow-[0_18px_45px_-36px_rgba(15,23,42,0.45)] sm:p-7">
         <div className="max-w-3xl">
           <p className="text-xs font-bold uppercase tracking-[0.18em] text-blue-700">
@@ -541,6 +539,8 @@ export default function CompareClient() {
           </button>
         </div>
       </section>
+
+      <AdPlaceholder />
 
     </section>
   );

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,6 +1,6 @@
 # Current State
 
-Last updated after implementing the Phase 1B.3 pricing pilot for product review.
+Last updated after implementing the Phase 1B.4 comparison-hierarchy pilot for product review.
 
 ## Product State
 
@@ -11,6 +11,15 @@ The current UI is English-first. The product supports skill discovery, curated c
 Recent product review exposed an important distinction: source-trusted catalog data is not automatically decision-useful data. The product must not only avoid inventing facts; it must preserve enough structured provider-backed information to help a user actually choose between courses.
 
 ## Latest Completed Initiatives
+
+### Phase 1B.4 — Compare Decision Hierarchy — Issue #99
+
+Key outcomes:
+
+- Compare now follows the intended decision flow: decision summary, at-a-glance course snapshot, detailed pricing evidence, criteria, curriculum detail, then final verification and provider actions.
+- The snapshot consolidates verified offering, starting point, pricing, workload, credential, learning-focus, practical-work, prerequisite, and fit signals without adding catalog fields or recommendation claims.
+- The standalone compare-page fit section was removed, while unknown or unverified values remain explicitly uncertain for mixed pilot/non-pilot comparisons.
+- Desktop and mobile checks cover both approved pilot pairs and a mixed pilot/non-pilot regression comparison without horizontal overflow or browser errors.
 
 ### Phase 1B.3 — Pricing as Core Decision Data — Issue #97
 
@@ -61,9 +70,9 @@ Earlier completed initiatives, including Phase 1 Source Verification Batches A/B
 
 - **Phase 0 — MVP:** complete for the current MVP scope.
 - **Phase 1A — Source Trust:** complete for the current 19-course curated MVP catalog; ongoing maintenance only.
-- **Phase 1B — Decision-Grade Data:** Phase 1B.1, Phase 1B.2, and the Phase 1B.3 pricing pilot are implemented; product review must decide whether and how to migrate later batches.
+- **Phase 1B — Decision-Grade Data:** Phase 1B.1 through Phase 1B.4 are implemented for the four-course pilot; product review must decide whether and how to migrate later batches.
 - **Phase 2 — Monetization:** gated / not started. It activates only when a real auditable affiliate/referral program exists and does not block Phase 3.
-- **Phase 3 — Discovery and SEO:** active, with the indexable-surface foundation complete. Further content/traffic expansion is paused until the Phase 1B.2 pilot proves that core comparisons provide meaningful decision value.
+- **Phase 3 — Discovery and SEO:** active, with the indexable-surface foundation complete. Further content/traffic expansion is paused until product review of the Phase 1B.4 pilot confirms that core comparisons provide meaningful decision value.
 - **Phase 4 — Recommendation:** later, gated behind explicit criteria and trustworthy signals.
 - **Phase 5 — Robust Product:** only if traction justifies the additional architecture.
 
@@ -107,7 +116,7 @@ Pilot scope is exactly four courses and two comparisons:
 
 The gate is internal product-quality validation, not a visible ranking or course score.
 
-## After Phase 1B.3
+## After Phase 1B.4
 
 Return to product review. Do not automatically migrate all 19 courses and do not resume SEO content expansion automatically.
 

--- a/docs/MVP_READINESS.md
+++ b/docs/MVP_READINESS.md
@@ -4,9 +4,9 @@
 
 - Skills Compare is an English-first product for finding skills, reviewing relevant online courses, comparing two options, and opening the original provider page.
 - Phase 0 is complete for the current MVP scope.
-- Phase 1A source trust is complete for the current 19-course catalog; the Phase 1B.3 pricing pilot extends the Phase 1B.2 decision-data pilot on exactly four courses and awaits product review before any wider migration.
+- Phase 1A source trust is complete for the current 19-course catalog; the Phase 1B.4 comparison-hierarchy pilot builds on the Phase 1B.2 decision-data and Phase 1B.3 pricing work for exactly four courses and awaits product review before any wider migration.
 - Phase 2 monetization is gated until a real auditable affiliate/referral program exists and does not block Phase 3.
-- Phase 3 Discovery and SEO has its indexable-surface foundation in place; content expansion remains paused pending review of the Phase 1B.2 pilot.
+- Phase 3 Discovery and SEO has its indexable-surface foundation in place; content expansion remains paused pending review of the Phase 1B.4 pilot.
 - The normalized catalog contains 19 curated courses.
 - 17 courses are `partially_verified`; 2 remain `pending` because the exact recorded offering could not be confirmed from a current official source.
 - Source URL mismatches are 0 after Phase 1 Source Verification — Coverage Batch B.
@@ -19,6 +19,7 @@
 - Decision-focused visual polish is merged across the core Search -> Compare -> Decide journey.
 - Decision Data Contract v2 preserves provider-backed offering, workload, tool, practical-work, credential, and cost-model signals for the four-course pilot.
 - Structured pricing preserves source-backed payable paths, USD amounts, cadence, scope, provenance, freshness, and regional/access context for the same four-course pilot.
+- Compare presents decision differences and a source-backed at-a-glance snapshot before detailed pricing, criteria, curriculum, and final provider verification.
 
 ## Trust and Data Quality Reality
 
@@ -40,7 +41,7 @@
 - Skill pages show available courses from the normalized catalog.
 - Course cards expose core decision facts and prioritize compare selection over outbound provider clicks.
 - Course detail pages are decision-support pages with fit framing, verify-before-enrolling checks, provider CTA, compare action, learning content, and key facts.
-- Compare supports two-course comparison with deterministic decision summary, verification risks, fit context, deep comparison details, checklist, and outbound provider CTAs. Pilot comparisons additionally expose the seven approved decision dimensions.
+- Compare supports two-course comparison with a deterministic decision summary, consolidated fit context, deep comparison details, final verification checklist, and outbound provider CTAs. Pilot comparisons additionally expose an at-a-glance snapshot and the seven approved decision dimensions.
 - The compare page uses mobile-friendly stacked content instead of relying on a cramped desktop table.
 - Compare selection persists across navigation and recent visits for up to 24 hours, with an explicit returning-selection state and clear action.
 - Canonical and Open Graph metadata foundations are present for core pages.
@@ -78,4 +79,4 @@ Use the documented repository-local TypeScript fallback only when the normal pnp
 
 ## Active Near-Term Gate
 
-Product review must evaluate the Phase 1B.3 pricing pilot before approving any migration of the remaining 15 catalog records or resuming Phase 3 content expansion. Phase 2 monetization remains gated until a real program exists.
+Product review must evaluate the Phase 1B.4 comparison-hierarchy pilot before approving any migration of the remaining 15 catalog records or resuming Phase 3 content expansion. Phase 2 monetization remains gated until a real program exists.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,7 +24,7 @@ Future work in this area should be limited to concrete usability defects or regr
 
 ## Phase 1 — Real Data
 
-**Status: Phase 1A source trust complete; Phase 1B.3 pricing pilot implemented and awaiting product review.**
+**Status: Phase 1A source trust complete; Phase 1B.4 comparison-hierarchy pilot implemented and awaiting product review.**
 
 Goal: make the catalog both trustworthy and useful enough to support real user decisions.
 
@@ -49,6 +49,7 @@ Completed:
 - **Phase 1B.1 — Comparison Integrity Fix** in PR #93: unknown or unverified values no longer create confident `Same` / `Different` claims; runtime mapping now preserves nullable and verification semantics needed for trustworthy comparisons.
 - **Phase 1B.2 — Decision Data Contract v2 pilot** in issue #94: the structured contract and four-course migration are implemented, both required comparisons pass the internal 5/7 gate, and unsupported dimensions remain explicitly insufficient.
 - **Phase 1B.3 — Pricing as Core Decision Data** in issue #97: structured multi-path pricing is implemented for the same four-course pilot, pricing is a hard gate in addition to the unchanged 5/7 gate, and the comparison surfaces exact USD commitments with provenance and regional context.
+- **Phase 1B.4 — Compare Decision Hierarchy** in issue #99: the compare flow now moves from a deterministic decision summary into a source-backed course snapshot, detailed pricing evidence, criteria, curriculum detail, and final provider verification for the same four-course pilot.
 
 Do not migrate the remaining catalog until the pilot proves that the new contract materially improves decision quality without inventing information.
 
@@ -70,7 +71,7 @@ Do not implement speculative affiliate parameters, fake discounts, paid ranking,
 
 ## Phase 3 — Discovery and SEO
 
-**Status: active; indexable-surface foundation complete, content expansion paused pending product review of the Phase 1B.2 pilot.**
+**Status: active; indexable-surface foundation complete, content expansion paused pending product review of the Phase 1B.4 pilot.**
 
 Goal: grow qualified organic traffic by making useful decision surfaces discoverable and by adding genuinely differentiated content only when the catalog supports it.
 
@@ -78,7 +79,7 @@ Completed:
 
 - **Indexable Surface Foundation (Batch A)** in PR #92: sitemap now promotes the homepage, canonical skill pages, and canonical course-detail pages; `/compare` and generated template SEO routes are no longer promoted in the sitemap; generated routes remain accessible with `noindex, follow`; prominent homepage SEO links target canonical skill pages.
 
-Next SEO work must wait for product review after the Phase 1B.2 pilot. Do not create new SEO page types, keyword-scaled content, or indexable template volume merely because the technical foundation exists.
+Next SEO work must wait for product review after the Phase 1B.4 pilot. Do not create new SEO page types, keyword-scaled content, or indexable template volume merely because the technical foundation exists.
 
 ## Phase 4 — Recommendation
 
@@ -111,8 +112,8 @@ Do not build Phase 5 architecture to solve hypothetical scale.
 ## Immediate Sequence
 
 1. Maintain conservative Phase 1A source trust without reopening verification work for its own sake.
-2. Review the completed Phase 1B.3 four-course pricing pilot against the explicit decision-readiness and product acceptance criteria.
+2. Review the completed Phase 1B.4 four-course comparison-hierarchy pilot against the explicit decision-readiness and product acceptance criteria.
 3. Do not begin catalog-wide migration without a new product decision.
-4. Keep Phase 3 content/traffic expansion paused until the pricing pilot shows that core comparison pages provide meaningful decision value.
+4. Keep Phase 3 content/traffic expansion paused until the comparison-hierarchy pilot shows that core comparison pages provide meaningful decision value.
 5. If the pilot succeeds, migrate the remaining catalog only in small auditable batches and then return to selective people-first SEO work.
 6. Activate Phase 2 monetization only when a real program and appropriate disclosures are ready; it is not a prerequisite for Phase 3.

--- a/src/lib/decision-support.ts
+++ b/src/lib/decision-support.ts
@@ -10,6 +10,18 @@ export type ComparisonRow = {
   interpretation: string;
 };
 
+export type CourseSnapshot = {
+  offeringType: string;
+  startingPoint: string;
+  pricing: string[];
+  workload: string;
+  credential: string;
+  learningFocus: string;
+  practicalSignal: string;
+  prerequisiteSignal: string;
+  fitSummary: string;
+};
+
 export const CORE_DECISION_DIMENSIONS = [
   { key: "offeringCredential", label: "Offering / credential type" },
   { key: "workload", label: "Workload / time commitment" },
@@ -25,6 +37,7 @@ export type CoreDecisionDimension = (typeof CORE_DECISION_DIMENSIONS)[number]["k
 export type PricingOption = NonNullable<Course["pricingOptions"]>[number];
 
 const normalize = (value: string) => value.trim().toLowerCase();
+const STARTS_WITH_VOWEL = /^[aeiou]/i;
 
 type VerifiedField = keyof NonNullable<Course["verifiedFields"]>;
 
@@ -122,6 +135,78 @@ const formatOfferingType = (course: Course) => {
   } as const;
 
   return course.offeringType ? labels[course.offeringType] : "Offering type not verified";
+};
+
+const summarizeSnapshotBullets = (items: string[], fallback: string) =>
+  items.length > 0 ? items.slice(0, 2).join("; ") : fallback;
+
+const withIndefiniteArticle = (value: string) =>
+  `${STARTS_WITH_VOWEL.test(value) ? "an" : "a"} ${value}`;
+
+export const getCourseSnapshot = (course: Course): CourseSnapshot => {
+  const pricingOptions = getActionablePricingOptions(course);
+  const offeringVerified =
+    isFieldVerified(course, "offeringType") && course.offeringType != null;
+  const levelVerified =
+    isFieldVerified(course, "level") && course.level !== "Unknown";
+  const prerequisitesVerified =
+    isFieldVerified(course, "prerequisites") &&
+    course.prerequisitesBullets.length > 0;
+  const learningFocusVerified =
+    isFieldVerified(course, "syllabus") && course.syllabusBullets.length > 0;
+  const practicalWorkVerified =
+    isFieldVerified(course, "practicalWork") &&
+    (course.practicalWorkBullets?.length ?? 0) > 0;
+  const credentialVerified =
+    isFieldVerified(course, "credential") && course.credential != null;
+
+  const offeringType = offeringVerified
+    ? formatOfferingType(course)
+    : "Offering type not verified";
+  const prerequisiteSignal = prerequisitesVerified
+    ? summarizeSnapshotBullets(course.prerequisitesBullets, "Prerequisites not verified")
+    : "Prerequisites not verified";
+  const descriptorParts = [
+    levelVerified ? course.level.toLowerCase() : null,
+    offeringVerified ? offeringType.toLowerCase() : "course option"
+  ].filter((part): part is string => part !== null);
+  const fitDescriptor = withIndefiniteArticle(descriptorParts.join(" "));
+  const handsOnFit = practicalWorkVerified ? " with verified hands-on work" : "";
+  const fitSummary = prerequisitesVerified
+    ? `Good fit if you want ${fitDescriptor}${handsOnFit} and this starting point matches you: ${prerequisiteSignal}.`
+    : !isDurationPending(course)
+      ? `Good fit if you want ${fitDescriptor}${handsOnFit} and can commit to ${course.durationText.toLowerCase()}.`
+      : `Good fit if you want ${fitDescriptor}${handsOnFit} and are comfortable verifying the starting point and workload.`;
+
+  return {
+    offeringType,
+    startingPoint: levelVerified
+      ? `${course.level} level`
+      : "Starting level not verified",
+    pricing:
+      pricingOptions.length > 0
+        ? pricingOptions.map(formatPricingOption)
+        : ["Actionable source-backed pricing not verified"],
+    workload: isDurationPending(course)
+      ? "Workload not verified"
+      : course.durationText,
+    credential: credentialVerified
+      ? (course.credential?.text ?? "Credential context not verified")
+      : course.certificate === true && isFieldVerified(course, "certificate")
+        ? "Certificate shown; credential context not verified"
+        : "Credential context not verified",
+    learningFocus: learningFocusVerified
+      ? summarizeSnapshotBullets(course.syllabusBullets, "Learning focus not verified")
+      : "Learning focus not verified",
+    practicalSignal: practicalWorkVerified
+      ? summarizeSnapshotBullets(
+          course.practicalWorkBullets ?? [],
+          "Practical work not verified"
+        )
+      : "Hands-on or practical work not verified",
+    prerequisiteSignal,
+    fitSummary
+  };
 };
 
 const formatOfferingCredential = (course: Course) =>
@@ -263,16 +348,40 @@ export const getPendingDataImpact = (course: Course) => {
 
 export const getDecisionSummary = (left: Course, right: Course) => {
   const rows = buildComparisonRows(left, right);
+  const priorityLabels = [
+    "Verified pricing",
+    "Workload",
+    "Duration",
+    "Starting point",
+    "Prerequisites",
+    "Offering / credential",
+    "Cost model",
+    "Practical work",
+    "Learning topics",
+    "Tools / technologies",
+    "Level",
+    "Certificate",
+    "Platform",
+    "Language",
+    "Rating / reviews"
+  ];
+  const priority = new Map(priorityLabels.map((label, index) => [label, index]));
+  const byDecisionPriority = (first: ComparisonRow, second: ComparisonRow) =>
+    (priority.get(first.label) ?? priorityLabels.length) -
+    (priority.get(second.label) ?? priorityLabels.length);
   const similarities = rows
     .filter((row) => row.status === "Same")
-    .slice(0, 3)
+    .sort(byDecisionPriority)
+    .slice(0, 2)
     .map((row) => `${row.label}: both courses show ${row.left}.`);
   const differences = rows
     .filter((row) => row.status === "Different")
-    .slice(0, 3)
+    .sort(byDecisionPriority)
+    .slice(0, 5)
     .map((row) => `${row.label}: ${row.left} vs ${row.right}.`);
   const uncertainLabels = rows
     .filter((row) => row.status === "Insufficient data")
+    .sort(byDecisionPriority)
     .map((row) => row.label.toLowerCase());
 
   return {
@@ -290,13 +399,7 @@ export const getDecisionSummary = (left: Course, right: Course) => {
             `Comparable data is insufficient for ${uncertainLabels.join(", ")}.`,
             "Those criteria are marked below so unknown values are not treated as matches or differences."
           ]
-        : ["All displayed criteria have enough catalog evidence for a factual comparison."],
-    fitFraming: [
-      "Compare the verified payment amount, renewal cadence, and what each path covers.",
-      "Choose based on your current level, time commitment, and need for certificate visibility.",
-      "Use provider checkout to confirm the final transaction and regional terms.",
-      "The comparison is factual and does not rank one course above the other."
-    ]
+        : ["All displayed criteria have enough catalog evidence for a factual comparison."]
   };
 };
 


### PR DESCRIPTION
Closes #99

## Before / after rationale

Before, the compare page repeated the same facts across the decision summary, pricing, fit cards, criteria, and course-detail cards. Generic provider actions and verification warnings also interrupted the flow before Skills Compare had delivered its full comparison value.

After, the page follows the approved decision sequence: deterministic decision summary → source-backed course snapshot → detailed pricing evidence → Same / Different / Insufficient data criteria → curriculum detail → final verification and provider actions. Major differences receive the strongest visual weight, while platform/language similarities remain secondary.

## What changed

- Added a two-column at-a-glance snapshot for offering type, starting point, current verified pricing paths, workload, credential context, learning focus, practical-work signal, prerequisites, and concise factual fit framing.
- Prioritized pricing/payment, workload, starting point, offering/credential, and cost-model differences in the deterministic decision summary.
- Removed the standalone compare-page “May fit you if” section and eliminated generic provider CTAs from the detailed course cards.
- Moved provider verification, the enrollment checklist, and generic provider actions after criteria and detailed course content.
- Preserved structured pricing evidence/actions, the pricing hard gate, the unchanged 5/7 gate, mixed pilot/non-pilot uncertainty behavior, and the existing detailed criteria.
- Updated durable roadmap/current-state/readiness documentation for Phase 1B.4.

## Product safeguards

- No catalog, schema, pricing contract, gate, SEO-generation input, dependency, recommendation, ranking, monetization, analytics, or provider data change.
- Unknown and unverified snapshot fields stay explicitly unknown.
- IBM’s displayed $59/month path remains labeled as Coursera Plus catalog access rather than a direct certificate price.

## Validation

- `corepack pnpm validate:data` — passed; 19 courses and both pilot gates passed.
- `corepack pnpm report:data-quality` — passed with no source or coverage regression.
- `corepack pnpm exec tsc --noEmit` — Windows launcher could not resolve `tsc`; the documented `node node_modules/typescript/bin/tsc --noEmit` fallback passed.
- `corepack pnpm build` — passed.
- Browser checks at 1440×1000 and 390×844 passed for both pilot pairs and AI For Everyone vs Supervised Machine Learning as the mixed pilot/non-pilot regression pair.
- Browser checks confirmed required snapshot facts, detailed pricing retention, final provider-action ordering, no standalone fit section, no horizontal overflow, no error overlays, and no console errors.

Changed files: 5.