### PR TITLE
Phase 1B.7: multi-provider acceptance and AdelaideX migration

### DIFF
--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -30,7 +30,7 @@ const statusClasses = {
 };
 
 const decisionChecklist = [
-  "I confirmed the final checkout amount and renewal terms.",
+  "I confirmed the final checkout amount and any subscription or renewal terms that apply.",
   "I checked certificate terms.",
   "I confirmed duration fits my weekly schedule.",
   "I reviewed prerequisites and learning topics.",

--- a/data/decision-grade-manifest.json
+++ b/data/decision-grade-manifest.json
@@ -9,6 +9,7 @@
     "aws-cloud-technical-essentials-aws",
     "introduction-to-cloud-computing-ibm",
     "google-project-management-google",
+    "introduction-project-management-edx-adelaidex",
     "project-management-principles-practices-umci"
   ],
   "readinessPairs": [
@@ -31,6 +32,10 @@
     [
       "google-project-management-google",
       "project-management-principles-practices-umci"
+    ],
+    [
+      "google-project-management-google",
+      "introduction-project-management-edx-adelaidex"
     ]
   ]
 }

--- a/data/normalized/course-source-metadata.json
+++ b/data/normalized/course-source-metadata.json
@@ -317,12 +317,12 @@
     "sourceUrl": "https://www.edx.org/learn/project-management/university-of-adelaide-introduction-to-project-management",
     "sourceType": "official_provider_page",
     "verificationStatus": "partially_verified",
-    "lastVerifiedAt": "2026-08-17",
+    "lastVerifiedAt": "2026-08-27",
     "verifiedFields": {
       "title": true,
       "platform": true,
       "sourceUrl": true,
-      "price": false,
+      "price": true,
       "rating": false,
       "reviewCount": false,
       "duration": true,
@@ -330,9 +330,16 @@
       "language": true,
       "level": true,
       "syllabus": true,
-      "prerequisites": true
+      "prerequisites": true,
+      "offeringType": true,
+      "workload": true,
+      "toolsTechnologies": false,
+      "practicalWork": true,
+      "credential": true,
+      "costModel": true,
+      "pricingOptions": true
     },
-    "notes": "Source: current official edX provider page for the same AdelaideX offering. The recorded URL moved to the current canonical URL, and the normalized URL, title, description, certificate availability, and prerequisites were corrected. Verified the AdelaideX: Introduction to Project Management title, edX platform/source URL, Adelaide University attribution, introductory level, English language, paid-track certificate availability, 6 weeks at 2-3 hours/week workload signal, learning topics covering planning, scope, scheduling, costing, risk, communication, and delivery, and no prior experience requirement. durationHours remains null because the weekly range is not an exact total. Price, rating, and review count intentionally remain unknown/null because they are volatile."
+    "notes": "Source: current public official edX course page for the same AdelaideX offering, reviewed 2026-08-27. Re-verified the AdelaideX: Introduction to Project Management title, edX platform/source URL, Adelaide University attribution, single-course and school-verified-certificate context, introductory level, English primary taught language, 6 weeks at 2-3 hours/week workload, no prerequisites, learning topics covering initiation, planning, scope, scheduling, costing, risk, communication, teams, progress measurement, and delivery, and a course-module activity applying project characteristics to the learner's own project. Pricing path: $149 USD one-time for the Premium certificate track, including unlimited access, graded assessments, and a certificate; a separate audit path has time-limited access. The temporary ACTION2026 promotion was excluded as the canonical commitment. The current official page names project-management concepts and activities but no software or technology, so toolsTechnologies remains empty and unverified. durationHours remains null because the weekly range is not an exact total. Rating and review count remain unknown/null because they are volatile."
   },
   {
     "courseId": "project-management-principles-practices-umci",

--- a/data/normalized/courses.json
+++ b/data/normalized/courses.json
@@ -736,9 +736,9 @@
     "level": "beginner",
     "durationHours": null,
     "language": "en",
-    "priceModel": "unknown",
-    "priceAmount": null,
-    "currency": null,
+    "priceModel": "paid_once",
+    "priceAmount": 149,
+    "currency": "USD",
     "priceInterval": null,
     "rating": null,
     "reviewCount": null,
@@ -746,12 +746,53 @@
     "lastUpdatedAt": null,
     "shortDescription": "Adelaide University introductory course covering project planning, scope, scheduling, costing, risk, communication, and delivery.",
     "syllabusBullets": [
-      "Project planning fundamentals",
-      "Scope, schedule, and resource basics",
-      "Project communication and tracking"
+      "Project characteristics, initiation, and project suitability",
+      "Planning, scoping, scheduling, and costing a project",
+      "Project impacts, risk identification, and risk response",
+      "Project stakeholders, teams, communication, and leadership",
+      "Success criteria, progress measurement, stakeholder feedback, and lessons learned"
     ],
     "prerequisitesBullets": [
       "No prior experience required"
+    ],
+    "offeringType": "course",
+    "workload": {
+      "durationQuantity": 6,
+      "durationUnit": "week",
+      "hoursPerWeek": null,
+      "text": "6 weeks at 2-3 hours per week"
+    },
+    "toolsTechnologies": [],
+    "practicalWorkBullets": [
+      "Apply project characteristics to your own project during the opening course module"
+    ],
+    "credential": {
+      "type": "course_certificate",
+      "text": "AdelaideX school-verified course certificate"
+    },
+    "costModel": {
+      "type": "paid_certificate",
+      "text": "The course can be audited with time-limited access; the paid Premium track adds unlimited access, graded assessments, and a certificate"
+    },
+    "pricingOptions": [
+      {
+        "id": "edx-premium-certificate-track",
+        "model": "one_time",
+        "amount": 149,
+        "currency": "USD",
+        "normalizedUsdAmount": 149,
+        "cadence": "one_time",
+        "scope": "Premium certificate track for Introduction to Project Management, including unlimited access, graded assessments, and a certificate",
+        "normalizationBasis": "provider_published_usd",
+        "actionUrl": "https://www.edx.org/learn/project-management/university-of-adelaide-introduction-to-project-management",
+        "evidenceUrls": [
+          "https://www.edx.org/learn/project-management/university-of-adelaide-introduction-to-project-management"
+        ],
+        "observedAt": "2026-08-27",
+        "referenceMarket": null,
+        "accessContext": "public_provider_page",
+        "conditions": "Public edX course page displayed $149 USD for the Premium certificate track; the separate audit path has time-limited access; the temporary ACTION2026 promotion was excluded; taxes, eligibility, and course-run availability may vary"
+      }
     ],
     "source": "manual"
   },

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,6 +1,6 @@
 # Current State
 
-Last updated after implementing Phase 1B.6 decision-grade rollout Batch 2 for product review.
+Last updated after implementing Phase 1B.7 multi-provider acceptance and the bounded AdelaideX migration for independent product review.
 
 ## Product State
 
@@ -11,6 +11,17 @@ The current UI is English-first. The product supports skill discovery, curated c
 Recent product review exposed an important distinction: source-trusted catalog data is not automatically decision-useful data. The product must not only avoid inventing facts; it must preserve enough structured provider-backed information to help a user actually choose between courses.
 
 ## Latest Completed Initiatives
+
+### Phase 1B.7 — Multi-provider Acceptance + Cross-platform Project Management — Issue #108
+
+Key outcomes:
+
+- All five incumbent readiness pairs pass cumulative desktop/mobile product acceptance in the actual comparison UI; the durable review explicitly distinguishes data-gate success from decision usefulness.
+- The current public edX page establishes a `$149 USD` one-time Premium certificate path for AdelaideX: Introduction to Project Management; the temporary promotion is excluded.
+- Google Project Management vs AdelaideX passes pricing plus 6/7 source-backed dimensions. Tools/technologies remains explicitly insufficient because edX names no software or technology.
+- The decision-grade manifest now contains exactly 11 courses and six approved pairs with exact migration alignment and clean regression across every prior pair.
+- Provider-neutral pricing, credential, CTA, workload, provenance, summary, card, and detail presentation work across Coursera and edX. The final checklist now makes subscription/renewal verification conditional when applicable.
+- The product appears ready for independent review to consider resuming selective Phase 3 SEO work; SEO remains paused and no new SEO surface was added.
 
 ### Phase 1B.6 — Decision-Grade Rollout Batch 2 — Issue #106
 
@@ -90,9 +101,9 @@ Earlier completed initiatives, including Phase 1 Source Verification Batches A/B
 
 - **Phase 0 — MVP:** complete for the current MVP scope.
 - **Phase 1A — Source Trust:** complete for the current 19-course curated MVP catalog; ongoing maintenance only.
-- **Phase 1B — Decision-Grade Data:** Phase 1B.1 through Phase 1B.6 Batch 2 are implemented; ten courses across five approved pairs are decision-grade, and product review must approve any later batch.
+- **Phase 1B — Decision-Grade Data:** Phase 1B.1 through Phase 1B.7 are implemented; 11 courses across six approved pairs are decision-grade, and independent product review must approve any later batch.
 - **Phase 2 — Monetization:** gated / not started. It activates only when a real auditable affiliate/referral program exists and does not block Phase 3.
-- **Phase 3 — Discovery and SEO:** active, with the indexable-surface foundation complete. Further content/traffic expansion is paused until product review of the Phase 1B.6 rollout confirms that core comparisons provide meaningful decision value.
+- **Phase 3 — Discovery and SEO:** active, with the indexable-surface foundation complete. Phase 1B.7 acceptance supports consideration of selective people-first expansion, but content/traffic work remains paused until independent product review.
 - **Phase 4 — Recommendation:** later, gated behind explicit criteria and trustworthy signals.
 - **Phase 5 — Robust Product:** only if traction justifies the additional architecture.
 
@@ -102,8 +113,8 @@ Earlier completed initiatives, including Phase 1 Source Verification Batches A/B
 - 17 courses are currently `partially_verified`.
 - 2 courses remain `pending` with explicit source blockers rather than unreviewed status.
 - Source URL mismatches: 0 after the completed verification batches.
-- Pricing remains unknown or unverified for the 9 non-migrated courses; the ten approved decision-grade records now have actionable source-backed USD pricing paths. Most ratings and review counts remain unknown by design.
-- The ten approved decision-grade records preserve provider-described workload schedules such as months plus hours per week while exact `durationHours` remains null unless the source explicitly states a total.
+- Pricing remains unknown or unverified for the 8 non-migrated courses; the 11 approved decision-grade records now have actionable source-backed USD pricing paths. Most ratings and review counts remain unknown by design.
+- The 11 approved decision-grade records preserve provider-described workload schedules such as months plus hours per week while exact `durationHours` remains null unless the source explicitly states a total.
 - The current normalized `language` field represents the primary taught language when clearly supported by an official source. Additional dubbing/subtitle/language availability remains provenance context unless a later explicit schema initiative changes that model.
 - `report:data-quality` remains part of normal validation.
 - Official provider pages remain the final source for volatile enrollment terms, but Skills Compare should perform the basic comparison work rather than merely redirecting users to two provider pages.
@@ -148,11 +159,16 @@ The gate is internal product-quality validation, not a visible ranking or course
 - Tools/technologies is explicitly insufficient for the pair because the UCI listing names no software or technology.
 - The original four approved pairs retain their prior pricing and readiness results.
 
-## After Phase 1B.6
+## Phase 1B.6 Acceptance Resolution
 
-Return to product review. Do not automatically migrate the remaining 9 courses and do not resume SEO content expansion automatically.
+Phase 1B.7 completed the required cumulative review. All five incumbent comparisons let a user understand the material learning tradeoffs, current economic commitments, and remaining uncertainty without first opening both provider pages. This acceptance does not authorize automatic migration of the remaining 8 courses or automatically resume SEO expansion.
 
-Judge whether all five approved comparisons, including the new Project Management pair, let a user understand both the learning tradeoffs and current economic commitments without opening both provider pages. If the batch succeeds, decide the next smallest auditable migration sequence; if it fails, revise the decision data or pricing evidence before expanding the manifest.
+## Phase 1B.7 Result
+
+- All five incumbent pairs pass cumulative desktop/mobile product acceptance.
+- Google Project Management vs AdelaideX: **6/7 pass** plus pricing **pass**; tools/technologies is explicitly insufficient.
+- The approved decision-grade set is 11 courses across six pairs, including the first Coursera-versus-edX pair.
+- Independent product review may consider resuming selective Phase 3 SEO work, but SEO remains paused until that decision is made.
 
 ## Parallel Ongoing Work
 

--- a/docs/MVP_READINESS.md
+++ b/docs/MVP_READINESS.md
@@ -4,9 +4,9 @@
 
 - Skills Compare is an English-first product for finding skills, reviewing relevant online courses, comparing two options, and opening the original provider page.
 - Phase 0 is complete for the current MVP scope.
-- Phase 1A source trust is complete for the current 19-course catalog; Phase 1B.6 Batch 2 expands the approved decision-grade set from eight to exactly ten courses and awaits product review before any later batch.
+- Phase 1A source trust is complete for the current 19-course catalog; Phase 1B.7 expands the approved decision-grade set to exactly 11 courses and six pairs, including the first Coursera-versus-edX pair, and awaits independent product review before any later batch.
 - Phase 2 monetization is gated until a real auditable affiliate/referral program exists and does not block Phase 3.
-- Phase 3 Discovery and SEO has its indexable-surface foundation in place; content expansion remains paused pending review of the Phase 1B.6 rollout batch.
+- Phase 3 Discovery and SEO has its indexable-surface foundation in place; content expansion remains paused pending independent review of Phase 1B.7.
 - The normalized catalog contains 19 curated courses.
 - 17 courses are `partially_verified`; 2 remain `pending` because the exact recorded offering could not be confirmed from a current official source.
 - Source URL mismatches are 0 after Phase 1 Source Verification — Coverage Batch B.
@@ -17,8 +17,8 @@
 - A data quality report is available with `corepack pnpm report:data-quality` and includes verification-status counts, verified-field coverage, fully pending courses, partially verified courses, and unknown field counts.
 - Mobile Selection and Discovery UX is merged: compare selection persists for up to 24 hours, returning selections are surfaced, and the compare bar is available globally outside the compare page.
 - Decision-focused visual polish is merged across the core Search -> Compare -> Decide journey.
-- Decision Data Contract v2 preserves provider-backed offering, workload, tool, practical-work, credential, and cost-model signals for the ten explicitly approved courses.
-- Structured pricing preserves source-backed payable paths, USD amounts, cadence, scope, provenance, freshness, and regional/access context for the same ten-course set.
+- Decision Data Contract v2 preserves provider-backed offering, workload, tool, practical-work, credential, and cost-model signals for the 11 explicitly approved courses.
+- Structured pricing preserves source-backed payable paths, USD amounts, cadence, scope, provenance, freshness, and regional/access context for the same 11-course set.
 - Compare presents decision differences and a source-backed at-a-glance snapshot before detailed pricing, criteria, curriculum, and final provider verification.
 
 ## Trust and Data Quality Reality
@@ -26,7 +26,7 @@
 - Phase 1 manual verification reviewed the full 19-course curated catalog at least at the record level.
 - Verification remains conservative and can be partial when a current official page does not support a field.
 - Stable fields such as title, platform/source URL, level, primary taught language, certificate visibility, workload/duration signals, learning topics, and prerequisites are marked verified only when clearly supported.
-- Prices remain unverified or unknown for the 9 non-migrated courses; the ten approved decision-grade courses have actionable source-backed USD pricing paths. Ratings, review counts, and some durations remain unknown by design.
+- Prices remain unverified or unknown for the 8 non-migrated courses; the 11 approved decision-grade courses have actionable source-backed USD pricing paths. Ratings, review counts, and some durations remain unknown by design.
 - Monthly or weekly workload estimates are not converted into invented exact `durationHours`; those values remain null unless the official source provides a sufficiently exact total.
 - The normalized `language` field represents the primary taught language when clearly supported. Additional dubbing, subtitle, translation, or language availability remains provenance context unless a future explicit schema initiative expands the model.
 - `introduction-cyber-security-nyux-edx` remains pending because the recorded edX page is unavailable and no current official page clearly represents the exact same NYUx offering.
@@ -66,7 +66,8 @@
 - Google Data Analytics vs Google Advanced Data Analytics passes 7/7 plus the pricing hard gate.
 - AWS Cloud Technical Essentials vs Introduction to Cloud Computing passes 7/7 plus the pricing hard gate.
 - Google Project Management Professional Certificate vs Project Management Principles and Practices Specialization passes 6/7 plus the pricing hard gate, with tools/technologies explicitly insufficient for the pair.
-- The schema migration is limited to the ten records in `data/decision-grade-manifest.json`. Product review must decide whether another small, explicit batch is justified.
+- Google Project Management Professional Certificate vs AdelaideX: Introduction to Project Management passes 6/7 plus the pricing hard gate, with edX tools/technologies explicitly insufficient for the pair.
+- The schema migration is limited to the 11 records in `data/decision-grade-manifest.json`. Independent product review must decide whether another small, explicit batch is justified.
 - Exact actionable pricing is required for every approved decision-grade pair. Provider checkout remains the final source for transaction-specific taxes, eligibility, regional variation, and availability.
 
 ## Validation Workflow
@@ -82,4 +83,4 @@ Use the documented repository-local TypeScript fallback only when the normal pnp
 
 ## Active Near-Term Gate
 
-Product review must evaluate the Phase 1B.6 rollout batch before approving any migration of the remaining 9 catalog records or resuming Phase 3 content expansion. Phase 2 monetization remains gated until a real program exists.
+Independent product review must evaluate the Phase 1B.7 evidence before approving any migration of the remaining 8 catalog records or resuming Phase 3 content expansion. Phase 2 monetization remains gated until a real program exists.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,7 +24,7 @@ Future work in this area should be limited to concrete usability defects or regr
 
 ## Phase 1 — Real Data
 
-**Status: Phase 1A source trust complete; Phase 1B.6 decision-grade rollout Batch 2 implemented and awaiting product review.**
+**Status: Phase 1A source trust complete; Phase 1B.7 multi-provider acceptance and the bounded AdelaideX migration are implemented and awaiting independent product review.**
 
 Goal: make the catalog both trustworthy and useful enough to support real user decisions.
 
@@ -52,6 +52,7 @@ Completed:
 - **Phase 1B.4 — Compare Decision Hierarchy** in issue #99: the compare flow now moves from a deterministic decision summary into a source-backed course snapshot, detailed pricing evidence, criteria, curriculum detail, and final provider verification for the same four-course pilot.
 - **Phase 1B.5 — Decision-Grade Rollout Batch 1** in issue #101: exactly four additional courses across Data Analysis and Cloud Computing now use the approved contract. Both new pairs pass pricing plus 7/7 source-backed dimensions, and an explicit eight-course/four-pair manifest keeps unrelated catalog records outside the migration.
 - **Phase 1B.6 — Decision-Grade Rollout Batch 2** in issue #106: the Google Project Management Professional Certificate and UCI Project Management Principles and Practices Specialization now use the approved contract. The pair passes pricing plus 6/7 source-backed dimensions, with UCI tools/technologies explicitly insufficient, and the manifest now contains exactly ten courses across five pairs.
+- **Phase 1B.7 — Multi-provider Acceptance + Cross-platform Project Management** in issue #108: all five incumbent pairs pass cumulative desktop/mobile product acceptance, the current public AdelaideX course page establishes a non-promotional `$149 USD` one-time Premium certificate path, and Google Project Management vs AdelaideX passes pricing plus 6/7 dimensions with edX tools/technologies explicitly insufficient. The manifest now contains exactly 11 courses across six approved pairs.
 
 Do not migrate the remaining catalog automatically. Any later rollout requires another explicit, auditable batch decision.
 
@@ -73,7 +74,7 @@ Do not implement speculative affiliate parameters, fake discounts, paid ranking,
 
 ## Phase 3 — Discovery and SEO
 
-**Status: active; indexable-surface foundation complete, content expansion paused pending product review of the Phase 1B.6 rollout batch.**
+**Status: active; indexable-surface foundation complete, content expansion paused pending independent product review of Phase 1B.7.**
 
 Goal: grow qualified organic traffic by making useful decision surfaces discoverable and by adding genuinely differentiated content only when the catalog supports it.
 
@@ -81,7 +82,7 @@ Completed:
 
 - **Indexable Surface Foundation (Batch A)** in PR #92: sitemap now promotes the homepage, canonical skill pages, and canonical course-detail pages; `/compare` and generated template SEO routes are no longer promoted in the sitemap; generated routes remain accessible with `noindex, follow`; prominent homepage SEO links target canonical skill pages.
 
-Next SEO work must wait for product review after the Phase 1B.6 rollout batch. Do not create new SEO page types, keyword-scaled content, or indexable template volume merely because the technical foundation exists.
+Phase 1B.7 product acceptance indicates that selective people-first SEO work may be ready for consideration, but next SEO work must still wait for the independent product-review decision. Do not create new SEO page types, keyword-scaled content, or indexable template volume merely because the technical foundation exists.
 
 ## Phase 4 — Recommendation
 
@@ -114,8 +115,8 @@ Do not build Phase 5 architecture to solve hypothetical scale.
 ## Immediate Sequence
 
 1. Maintain conservative Phase 1A source trust without reopening verification work for its own sake.
-2. Review the completed Phase 1B.6 Project Management batch and the cumulative five approved comparison pairs against the explicit decision-readiness and product acceptance criteria.
+2. Independently review the completed Phase 1B.7 cumulative acceptance evidence and cross-platform AdelaideX migration.
 3. Do not begin catalog-wide migration or add courses to the decision-grade manifest without a new product decision.
-4. Keep Phase 3 content/traffic expansion paused until the decision-grade rollout shows that core comparison pages provide meaningful decision value.
-5. If the pilot succeeds, migrate the remaining catalog only in small auditable batches and then return to selective people-first SEO work.
+4. Keep Phase 3 content/traffic expansion paused until independent product review accepts the Phase 1B.7 evidence.
+5. If review accepts the initiative, resume only selective people-first SEO work and keep any later catalog migration small and auditable.
 6. Activate Phase 2 monetization only when a real program and appropriate disclosures are ready; it is not a prerequisite for Phase 3.

--- a/docs/decision-grade-phase-1b7-multi-provider-acceptance.md
+++ b/docs/decision-grade-phase-1b7-multi-provider-acceptance.md
@@ -1,0 +1,69 @@
+# Phase 1B.7 Multi-provider Acceptance and Cross-platform Project Management
+
+Reviewed on 2026-08-27. This initiative combines cumulative product acceptance of the five previously approved pairs with one bounded AdelaideX migration. Only current public official provider evidence was used for new course claims.
+
+## Cumulative product acceptance
+
+The five incumbent pairs were reviewed in the actual comparison UI on desktop and mobile. The data-quality gate result and the product-usefulness judgment are distinct:
+
+| Pair | Data-quality gate | Product acceptance finding |
+| --- | --- | --- |
+| AI For Everyone vs Deep Learning Specialization | Pricing PASS + 5/7 | PASS. A user can distinguish a short beginner course from an intermediate five-course Specialization, compare one-time and monthly commitments, workload, prerequisites, credential, and learning focus. Tools and practical work remain visibly insufficient rather than being treated as matches. |
+| Google Cybersecurity vs IBM Cybersecurity Analyst | Pricing PASS + 5/7 | PASS. The UI makes workload, credential context, pricing paths, learning focus, named tools, and practical work useful before provider exit. IBM starting-point and cost-model context remain explicit insufficiencies. |
+| Google Data Analytics vs Google Advanced Data Analytics | Pricing PASS + 7/7 | PASS. The beginner-versus-advanced starting point, shared workload, tools, curriculum, practical work, credential, and monthly commitments form a clear progression decision. |
+| AWS Cloud Technical Essentials vs IBM Introduction to Cloud Computing | Pricing PASS + 7/7 | PASS. A user can distinguish AWS-specific technical depth from a broader cloud introduction, including workload, starting point, tools, labs/projects, credential, and subscription scope. |
+| Google Project Management vs UCI Project Management Principles and Practices | Pricing PASS + 6/7 | PASS. The Professional Certificate versus Specialization format, six-month versus four-week workload, learning focus, practical artifacts, and payment paths are decision-useful. UCI tools/technologies remains visibly insufficient. |
+
+Green validators alone were not treated as acceptance evidence. Each rendered comparison was inspected for decision summary, source-backed snapshot, pricing evidence, criteria statuses, detailed content, uncertainty, final verification, and provider actions.
+
+## AdelaideX official evidence
+
+Current official source: [AdelaideX: Introduction to Project Management on edX](https://www.edx.org/learn/project-management/university-of-adelaide-introduction-to-project-management), observed 2026-08-27 on the public course page.
+
+- Offering / credential: one AdelaideX course with an AdelaideX school-verified course certificate on the paid Premium track.
+- Workload: six weeks at 2–3 hours per week; `durationHours` remains null because the range is not an exact total.
+- Starting point: introductory, with no prerequisites or prior experience required.
+- Learning topics: project characteristics and initiation; planning, scope, schedule, and cost; risk; teams, communication, and leadership; progress, feedback, and lessons learned.
+- Tools / technologies: insufficient. The current official page names project-management concepts and activities but no software or technology.
+- Practical work: the current syllabus applies project characteristics to the learner's own project in the opening module.
+- Cost model: time-limited audit access is separate from a paid Premium track with unlimited access, graded assessments, and a certificate.
+- Volatile rating and review signals remain unknown in the catalog even though the live page displayed them during review.
+
+## Pricing hard gate and readiness result
+
+AdelaideX pricing: **PASS**.
+
+- Payment model / cadence: one-time / one-time.
+- Exact source and normalized amount: `$149 USD` / `$149 USD`.
+- Scope: Premium certificate track for the actual Introduction to Project Management course, including unlimited access, graded assessments, and a certificate.
+- Action and evidence URL: the same public official edX course page linked above.
+- Observed: 2026-08-27.
+- Market / access context: public provider page; the page states USD and no market restriction.
+- Conditions: taxes, eligibility, and course-run availability may vary; the separate audit path is time-limited.
+- Excluded: the temporary `ACTION2026` promotion was not used as the canonical baseline.
+
+Google Project Management vs AdelaideX: pricing **PASS** + **6/7 PASS**. Offering/credential, workload, starting point, learning topics, practical work, and cost-model context are source-backed for both. Tools/technologies is explicitly insufficient because edX names no software or technology.
+
+The manifest now contains exactly 11 migrated courses and six approved readiness pairs. The five prior pairs and all prior approved IDs are preserved, and manifest/migration alignment remains exact.
+
+## Provider-neutrality audit
+
+The edX course was checked on the Project Management skill page, its course detail page, and the Google-versus-AdelaideX comparison.
+
+- Pricing presentation correctly distinguishes Google's monthly program/platform subscriptions from edX's one-time Premium certificate track.
+- Credential wording distinguishes a Professional Certificate from a school-verified course certificate.
+- Provider actions remain neutral (`Open provider page`, `Open verified pricing path`, and comparison provider actions).
+- Workload, source/provenance links, decision summary, comparison rows, course cards, and detail facts render without Coursera-specific assumptions.
+- One concrete defect was fixed: the final comparison checklist now asks users to confirm subscription or renewal terms only when they apply, so a one-time edX path is not described as renewing.
+- No schema expansion or redesign was required.
+
+## Runtime acceptance evidence
+
+- Desktop: all six pairs checked at 1440 × 1000. Every decision section and provider action rendered; no horizontal overflow, off-screen controls, or browser console errors were found.
+- Mobile: all six pairs checked at 390 × 844. Long titles wrapped, stacked sections remained readable, all provider actions remained available, and no horizontal overflow, off-screen controls, or browser console errors were found.
+- The AdelaideX course card and detail page were checked on both desktop and mobile. Platform, one-time price, duration, certificate context, verified pricing action, and provider action all rendered correctly.
+- Inline provenance links remain compact text links; primary decision and provider controls retain their existing touch-target sizing.
+
+## Product-review conclusion
+
+The product appears ready for independent ChatGPT/product review to consider resuming selective, people-first Phase 3 SEO work. This is an acceptance recommendation, not a release decision: this PR does not unpause SEO, add routes, or create content volume.


### PR DESCRIPTION
## Summary

Completes issue #108 end-to-end.

- Performed the required publishing preflight from current `origin/main`.
- Completed cumulative product acceptance for all five incumbent readiness pairs in the actual desktop and mobile UI.
- Re-researched the existing AdelaideX course from the current public official edX course page.
- Migrated AdelaideX through the existing Decision Data Contract v2 and added the Google-vs-AdelaideX readiness pair.
- Audited provider neutrality across comparison, course card, and course detail surfaces.
- Added one focused provider-neutral wording fix and durable initiative evidence.
- Kept Phase 3 SEO expansion paused for independent product review.

Closes #108.

## Current official AdelaideX evidence

Source observed 2026-08-27:

- https://www.edx.org/learn/project-management/university-of-adelaide-introduction-to-project-management

Verified:

- single AdelaideX course with an AdelaideX school-verified course certificate
- introductory level; no prior experience required
- 6 weeks at 2–3 hours/week
- current project-management syllabus and one explicit apply-to-your-own-project activity
- time-limited audit access versus paid Premium certificate-track context
- public `$149 USD` one-time Premium track with unlimited access, graded assessments, and certificate
- public provider-page action/evidence context

Preserved as insufficient:

- tools/technologies: the current official course page names concepts and activities but no software or technology
- rating/review count: intentionally left null as volatile

Excluded:

- temporary `ACTION2026` promotion
- inferred total workload
- any generic edX price range or private/logged-in checkout evidence

## Gate result

AdelaideX pricing hard gate: **PASS**.

Google Project Management vs AdelaideX:

- pricing: **PASS**
- decision readiness: **6/7 PASS**
- insufficient: tools/technologies only

The hard gate and 5/7 threshold were not weakened.

## Manifest and regression

- Approved courses: **11**
- Approved readiness pairs: **6**
- Added exactly one pair:
  - `google-project-management-google`
  - `introduction-project-management-edx-adelaidex`
- Preserved every previous approved ID and pair.
- Manifest/migration alignment: **exact**
- All five prior pricing/readiness gates regress cleanly.

## Cumulative product acceptance

- AI For Everyone vs Deep Learning Specialization: product acceptance **PASS**; gate remains pricing PASS + 5/7 with tools/practical work explicitly insufficient.
- Google Cybersecurity vs IBM Cybersecurity Analyst: product acceptance **PASS**; gate remains pricing PASS + 5/7 with starting point/cost model explicitly insufficient.
- Google Data Analytics vs Google Advanced Data Analytics: product acceptance **PASS**; gate remains pricing PASS + 7/7.
- AWS Cloud Technical Essentials vs IBM Introduction to Cloud Computing: product acceptance **PASS**; gate remains pricing PASS + 7/7.
- Google Project Management vs UCI Project Management: product acceptance **PASS**; gate remains pricing PASS + 6/7 with tools explicitly insufficient.

This review separately evaluated product decision usefulness; green validators were not treated as sufficient acceptance evidence.

## Provider-neutrality audit

Checked pricing labels/presentation, credential wording, provider actions, workload, provenance, decision summaries, comparison rows, course cards, and course details for the edX record.

One concrete defect was fixed: the final checklist now asks users to confirm subscription or renewal terms only when they apply, so a one-time edX path is not described as renewing.

No schema expansion, redesign, ranking, recommendation logic, or speculative abstraction was added.

## Desktop/mobile acceptance

All six approved pairs were checked in the running product:

- desktop: 1440 × 1000
- mobile: 390 × 844
- all decision sections present
- both provider actions present
- no horizontal overflow
- no off-screen controls
- no browser console errors
- long titles wrap correctly on mobile

The AdelaideX course card and course detail page were also checked on desktop/mobile; platform, one-time price, workload, certificate context, pricing action, and provider action render correctly.

## Validation

- `corepack pnpm validate:data` — PASS
- `corepack pnpm report:data-quality` — PASS; no unexplained regression
- `corepack pnpm exec tsc --noEmit` — Windows launcher-resolution failure before TypeScript ran
- `node node_modules/typescript/bin/tsc --noEmit` — PASS using the documented narrow fallback
- `corepack pnpm build` — PASS
- all six readiness-pair gates — PASS
- manifest/migration alignment — PASS
- desktop/mobile runtime regression matrix — PASS
- `git diff --check` and staged `git diff --cached --check` — PASS

No dependencies or tooling were changed. The build emitted only the existing stale Browserslist-data warning.

## Files changed

8 files.

## Product-review state

The durable review concludes that the product appears ready for independent ChatGPT/product review to consider selective, people-first Phase 3 SEO work. This PR does **not** unpause SEO or add any SEO routes/content.

## Blockers / conflicts

None.

This PR must remain draft. Do not mark ready and do not merge.