### PR TITLE
Phase 1B.6: Add project management decision-grade pair

### DIFF
--- a/data/decision-grade-manifest.json
+++ b/data/decision-grade-manifest.json
@@ -7,7 +7,9 @@
     "google-data-analytics-google",
     "google-advanced-data-analytics-google",
     "aws-cloud-technical-essentials-aws",
-    "introduction-to-cloud-computing-ibm"
+    "introduction-to-cloud-computing-ibm",
+    "google-project-management-google",
+    "project-management-principles-practices-umci"
   ],
   "readinessPairs": [
     [
@@ -25,6 +27,10 @@
     [
       "aws-cloud-technical-essentials-aws",
       "introduction-to-cloud-computing-ibm"
+    ],
+    [
+      "google-project-management-google",
+      "project-management-principles-practices-umci"
     ]
   ]
 }

--- a/data/normalized/course-source-metadata.json
+++ b/data/normalized/course-source-metadata.json
@@ -288,12 +288,12 @@
     "sourceUrl": "https://www.coursera.org/professional-certificates/google-project-management",
     "sourceType": "official_provider_page",
     "verificationStatus": "partially_verified",
-    "lastVerifiedAt": "2026-06-06",
+    "lastVerifiedAt": "2026-08-27",
     "verifiedFields": {
       "title": true,
       "platform": true,
       "sourceUrl": true,
-      "price": false,
+      "price": true,
       "rating": false,
       "reviewCount": false,
       "duration": true,
@@ -301,9 +301,16 @@
       "language": true,
       "level": true,
       "syllabus": true,
-      "prerequisites": true
+      "prerequisites": true,
+      "offeringType": true,
+      "workload": true,
+      "toolsTechnologies": true,
+      "practicalWork": true,
+      "credential": true,
+      "costModel": true,
+      "pricingOptions": true
     },
-    "notes": "Source: official Coursera provider page. Verified title, platform/source URL, beginner level, English language, shareable certificate, 6 months at 10 hours/week workload signal, learning topics, and no degree/prior experience requirement. durationHours remains null because converting a monthly schedule to exact hours would be an estimate. Price, rating, and review count intentionally remain unknown/null because they are volatile."
+    "notes": "Sources: official Google Project Management Professional Certificate page on Coursera and official Coursera Plus plan page, reviewed 2026-08-27. Verified the professional-certificate and Google credential context; the page-summary workload of 6 months at 10 hours/week; no degree or prior experience requirement; entry-level project management practices, documentation, planning, budgeting, stakeholder communication, Agile, and Scrum topics; Google Sheets, Microsoft Excel, Google Docs, Microsoft Word, Google Slides, Microsoft PowerPoint, Asana, and Google Gemini tools; hundreds of practice-based assessments and hands-on activities; capstone deliverables; and subscription cost context. Pricing paths: $49 USD/month for the certificate in the United States and Canada after an initial 7-day trial, with lower pricing possible elsewhere; and the regular $59 USD/month Coursera Plus rate for catalog access including this certificate. The temporary $35 USD/month Coursera Plus promotion for eligible new subscribers through September 23, 2026 was excluded as the canonical commitment. The provider's under-$300 completion estimate was excluded because it depends on completion pace. The page summary says 6 months at 10 hours/week, while the pricing FAQ says less than 6 months at under 10 hours/week; both statements are preserved here, and the summary cadence is used without inferring a total. The page separately states over 140 hours of instruction, so durationHours remains null rather than converting that lower-bound statement into an exact total. Rating and review count remain unknown/null because they are volatile."
   },
   {
     "courseId": "introduction-project-management-edx-adelaidex",
@@ -332,12 +339,12 @@
     "sourceUrl": "https://www.coursera.org/specializations/project-management",
     "sourceType": "official_provider_page",
     "verificationStatus": "partially_verified",
-    "lastVerifiedAt": "2026-08-17",
+    "lastVerifiedAt": "2026-08-27",
     "verifiedFields": {
       "title": true,
       "platform": true,
       "sourceUrl": true,
-      "price": false,
+      "price": true,
       "rating": false,
       "reviewCount": false,
       "duration": true,
@@ -345,9 +352,16 @@
       "language": true,
       "level": true,
       "syllabus": true,
-      "prerequisites": true
+      "prerequisites": true,
+      "offeringType": true,
+      "workload": true,
+      "toolsTechnologies": false,
+      "practicalWork": true,
+      "credential": true,
+      "costModel": true,
+      "pricingOptions": true
     },
-    "notes": "Source: official Coursera provider page at the existing canonical URL. Verified title, platform/source URL, beginner level, English as the primary taught language, shareable certificate, 4 weeks at 10 hours/week workload signal, learning topics covering project scope, planning, scheduling, budgeting, and risk, and no prior experience requirement. The normalized prerequisites were corrected and durationHours remains null. The page also lists additional language availability; this does not change the verified English primary taught language. Price, rating, and review count intentionally remain unknown/null because they are volatile."
+    "notes": "Sources: official Project Management Principles and Practices Specialization page on Coursera and official Coursera Plus plan page, reviewed 2026-08-27. Verified the four-course Specialization and University of California, Irvine shareable-certificate context; the page-summary workload of 4 weeks at 10 hours/week; beginner level with no prior experience required; scope, work breakdown structure, planning, scheduling, budgeting, resource allocation, risk, change, communication, and procurement topics; projects and assignments producing project-management artifacts; and subscription cost context. No named software or technology is supported by the official listing, so toolsTechnologies remains empty and unverified rather than treating activities, methods, or deliverables as tools. Pricing path: the regular $59 USD/month Coursera Plus rate for catalog access, with the Specialization page's inclusion link resolving to Coursera Plus. The temporary $35 USD/month promotion for eligible new subscribers through September 23, 2026 was excluded as the canonical commitment, the provider-wide $49-$79 monthly range was excluded because it is not specific to this Specialization, and exact direct Specialization pricing was not public. The page summary says 4 weeks at 10 hours/week, while its four listed course estimates total 19 hours; both statements are preserved here, and durationHours remains null instead of selecting or synthesizing an exact total. The page also lists additional language availability; this does not change the verified English primary taught language. Rating and review count remain unknown/null because they are volatile."
   },
   {
     "courseId": "ibm-data-analyst-ibm",

--- a/data/normalized/courses.json
+++ b/data/normalized/courses.json
@@ -639,8 +639,8 @@
     "durationHours": null,
     "language": "en",
     "priceModel": "subscription",
-    "priceAmount": null,
-    "currency": null,
+    "priceAmount": 49,
+    "currency": "USD",
     "priceInterval": "month",
     "rating": null,
     "reviewCount": null,
@@ -656,6 +656,74 @@
     "prerequisitesBullets": [
       "No degree or prior project management experience required",
       "Beginner-level orientation"
+    ],
+    "offeringType": "professional_certificate",
+    "workload": {
+      "durationQuantity": 6,
+      "durationUnit": "month",
+      "hoursPerWeek": 10,
+      "text": "6 months at 10 hours a week"
+    },
+    "toolsTechnologies": [
+      "Google Sheets",
+      "Microsoft Excel",
+      "Google Docs",
+      "Microsoft Word",
+      "Google Slides",
+      "Microsoft PowerPoint",
+      "Asana",
+      "Google Gemini"
+    ],
+    "practicalWorkBullets": [
+      "Hundreds of practice-based assessments and hands-on activities simulating traditional and Agile project management scenarios",
+      "Capstone work creating a project charter, evaluating quality standards, and developing stakeholder reports"
+    ],
+    "credential": {
+      "type": "professional_certificate",
+      "text": "Google Project Management Professional Certificate"
+    },
+    "costModel": {
+      "type": "subscription",
+      "text": "Certificate access is billed monthly after an initial 7-day free trial, so the final cost depends on time enrolled"
+    },
+    "pricingOptions": [
+      {
+        "id": "google-certificate-us-canada-monthly",
+        "model": "subscription",
+        "amount": 49,
+        "currency": "USD",
+        "normalizedUsdAmount": 49,
+        "cadence": "month",
+        "scope": "Google Project Management Professional Certificate access in the United States and Canada",
+        "normalizationBasis": "provider_published_usd",
+        "actionUrl": "https://www.coursera.org/professional-certificates/google-project-management",
+        "evidenceUrls": [
+          "https://www.coursera.org/professional-certificates/google-project-management"
+        ],
+        "observedAt": "2026-08-27",
+        "referenceMarket": "United States and Canada",
+        "accessContext": "public_provider_page",
+        "conditions": "Charged after an initial 7-day free trial; pricing may be lower in other countries; taxes and checkout eligibility may vary"
+      },
+      {
+        "id": "coursera-plus-monthly",
+        "model": "platform_subscription",
+        "amount": 59,
+        "currency": "USD",
+        "normalizedUsdAmount": 59,
+        "cadence": "month",
+        "scope": "Coursera Plus catalog access, including the Google Project Management Professional Certificate",
+        "normalizationBasis": "provider_published_usd",
+        "actionUrl": "https://www.coursera.org/courseraplus",
+        "evidenceUrls": [
+          "https://www.coursera.org/professional-certificates/google-project-management",
+          "https://www.coursera.org/courseraplus"
+        ],
+        "observedAt": "2026-08-27",
+        "referenceMarket": "United States",
+        "accessContext": "public_provider_page",
+        "conditions": "Regular monthly rate; the public plan page currently advertises $35 USD/month for the first 3 months for eligible new subscribers through September 23, 2026, then automatic renewal at $59 USD/month; outside the United States local currency and pricing apply; taxes and eligibility may vary"
+      }
     ],
     "source": "coursera-curated"
   },
@@ -697,8 +765,8 @@
     "durationHours": null,
     "language": "en",
     "priceModel": "subscription",
-    "priceAmount": null,
-    "currency": null,
+    "priceAmount": 59,
+    "currency": "USD",
     "priceInterval": "month",
     "rating": null,
     "reviewCount": null,
@@ -713,6 +781,47 @@
     "prerequisitesBullets": [
       "No prior experience required",
       "Beginner-level orientation"
+    ],
+    "offeringType": "specialization",
+    "workload": {
+      "durationQuantity": 4,
+      "durationUnit": "week",
+      "hoursPerWeek": 10,
+      "text": "4 weeks at 10 hours a week"
+    },
+    "toolsTechnologies": [],
+    "practicalWorkBullets": [
+      "Projects and assignments defining scope, building a work breakdown structure, and creating a project plan and budget",
+      "Applied work allocating resources, managing development, identifying risks, and addressing procurement"
+    ],
+    "credential": {
+      "type": "specialization_certificate",
+      "text": "Shareable Project Management Principles and Practices Specialization certificate from the University of California, Irvine"
+    },
+    "costModel": {
+      "type": "subscription",
+      "text": "The Specialization is available through subscription access; an exact direct rate is not public, while the included Coursera Plus path is billed monthly"
+    },
+    "pricingOptions": [
+      {
+        "id": "coursera-plus-monthly",
+        "model": "platform_subscription",
+        "amount": 59,
+        "currency": "USD",
+        "normalizedUsdAmount": 59,
+        "cadence": "month",
+        "scope": "Coursera Plus catalog access, including the Project Management Principles and Practices Specialization",
+        "normalizationBasis": "provider_published_usd",
+        "actionUrl": "https://www.coursera.org/courseraplus",
+        "evidenceUrls": [
+          "https://www.coursera.org/specializations/project-management",
+          "https://www.coursera.org/courseraplus"
+        ],
+        "observedAt": "2026-08-27",
+        "referenceMarket": "United States",
+        "accessContext": "public_provider_page",
+        "conditions": "Regular monthly rate; the public plan page currently advertises $35 USD/month for the first 3 months for eligible new subscribers through September 23, 2026, then automatic renewal at $59 USD/month; outside the United States local currency and pricing apply; exact direct Specialization pricing is not stated publicly; taxes and eligibility may vary"
+      }
     ],
     "source": "coursera-curated"
   },

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,6 +1,6 @@
 # Current State
 
-Last updated after implementing Phase 1B.5 decision-grade rollout Batch 1 for product review.
+Last updated after implementing Phase 1B.6 decision-grade rollout Batch 2 for product review.
 
 ## Product State
 
@@ -11,6 +11,16 @@ The current UI is English-first. The product supports skill discovery, curated c
 Recent product review exposed an important distinction: source-trusted catalog data is not automatically decision-useful data. The product must not only avoid inventing facts; it must preserve enough structured provider-backed information to help a user actually choose between courses.
 
 ## Latest Completed Initiatives
+
+### Phase 1B.6 — Decision-Grade Rollout Batch 2 — Issue #106
+
+Key outcomes:
+
+- Exactly two additional courses are migrated: Google Project Management Professional Certificate and Project Management Principles and Practices Specialization.
+- The Project Management pair passes the actionable-pricing hard gate and 6/7 source-backed decision dimensions; tools/technologies remains explicitly insufficient because the UCI listing names no software or technology.
+- Google has a direct `$49 USD/month` U.S./Canada certificate path plus a verified Coursera Plus alternative; UCI has a verified `$59 USD/month` Coursera Plus path.
+- The manifest now limits the approved decision-grade set to ten courses and five approved pairs while preserving exact manifest/migration alignment.
+- Provider workload conflicts, pricing exclusions, and the pair result are recorded in `docs/decision-grade-phase-1b6-batch-2.md`.
 
 ### Phase 1B.5 — Decision-Grade Rollout Batch 1 — Issue #101
 
@@ -80,9 +90,9 @@ Earlier completed initiatives, including Phase 1 Source Verification Batches A/B
 
 - **Phase 0 — MVP:** complete for the current MVP scope.
 - **Phase 1A — Source Trust:** complete for the current 19-course curated MVP catalog; ongoing maintenance only.
-- **Phase 1B — Decision-Grade Data:** Phase 1B.1 through Phase 1B.5 Batch 1 are implemented; eight courses across four approved pairs are decision-grade, and product review must approve any later batch.
+- **Phase 1B — Decision-Grade Data:** Phase 1B.1 through Phase 1B.6 Batch 2 are implemented; ten courses across five approved pairs are decision-grade, and product review must approve any later batch.
 - **Phase 2 — Monetization:** gated / not started. It activates only when a real auditable affiliate/referral program exists and does not block Phase 3.
-- **Phase 3 — Discovery and SEO:** active, with the indexable-surface foundation complete. Further content/traffic expansion is paused until product review of the Phase 1B.4 pilot confirms that core comparisons provide meaningful decision value.
+- **Phase 3 — Discovery and SEO:** active, with the indexable-surface foundation complete. Further content/traffic expansion is paused until product review of the Phase 1B.6 rollout confirms that core comparisons provide meaningful decision value.
 - **Phase 4 — Recommendation:** later, gated behind explicit criteria and trustworthy signals.
 - **Phase 5 — Robust Product:** only if traction justifies the additional architecture.
 
@@ -92,8 +102,8 @@ Earlier completed initiatives, including Phase 1 Source Verification Batches A/B
 - 17 courses are currently `partially_verified`.
 - 2 courses remain `pending` with explicit source blockers rather than unreviewed status.
 - Source URL mismatches: 0 after the completed verification batches.
-- Pricing remains unknown or unverified for the 11 non-migrated courses; the eight approved decision-grade records now have actionable source-backed USD pricing paths. Most ratings and review counts remain unknown by design.
-- The eight approved decision-grade records preserve provider-described workload schedules such as months plus hours per week while exact `durationHours` remains null unless the source explicitly states a total.
+- Pricing remains unknown or unverified for the 9 non-migrated courses; the ten approved decision-grade records now have actionable source-backed USD pricing paths. Most ratings and review counts remain unknown by design.
+- The ten approved decision-grade records preserve provider-described workload schedules such as months plus hours per week while exact `durationHours` remains null unless the source explicitly states a total.
 - The current normalized `language` field represents the primary taught language when clearly supported by an official source. Additional dubbing/subtitle/language availability remains provenance context unless a later explicit schema initiative changes that model.
 - `report:data-quality` remains part of normal validation.
 - Official provider pages remain the final source for volatile enrollment terms, but Skills Compare should perform the basic comparison work rather than merely redirecting users to two provider pages.
@@ -132,11 +142,17 @@ The gate is internal product-quality validation, not a visible ranking or course
 - AWS Cloud Technical Essentials vs Introduction to Cloud Computing: **7/7 pass** plus pricing **pass**.
 - The original two pilot pairs retain their prior pricing and 5/7 results.
 
-## After Phase 1B.5
+## Phase 1B.6 Batch 2 Result
 
-Return to product review. Do not automatically migrate the remaining 11 courses and do not resume SEO content expansion automatically.
+- Google Project Management Professional Certificate vs Project Management Principles and Practices Specialization: **6/7 pass** plus pricing **pass**.
+- Tools/technologies is explicitly insufficient for the pair because the UCI listing names no software or technology.
+- The original four approved pairs retain their prior pricing and readiness results.
 
-Judge whether all four approved comparisons, including the new Data Analysis and Cloud Computing pairs, let a user understand both the learning tradeoffs and current economic commitments without opening both provider pages. If the batch succeeds, decide the next smallest auditable migration sequence; if it fails, revise the decision data or pricing evidence before expanding the manifest.
+## After Phase 1B.6
+
+Return to product review. Do not automatically migrate the remaining 9 courses and do not resume SEO content expansion automatically.
+
+Judge whether all five approved comparisons, including the new Project Management pair, let a user understand both the learning tradeoffs and current economic commitments without opening both provider pages. If the batch succeeds, decide the next smallest auditable migration sequence; if it fails, revise the decision data or pricing evidence before expanding the manifest.
 
 ## Parallel Ongoing Work
 

--- a/docs/MVP_READINESS.md
+++ b/docs/MVP_READINESS.md
@@ -4,9 +4,9 @@
 
 - Skills Compare is an English-first product for finding skills, reviewing relevant online courses, comparing two options, and opening the original provider page.
 - Phase 0 is complete for the current MVP scope.
-- Phase 1A source trust is complete for the current 19-course catalog; Phase 1B.5 Batch 1 expands the approved decision-grade set from four to exactly eight courses and awaits product review before any later batch.
+- Phase 1A source trust is complete for the current 19-course catalog; Phase 1B.6 Batch 2 expands the approved decision-grade set from eight to exactly ten courses and awaits product review before any later batch.
 - Phase 2 monetization is gated until a real auditable affiliate/referral program exists and does not block Phase 3.
-- Phase 3 Discovery and SEO has its indexable-surface foundation in place; content expansion remains paused pending review of the Phase 1B.5 rollout batch.
+- Phase 3 Discovery and SEO has its indexable-surface foundation in place; content expansion remains paused pending review of the Phase 1B.6 rollout batch.
 - The normalized catalog contains 19 curated courses.
 - 17 courses are `partially_verified`; 2 remain `pending` because the exact recorded offering could not be confirmed from a current official source.
 - Source URL mismatches are 0 after Phase 1 Source Verification — Coverage Batch B.
@@ -17,8 +17,8 @@
 - A data quality report is available with `corepack pnpm report:data-quality` and includes verification-status counts, verified-field coverage, fully pending courses, partially verified courses, and unknown field counts.
 - Mobile Selection and Discovery UX is merged: compare selection persists for up to 24 hours, returning selections are surfaced, and the compare bar is available globally outside the compare page.
 - Decision-focused visual polish is merged across the core Search -> Compare -> Decide journey.
-- Decision Data Contract v2 preserves provider-backed offering, workload, tool, practical-work, credential, and cost-model signals for the eight explicitly approved courses.
-- Structured pricing preserves source-backed payable paths, USD amounts, cadence, scope, provenance, freshness, and regional/access context for the same eight-course set.
+- Decision Data Contract v2 preserves provider-backed offering, workload, tool, practical-work, credential, and cost-model signals for the ten explicitly approved courses.
+- Structured pricing preserves source-backed payable paths, USD amounts, cadence, scope, provenance, freshness, and regional/access context for the same ten-course set.
 - Compare presents decision differences and a source-backed at-a-glance snapshot before detailed pricing, criteria, curriculum, and final provider verification.
 
 ## Trust and Data Quality Reality
@@ -26,7 +26,7 @@
 - Phase 1 manual verification reviewed the full 19-course curated catalog at least at the record level.
 - Verification remains conservative and can be partial when a current official page does not support a field.
 - Stable fields such as title, platform/source URL, level, primary taught language, certificate visibility, workload/duration signals, learning topics, and prerequisites are marked verified only when clearly supported.
-- Prices remain unverified or unknown for the 11 non-migrated courses; the eight approved decision-grade courses have actionable source-backed USD pricing paths. Ratings, review counts, and some durations remain unknown by design.
+- Prices remain unverified or unknown for the 9 non-migrated courses; the ten approved decision-grade courses have actionable source-backed USD pricing paths. Ratings, review counts, and some durations remain unknown by design.
 - Monthly or weekly workload estimates are not converted into invented exact `durationHours`; those values remain null unless the official source provides a sufficiently exact total.
 - The normalized `language` field represents the primary taught language when clearly supported. Additional dubbing, subtitle, translation, or language availability remains provenance context unless a future explicit schema initiative expands the model.
 - `introduction-cyber-security-nyux-edx` remains pending because the recorded edX page is unavailable and no current official page clearly represents the exact same NYUx offering.
@@ -65,7 +65,8 @@
 - Both pairs also pass the separate pricing hard gate; every pilot course has at least one source-backed payable path displayed in USD.
 - Google Data Analytics vs Google Advanced Data Analytics passes 7/7 plus the pricing hard gate.
 - AWS Cloud Technical Essentials vs Introduction to Cloud Computing passes 7/7 plus the pricing hard gate.
-- The schema migration is limited to the eight records in `data/decision-grade-manifest.json`. Product review must decide whether another small, explicit batch is justified.
+- Google Project Management Professional Certificate vs Project Management Principles and Practices Specialization passes 6/7 plus the pricing hard gate, with tools/technologies explicitly insufficient for the pair.
+- The schema migration is limited to the ten records in `data/decision-grade-manifest.json`. Product review must decide whether another small, explicit batch is justified.
 - Exact actionable pricing is required for every approved decision-grade pair. Provider checkout remains the final source for transaction-specific taxes, eligibility, regional variation, and availability.
 
 ## Validation Workflow
@@ -81,4 +82,4 @@ Use the documented repository-local TypeScript fallback only when the normal pnp
 
 ## Active Near-Term Gate
 
-Product review must evaluate the Phase 1B.5 rollout batch before approving any migration of the remaining 11 catalog records or resuming Phase 3 content expansion. Phase 2 monetization remains gated until a real program exists.
+Product review must evaluate the Phase 1B.6 rollout batch before approving any migration of the remaining 9 catalog records or resuming Phase 3 content expansion. Phase 2 monetization remains gated until a real program exists.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,7 +24,7 @@ Future work in this area should be limited to concrete usability defects or regr
 
 ## Phase 1 — Real Data
 
-**Status: Phase 1A source trust complete; Phase 1B.5 decision-grade rollout Batch 1 implemented and awaiting product review.**
+**Status: Phase 1A source trust complete; Phase 1B.6 decision-grade rollout Batch 2 implemented and awaiting product review.**
 
 Goal: make the catalog both trustworthy and useful enough to support real user decisions.
 
@@ -51,6 +51,7 @@ Completed:
 - **Phase 1B.3 — Pricing as Core Decision Data** in issue #97: structured multi-path pricing is implemented for the same four-course pilot, pricing is a hard gate in addition to the unchanged 5/7 gate, and the comparison surfaces exact USD commitments with provenance and regional context.
 - **Phase 1B.4 — Compare Decision Hierarchy** in issue #99: the compare flow now moves from a deterministic decision summary into a source-backed course snapshot, detailed pricing evidence, criteria, curriculum detail, and final provider verification for the same four-course pilot.
 - **Phase 1B.5 — Decision-Grade Rollout Batch 1** in issue #101: exactly four additional courses across Data Analysis and Cloud Computing now use the approved contract. Both new pairs pass pricing plus 7/7 source-backed dimensions, and an explicit eight-course/four-pair manifest keeps unrelated catalog records outside the migration.
+- **Phase 1B.6 — Decision-Grade Rollout Batch 2** in issue #106: the Google Project Management Professional Certificate and UCI Project Management Principles and Practices Specialization now use the approved contract. The pair passes pricing plus 6/7 source-backed dimensions, with UCI tools/technologies explicitly insufficient, and the manifest now contains exactly ten courses across five pairs.
 
 Do not migrate the remaining catalog automatically. Any later rollout requires another explicit, auditable batch decision.
 
@@ -72,7 +73,7 @@ Do not implement speculative affiliate parameters, fake discounts, paid ranking,
 
 ## Phase 3 — Discovery and SEO
 
-**Status: active; indexable-surface foundation complete, content expansion paused pending product review of the Phase 1B.5 rollout batch.**
+**Status: active; indexable-surface foundation complete, content expansion paused pending product review of the Phase 1B.6 rollout batch.**
 
 Goal: grow qualified organic traffic by making useful decision surfaces discoverable and by adding genuinely differentiated content only when the catalog supports it.
 
@@ -80,7 +81,7 @@ Completed:
 
 - **Indexable Surface Foundation (Batch A)** in PR #92: sitemap now promotes the homepage, canonical skill pages, and canonical course-detail pages; `/compare` and generated template SEO routes are no longer promoted in the sitemap; generated routes remain accessible with `noindex, follow`; prominent homepage SEO links target canonical skill pages.
 
-Next SEO work must wait for product review after the Phase 1B.5 rollout batch. Do not create new SEO page types, keyword-scaled content, or indexable template volume merely because the technical foundation exists.
+Next SEO work must wait for product review after the Phase 1B.6 rollout batch. Do not create new SEO page types, keyword-scaled content, or indexable template volume merely because the technical foundation exists.
 
 ## Phase 4 — Recommendation
 
@@ -113,7 +114,7 @@ Do not build Phase 5 architecture to solve hypothetical scale.
 ## Immediate Sequence
 
 1. Maintain conservative Phase 1A source trust without reopening verification work for its own sake.
-2. Review the completed Phase 1B.5 Data Analysis and Cloud Computing batch against the explicit decision-readiness and product acceptance criteria.
+2. Review the completed Phase 1B.6 Project Management batch and the cumulative five approved comparison pairs against the explicit decision-readiness and product acceptance criteria.
 3. Do not begin catalog-wide migration or add courses to the decision-grade manifest without a new product decision.
 4. Keep Phase 3 content/traffic expansion paused until the decision-grade rollout shows that core comparison pages provide meaningful decision value.
 5. If the pilot succeeds, migrate the remaining catalog only in small auditable batches and then return to selective people-first SEO work.

--- a/docs/decision-grade-phase-1b6-batch-2.md
+++ b/docs/decision-grade-phase-1b6-batch-2.md
@@ -1,0 +1,28 @@
+# Phase 1B.6 Decision-Grade Rollout — Batch 2
+
+Reviewed on 2026-08-27. This batch migrates exactly two additional courses: the approved Project Management comparison pair. Official provider/platform pages are the only evidence used.
+
+## Google Project Management Professional Certificate
+
+- Official evidence: [certificate page](https://www.coursera.org/professional-certificates/google-project-management) and [Coursera Plus plan](https://www.coursera.org/courseraplus).
+- Decision facts: seven-course professional certificate; beginner level with no degree or prior experience required; 6 months at 10 hours/week; entry-level project management practices, documentation, planning, budgeting, stakeholder communication, Agile, and Scrum; Google Sheets, Microsoft Excel, Google Docs, Microsoft Word, Google Slides, Microsoft PowerPoint, Asana, and Google Gemini; hundreds of practice-based assessments and hands-on activities plus capstone deliverables; monthly subscription context.
+- Pricing: `$49 USD/month` for certificate access in the United States and Canada after an initial 7-day trial. The page says other markets may be lower. The alternative `$59 USD/month` path buys Coursera Plus catalog access and includes this certificate.
+- Exclusions: the pace-dependent under-`$300` completion estimate and the temporary `$35 USD/month` Coursera Plus promotion for eligible new subscribers through September 23, 2026 are not canonical commitments.
+- Workload conflict: the page summary says 6 months at 10 hours/week, while the pricing FAQ says less than 6 months at under 10 hours/week. The summary cadence is stored and both statements remain recorded in source metadata.
+- Duration handling: `durationHours` is null because the provider says the program includes over 140 hours of instruction rather than stating an exact total, and no total is inferred from cadence.
+
+## Project Management Principles and Practices Specialization
+
+- Official evidence: [Specialization page](https://www.coursera.org/specializations/project-management) and [Coursera Plus plan](https://www.coursera.org/courseraplus).
+- Decision facts: four-course University of California, Irvine Specialization with a shareable certificate; beginner level with no prior experience required; 4 weeks at 10 hours/week; project scope, work breakdown structure, planning, scheduling, budgeting, resource allocation, risk, change, communication, and procurement; projects and assignments that produce project-management artifacts; monthly subscription context.
+- Tools/technologies: insufficient. The official listing names methods, activities, and deliverables but no software or technology, so the field remains empty and unverified.
+- Pricing: `$59 USD/month` buys Coursera Plus catalog access, and the Specialization page's inclusion link resolves to Coursera Plus.
+- Exclusions: exact direct Specialization pricing is not public. The generic `$49–$79/month` range for individual Coursera courses and programs is not offering-specific, and the temporary `$35 USD/month` Coursera Plus promotion for eligible new subscribers through September 23, 2026 is not the canonical commitment.
+- Workload conflict: the page summary says 4 weeks at 10 hours/week, while the four listed course estimates total 19 hours. Both statements remain recorded in source metadata.
+- Duration handling: `durationHours` remains null rather than choosing between the conflicting signals or multiplying cadence into a synthetic exact total.
+
+## Gate result
+
+- Google Project Management Professional Certificate vs Project Management Principles and Practices Specialization: pricing **PASS** + **6/7 PASS**.
+
+The seven dimensions are offering/credential, workload, starting point, learning topics, tools/technologies, practical work, and cost model. Tools/technologies is explicitly insufficient for the pair because the UCI listing does not name any. This result is an internal data-quality gate, not a ranking or recommendation. The remaining catalog is not approved for automatic migration; `data/decision-grade-manifest.json` is the explicit allowlist and pair list.


### PR DESCRIPTION
## Summary

- migrate `google-project-management-google` and `project-management-principles-practices-umci` to the existing Decision Data Contract v2
- add the two courses and exactly one Project Management readiness pair to the explicit decision-grade manifest
- record source-backed pricing, decision dimensions, exclusions, workload conflicts, and rollout state

Closes #106

## Sources and data added

### Google Project Management Professional Certificate

Official sources:

- https://www.coursera.org/professional-certificates/google-project-management
- https://www.coursera.org/courseraplus

Added:

- professional-certificate / Google credential context
- 6 months at 10 hours/week workload
- no degree or prior experience starting point
- project documentation, planning, budgeting, stakeholder communication, Agile, and Scrum topics
- Google Sheets, Microsoft Excel, Google Docs, Microsoft Word, Google Slides, Microsoft PowerPoint, Asana, and Google Gemini
- practice-based assessments, hands-on activities, and capstone deliverables
- $49 USD/month U.S./Canada certificate path after the initial 7-day trial
- $59 USD/month Coursera Plus catalog-access alternative

Excluded:

- pace-dependent under-$300 completion estimate
- temporary $35 USD/month Coursera Plus promotion

### Project Management Principles and Practices Specialization

Official sources:

- https://www.coursera.org/specializations/project-management
- https://www.coursera.org/courseraplus

Added:

- four-course UCI Specialization / shareable credential context
- 4 weeks at 10 hours/week workload
- beginner, no-prior-experience starting point
- scope, work breakdown structure, planning, scheduling, budgeting, resource allocation, risk, change, communication, and procurement topics
- source-backed applied projects and assignments
- $59 USD/month Coursera Plus catalog-access path

Explicitly insufficient / excluded:

- no named software or technology is supported by the official listing, so tools/technologies remains empty and unverified
- exact direct Specialization pricing is not public
- generic provider-wide $49–$79/month pricing is not offering-specific
- temporary $35 USD/month Coursera Plus promotion is not canonical

## Gate result

- Project Management pair: pricing **PASS** + **6/7 PASS**
- Insufficient dimension: tools/technologies
- All four existing readiness pairs retain their prior pricing and readiness results
- Manifest/migration alignment: 10 approved courses across 5 pairs

## Source conflicts preserved

- Google: the page summary says 6 months at 10 hours/week, while the pricing FAQ says less than 6 months at under 10 hours/week; the summary cadence is stored and no total is inferred.
- UCI: the page summary says 4 weeks at 10 hours/week, while the four listed course estimates total 19 hours; `durationHours` remains null rather than selecting or synthesizing a total.

## Validation

- `corepack pnpm validate:data` — pass; all five pairs green
- `corepack pnpm report:data-quality` — pass; 19 courses, 10 approved, 0 source mismatches
- `corepack pnpm exec tsc --noEmit` — Windows launcher could not resolve `tsc`
- `node node_modules/typescript/bin/tsc --noEmit` — pass using the documented repository-local fallback
- `corepack pnpm build` — pass; 30 routes generated
- focused runtime smoke/regression — pass for actionable pricing, readiness, snapshots, and comparison rows across all five approved pairs
- `git diff --cached --check` — pass

## Scope

7 files changed. No compare UX, pricing schema, decision-data schema, SEO behavior/output, dependencies, workflows, or deployment configuration changed.

## Blockers

None.

This PR is intentionally left as a draft.