### PR TITLE
Phase 3B: add decision-led canonical skill guides

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/config/siteConfig";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/"
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`
+  };
+}

--- a/app/skills/[skillSlug]/SkillClient.tsx
+++ b/app/skills/[skillSlug]/SkillClient.tsx
@@ -3,10 +3,12 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { CourseCard } from "@/components/CourseCard";
+import { SkillDecisionGuide } from "@/components/SkillDecisionGuide";
 import { Filters } from "@/components/Filters";
 import { AdPlaceholder } from "@/components/AdPlaceholder";
 import { courses } from "@/lib/catalog-adapter";
 import { getSkillAlternatives, getSkillIntro } from "@/lib/skill-catalog";
+import type { DecisionReadyPair } from "@/lib/decision-ready-comparisons";
 import { slugify, titleFromSlug } from "@/utils/slugify";
 import { useCompareSelection } from "@/contexts/CompareSelectionContext";
 import type { Course } from "@/types/course";
@@ -40,9 +42,15 @@ type FiltersState = {
 
 type SkillClientProps = {
   skillSlug: string;
+  decisionReadyPairs: DecisionReadyPair[];
+  decisionIntro?: string;
 };
 
-export default function SkillClient({ skillSlug: rawSkillSlug }: SkillClientProps) {
+export default function SkillClient({
+  skillSlug: rawSkillSlug,
+  decisionReadyPairs,
+  decisionIntro
+}: SkillClientProps) {
   const skillSlug = rawSkillSlug ? normalizeSkillSlug(rawSkillSlug) : undefined;
   const { selectedIds, clear } = useCompareSelection();
 
@@ -123,11 +131,13 @@ export default function SkillClient({ skillSlug: rawSkillSlug }: SkillClientProp
       course.skillTags.every((tag) => slugify(tag) !== skillSlug)
     );
   const skillIntro = skillExists
-    ? getSkillIntro({
-        slug: skillSlug ?? "",
-        title: skillTitle,
-        courseCount: skillCourses.length
-      })
+    ? decisionReadyPairs.length > 0 && decisionIntro
+      ? decisionIntro
+      : getSkillIntro({
+          slug: skillSlug ?? "",
+          title: skillTitle,
+          courseCount: skillCourses.length
+        })
     : null;
   const availablePlatforms = Array.from(
     new Set(skillCourses.map((course) => course.platform))
@@ -178,9 +188,9 @@ export default function SkillClient({ skillSlug: rawSkillSlug }: SkillClientProp
         <p className="text-xs font-bold uppercase tracking-[0.22em] text-blue-700">
           Skill
         </p>
-        <h2 className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-slate-950 sm:text-4xl lg:text-5xl">
+        <h1 className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-slate-950 sm:text-4xl lg:text-5xl">
           {skillExists ? skillTitle : "Skill not found"}
-        </h2>
+        </h1>
         <p className="mt-4 max-w-3xl text-base leading-relaxed text-slate-600 sm:text-lg">
           {skillIntro ??
             "We do not have validated courses for this skill yet. Review available alternatives in the catalog."}
@@ -201,6 +211,13 @@ export default function SkillClient({ skillSlug: rawSkillSlug }: SkillClientProp
             Clear selection
           </button>
         </div>
+      ) : null}
+
+      {skillExists ? (
+        <SkillDecisionGuide
+          pairs={decisionReadyPairs}
+          skillTitle={skillTitle}
+        />
       ) : null}
 
       <Filters

--- a/app/skills/[skillSlug]/page.tsx
+++ b/app/skills/[skillSlug]/page.tsx
@@ -1,5 +1,9 @@
 import type { Metadata } from "next";
 import { getCoursesForSkill, getSkillSummary } from "@/lib/skill-catalog";
+import {
+  getDecisionReadyPairsForSkill,
+  getDecisionReadySkillIntro
+} from "@/lib/decision-ready-comparisons";
 import { buildPageMetadata } from "@/lib/metadata";
 import SkillClient from "./SkillClient";
 
@@ -22,6 +26,19 @@ export const generateMetadata = ({ params }: SkillPageProps): Metadata => {
   }
 
   const courseCount = getCoursesForSkill(skill.slug).length;
+  const pairCount = getDecisionReadyPairsForSkill(skill.slug).length;
+
+  if (pairCount > 0) {
+    return buildPageMetadata({
+      title: `${skill.title} course comparison guide | Skills Compare`,
+      description: getDecisionReadySkillIntro({
+        courseCount,
+        pairCount,
+        skillTitle: skill.title
+      }),
+      path: `/skills/${skill.slug}`
+    });
+  }
 
   return buildPageMetadata({
     title: `Compare ${skill.title} courses online | Skills Compare`,
@@ -31,5 +48,22 @@ export const generateMetadata = ({ params }: SkillPageProps): Metadata => {
 };
 
 export default function SkillPage({ params }: SkillPageProps) {
-  return <SkillClient skillSlug={params.skillSlug} />;
+  const skill = getSkillSummary(params.skillSlug);
+  const decisionReadyPairs = getDecisionReadyPairsForSkill(params.skillSlug);
+  const decisionIntro =
+    skill && decisionReadyPairs.length > 0
+      ? getDecisionReadySkillIntro({
+          courseCount: getCoursesForSkill(skill.slug).length,
+          pairCount: decisionReadyPairs.length,
+          skillTitle: skill.title
+        })
+      : undefined;
+
+  return (
+    <SkillClient
+      skillSlug={params.skillSlug}
+      decisionReadyPairs={decisionReadyPairs}
+      decisionIntro={decisionIntro}
+    />
+  );
 }

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,6 +1,6 @@
 # Current State
 
-Last updated after implementing Phase 1B.7 multi-provider acceptance and the bounded AdelaideX migration for independent product review.
+Last updated after implementing Phase 3B selective decision-led SEO reactivation for independent product review.
 
 ## Product State
 
@@ -11,6 +11,17 @@ The current UI is English-first. The product supports skill discovery, curated c
 Recent product review exposed an important distinction: source-trusted catalog data is not automatically decision-useful data. The product must not only avoid inventing facts; it must preserve enough structured provider-backed information to help a user actually choose between courses.
 
 ## Latest Completed Initiatives
+
+### Phase 3B — Selective Decision-led SEO Reactivation — Issue #111
+
+Key outcomes:
+
+- The five canonical skills with accepted decision-grade pairs (`ai`, `cybersecurity`, `data-analysis`, `cloud-computing`, and `project-management`) now expose crawlable, people-first decision guides without creating new routes or scaled SEO volume.
+- One deterministic manifest-driven model preserves readiness-pair order, maps verified catalog facts through the existing decision-support layer, and supplies reusable pair cards. Project Management therefore surfaces both approved pairs automatically, including the Coursera-versus-edX option.
+- Each pair links to the exact stable Compare URL and both canonical course-detail pages. The skill acquisition surface does not add outbound provider behavior, affiliate links, rankings, or provider-specific branches.
+- Target metadata now reflects stable course-comparison intent without volatile prices. The sitemap remains limited to the homepage, eight canonical skills, and 19 course-detail pages; all 20 generated SEO templates remain `noindex, follow` and outside the sitemap.
+- A focused regression check covers target-skill/pair mapping, canonical metadata, generated-route robots directives, sitemap boundaries, and non-target exclusion.
+- Issue #112 supersedes the earlier default-next-provider note: after review, Pluralsight Cloud/Cybersecurity is the default next batch only if current official pricing and entitlement evidence clears the hard gate; LinkedIn Learning remains the fallback. Commission does not influence visible presentation.
 
 ### Phase 1B.7 — Multi-provider Acceptance + Cross-platform Project Management — Issue #108
 
@@ -103,7 +114,7 @@ Earlier completed initiatives, including Phase 1 Source Verification Batches A/B
 - **Phase 1A — Source Trust:** complete for the current 19-course curated MVP catalog; ongoing maintenance only.
 - **Phase 1B — Decision-Grade Data:** Phase 1B.1 through Phase 1B.7 are implemented; 11 courses across six approved pairs are decision-grade, and independent product review must approve any later batch.
 - **Phase 2 — Monetization:** gated / not started. It activates only when a real auditable affiliate/referral program exists and does not block Phase 3.
-- **Phase 3 — Discovery and SEO:** active, with the indexable-surface foundation complete. Phase 1B.7 acceptance supports consideration of selective people-first expansion, but content/traffic work remains paused until independent product review.
+- **Phase 3 — Discovery and SEO:** active. The indexable-surface foundation and selective Phase 3B decision guides on five canonical skills are implemented; generated SEO templates remain gated pending stronger product/search evidence.
 - **Phase 4 — Recommendation:** later, gated behind explicit criteria and trustworthy signals.
 - **Phase 5 — Robust Product:** only if traction justifies the additional architecture.
 
@@ -168,11 +179,11 @@ Phase 1B.7 completed the required cumulative review. All five incumbent comparis
 - All five incumbent pairs pass cumulative desktop/mobile product acceptance.
 - Google Project Management vs AdelaideX: **6/7 pass** plus pricing **pass**; tools/technologies is explicitly insufficient.
 - The approved decision-grade set is 11 courses across six pairs, including the first Coursera-versus-edX pair.
-- Independent product review may consider resuming selective Phase 3 SEO work, but SEO remains paused until that decision is made.
+- Phase 3B uses this accepted decision-grade evidence only on the five corresponding canonical skill pages; it does not authorize additional catalog migration or scaled SEO routes.
 
 ## Parallel Ongoing Work
 
-Phase 1A source quality remains an ongoing maintenance concern, but verification should be driven by concrete decision-value needs rather than by a goal of maximizing verified-field counts. Phase 3 technical SEO foundation is in place, but additional indexable content waits for decision-quality review. Monetization remains gated behind a real program and disclosure design, and recommendation remains gated behind trustworthy signals and explicit criteria.
+Phase 1A source quality remains an ongoing maintenance concern, but verification should be driven by concrete decision-value needs rather than by a goal of maximizing verified-field counts. Phase 3B is bounded to existing canonical skill hubs; additional indexable volume still requires product and search evidence. The next provider-batch default is Pluralsight Cloud/Cybersecurity only if the existing evidence hard gate is satisfied, with LinkedIn Learning as fallback. Monetization remains gated behind a real program and disclosure design, and recommendation remains gated behind trustworthy signals and explicit criteria.
 
 ## Operational Note
 

--- a/docs/MVP_READINESS.md
+++ b/docs/MVP_READINESS.md
@@ -6,7 +6,7 @@
 - Phase 0 is complete for the current MVP scope.
 - Phase 1A source trust is complete for the current 19-course catalog; Phase 1B.7 expands the approved decision-grade set to exactly 11 courses and six pairs, including the first Coursera-versus-edX pair, and awaits independent product review before any later batch.
 - Phase 2 monetization is gated until a real auditable affiliate/referral program exists and does not block Phase 3.
-- Phase 3 Discovery and SEO has its indexable-surface foundation in place; content expansion remains paused pending independent review of Phase 1B.7.
+- Phase 3 Discovery and SEO has its indexable-surface foundation plus selective decision guides on the five canonical skills with approved readiness pairs; scaled/generated expansion remains gated.
 - The normalized catalog contains 19 curated courses.
 - 17 courses are `partially_verified`; 2 remain `pending` because the exact recorded offering could not be confirmed from a current official source.
 - Source URL mismatches are 0 after Phase 1 Source Verification — Coverage Batch B.
@@ -20,6 +20,7 @@
 - Decision Data Contract v2 preserves provider-backed offering, workload, tool, practical-work, credential, and cost-model signals for the 11 explicitly approved courses.
 - Structured pricing preserves source-backed payable paths, USD amounts, cadence, scope, provenance, freshness, and regional/access context for the same 11-course set.
 - Compare presents decision differences and a source-backed at-a-glance snapshot before detailed pricing, criteria, curriculum, and final provider verification.
+- Canonical AI, Cybersecurity, Data Analysis, Cloud Computing, and Project Management pages now surface all six manifest-approved pairs in deterministic order, with compact source-backed tradeoffs and explicit uncertainty before the detailed Compare flow.
 
 ## Trust and Data Quality Reality
 
@@ -83,4 +84,4 @@ Use the documented repository-local TypeScript fallback only when the normal pnp
 
 ## Active Near-Term Gate
 
-Independent product review must evaluate the Phase 1B.7 evidence before approving any migration of the remaining 8 catalog records or resuming Phase 3 content expansion. Phase 2 monetization remains gated until a real program exists.
+Independent product review must evaluate the selective Phase 3B implementation before any broader acquisition surface is considered. Any later catalog batch remains explicit and auditable. Under issue #112's sequencing overlay, Pluralsight Cloud/Cybersecurity is the default next provider target only if current official pricing and entitlement evidence satisfies the existing hard gate; LinkedIn Learning remains the fallback. Phase 2 monetization remains gated until a real program exists.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -74,15 +74,16 @@ Do not implement speculative affiliate parameters, fake discounts, paid ranking,
 
 ## Phase 3 — Discovery and SEO
 
-**Status: active; indexable-surface foundation complete, content expansion paused pending independent product review of Phase 1B.7.**
+**Status: active; indexable-surface foundation complete and selective decision-led canonical skill expansion implemented for independent product review.**
 
 Goal: grow qualified organic traffic by making useful decision surfaces discoverable and by adding genuinely differentiated content only when the catalog supports it.
 
 Completed:
 
 - **Indexable Surface Foundation (Batch A)** in PR #92: sitemap now promotes the homepage, canonical skill pages, and canonical course-detail pages; `/compare` and generated template SEO routes are no longer promoted in the sitemap; generated routes remain accessible with `noindex, follow`; prominent homepage SEO links target canonical skill pages.
+- **Phase 3B — Selective decision-led SEO reactivation** in issue #111: the five canonical skills with manifest-approved comparisons now expose reusable, source-backed decision guides and exact Compare entry points. Metadata reflects stable comparison intent, while generated SEO templates remain gated and the sitemap surface is unchanged.
 
-Phase 1B.7 product acceptance indicates that selective people-first SEO work may be ready for consideration, but next SEO work must still wait for the independent product-review decision. Do not create new SEO page types, keyword-scaled content, or indexable template volume merely because the technical foundation exists.
+Phase 3B deliberately limits acquisition work to durable canonical skill hubs backed by accepted comparison data. Do not create new SEO page types, keyword-scaled content, or indexable template volume merely because the technical foundation exists.
 
 ## Phase 4 — Recommendation
 
@@ -115,8 +116,8 @@ Do not build Phase 5 architecture to solve hypothetical scale.
 ## Immediate Sequence
 
 1. Maintain conservative Phase 1A source trust without reopening verification work for its own sake.
-2. Independently review the completed Phase 1B.7 cumulative acceptance evidence and cross-platform AdelaideX migration.
+2. Independently review the selective Phase 3B canonical-skill implementation and its acquisition-to-Compare flow.
 3. Do not begin catalog-wide migration or add courses to the decision-grade manifest without a new product decision.
-4. Keep Phase 3 content/traffic expansion paused until independent product review accepts the Phase 1B.7 evidence.
-5. If review accepts the initiative, resume only selective people-first SEO work and keep any later catalog migration small and auditable.
-6. Activate Phase 2 monetization only when a real program and appropriate disclosures are ready; it is not a prerequisite for Phase 3.
+4. After Phase 3B review, use issue #112's operating-leverage overlay for the next provider batch: Pluralsight Cloud/Cybersecurity is the default only if current official pricing and entitlement evidence clears the existing hard gate; LinkedIn Learning is the provider-neutral fallback if it does not.
+5. Keep generated SEO templates `noindex, follow` and avoid new pair routes or scaled SEO volume until product and search evidence justify them.
+6. Activate Phase 2 monetization only when a real program and appropriate disclosures are ready; commission must never affect visible ordering or factual presentation.

--- a/docs/selective-seo-phase-3b.md
+++ b/docs/selective-seo-phase-3b.md
@@ -1,0 +1,71 @@
+# Phase 3B — Selective Decision-led SEO Reactivation
+
+## Scope and architecture decision
+
+Issue #111 reactivates acquisition work only on the five canonical skill pages that have at least one accepted readiness pair:
+
+- `/skills/ai`
+- `/skills/cybersecurity`
+- `/skills/data-analysis`
+- `/skills/cloud-computing`
+- `/skills/project-management`
+
+The implementation uses `data/decision-grade-manifest.json` as the sole pair allowlist and preserves its ordering. A reusable comparison model resolves each pair against the normalized catalog, reuses the existing decision-readiness and comparison-row logic, and returns only the serializable fields used by the skill UI. A reusable pair card renders course/platform identity, canonical course-detail links, the highest-priority factual differences, explicit insufficiencies, and the exact internal Compare URL.
+
+This architecture was selected because it creates one acquisition-to-decision path instead of five hand-authored page variants, adds no runtime content generation or provider branches, and keeps the full evidence on Compare.
+
+## Comparison entry points
+
+The following links are surfaced in deterministic manifest order:
+
+1. AI For Everyone vs Deep Learning Specialization
+2. Google Cybersecurity Professional Certificate vs IBM Cybersecurity Analyst Professional Certificate
+3. Google Data Analytics Professional Certificate vs Google Advanced Data Analytics Professional Certificate
+4. AWS Cloud Technical Essentials vs Introduction to Cloud Computing
+5. Google Project Management Professional Certificate vs Project Management Principles and Practices Specialization
+6. Google Project Management Professional Certificate vs AdelaideX: Introduction to Project Management
+
+The Project Management guide preserves the visible difference between Coursera and edX. It renders the verified Google `$49/month` commitment separately from AdelaideX's `$149 total` Premium certificate path; it does not flatten subscription and one-time economics into the same claim.
+
+## SEO and indexing boundaries
+
+- Target titles and descriptions now express stable course-comparison intent and known data gaps without publishing volatile exact prices in metadata.
+- All five canonical skill pages retain their existing canonical URLs and default indexability.
+- The sitemap remains exactly 28 URLs: homepage, eight canonical skills, and 19 canonical course details.
+- `/compare` and all generated templates remain outside the sitemap.
+- All 20 generated templates remain accessible with `noindex, follow`.
+- No synthetic `lastModified`, duplicate canonical route, new pair route, or new page type was added.
+- `corepack pnpm generate:seo` was not run because no generation input changed.
+
+## Product acceptance
+
+All five target skill pages were reviewed in the live Next.js UI at both required sizes.
+
+| Canonical skill | 1440 × 1000 | 390 × 844 | Approved pair links | Notes |
+| --- | --- | --- | ---: | --- |
+| AI | Pass | Pass | 1 | Verified pricing and offering/workload differences; tools and practical-work uncertainty explicit |
+| Cybersecurity | Pass | Pass | 1 | Starting-point and cost-model uncertainty explicit |
+| Data Analysis | Pass | Pass | 1 | Fully source-backed displayed criteria; provider-change caveat remains |
+| Cloud Computing | Pass | Pass | 1 | Fully source-backed displayed criteria; provider-change caveat remains |
+| Project Management | Pass | Pass | 2 | Both same-platform and Coursera-vs-edX paths visible; monthly vs one-time commitments remain distinct |
+
+Across the matrix:
+
+- page intent, pair identity, platforms, and Compare actions were understandable without explanation;
+- exact pair URLs and canonical course-detail links were correct;
+- mobile Compare targets rendered at 48 px high;
+- no horizontal overflow, Next.js error overlay, browser console error, ranking/recommendation language, or unsupported claim appeared.
+
+All six detailed Compare URLs were also regressed at both sizes. Each rendered the decision summary, course snapshot, verified pricing, criteria, final verification section, and two provider actions without overflow or errors. The normal card-selection flow reached Compare with the selected pair, and the 24-hour selection state restored visibly on return.
+
+## Growth-efficiency and future monetization review
+
+1. **Reusable versus skill-specific:** pair resolution, ordering, factual row selection, uncertainty rendering, metadata pattern, and UI are shared. Skill-specific output comes only from approved manifest membership and verified catalog facts.
+2. **Marginal work for a sixth eligible skill:** after a separately approved data migration and readiness pair, the canonical skill page gains the guide automatically. Expected recurring work is source verification, the existing manifest/catalog update, and normal acceptance—not a new page or component variant.
+3. **Affiliate readiness:** this work makes later activation easier by adding no outbound link or CTA resolution. Skill acquisition funnels to internal Compare; provider URLs, disclosure copy, outbound contexts, and future affiliate resolution remain centralized in the existing provider-action layer.
+4. **Future pair landing pages:** the pair model and pair card are independent of the skill wrapper, so a separately approved canonical pair surface could reuse decision logic rather than duplicate it. No pair route is created in this initiative.
+5. **Recurring maintenance burden:** no new service, dependency, provider branch, analytics system, or hand-authored per-skill copy was introduced. Maintenance remains bounded to existing source/catalog/manifest review plus the focused SEO-boundary check.
+
+## Sequencing update
+
+Issue #112 supersedes the original default-next-provider note. After independent review of Phase 3B, Pluralsight Cloud/Cybersecurity is the default next provider batch only if current official pricing and entitlement evidence satisfies the existing hard gate. LinkedIn Learning remains the provider-neutral fallback. Commission must not influence visible ordering or factual presentation.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "validate:data": "tsx scripts/validate-data.ts",
     "report:data-quality": "node scripts/report-data-quality.js",
+    "check:selective-seo": "tsx scripts/check-selective-seo.ts",
     "ingest:edx": "tsx scripts/ingest-edx.ts",
     "ingest:coursera": "tsx scripts/ingest-coursera.ts",
     "build:catalog": "tsx scripts/build-catalog.ts",

--- a/scripts/check-selective-seo.ts
+++ b/scripts/check-selective-seo.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 
 import decisionGradeManifest from "../data/decision-grade-manifest.json";
+import robots from "../app/robots";
 import sitemap from "../app/sitemap";
 import { generateMetadata } from "../app/skills/[skillSlug]/page";
 import { SITE_URL } from "../src/config/siteConfig";
@@ -28,6 +29,24 @@ const expectedPairCounts = new Map([
   ["cloud-computing", 1],
   ["project-management", 2]
 ]);
+
+assert.equal(
+  SITE_URL,
+  "https://skillcompare.com",
+  "SEO checks must use the production canonical host https://skillcompare.com."
+);
+
+assert.deepEqual(
+  robots(),
+  {
+    rules: {
+      userAgent: "*",
+      allow: "/"
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`
+  },
+  "robots.txt must allow crawling and advertise the production sitemap."
+);
 
 assert.deepEqual(
   getDecisionReadySkillSlugs(),

--- a/scripts/check-selective-seo.ts
+++ b/scripts/check-selective-seo.ts
@@ -78,7 +78,7 @@ for (const skillSlug of targetSkillSlugs) {
   assert.notEqual(metadata.robots, "noindex", `${skillSlug} must remain indexable.`);
   assert.match(
     String(metadata.description),
-    /source-backed pricing, workload, credentials/i,
+    /source-backed pricing, decision differences, and known data gaps/i,
     `${skillSlug} metadata should express stable comparison intent.`
   );
   assert.doesNotMatch(

--- a/scripts/check-selective-seo.ts
+++ b/scripts/check-selective-seo.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+
+import decisionGradeManifest from "../data/decision-grade-manifest.json";
+import sitemap from "../app/sitemap";
+import { generateMetadata } from "../app/skills/[skillSlug]/page";
+import { SITE_URL } from "../src/config/siteConfig";
+import { courses } from "../src/lib/catalog-adapter";
+import {
+  getDecisionReadyPairsForSkill,
+  getDecisionReadySkillSlugs
+} from "../src/lib/decision-ready-comparisons";
+import { buildSeoPageMetadata } from "../src/lib/metadata";
+import { getAllSeoPages } from "../src/lib/seo/seoPages";
+import { getSkillSummaries } from "../src/lib/skill-catalog";
+
+const targetSkillSlugs = [
+  "ai",
+  "cybersecurity",
+  "data-analysis",
+  "cloud-computing",
+  "project-management"
+];
+
+const expectedPairCounts = new Map([
+  ["ai", 1],
+  ["cybersecurity", 1],
+  ["data-analysis", 1],
+  ["cloud-computing", 1],
+  ["project-management", 2]
+]);
+
+assert.deepEqual(
+  getDecisionReadySkillSlugs(),
+  targetSkillSlugs,
+  "Only the five approved canonical skills should expose decision-ready guides."
+);
+
+const surfacedPairs = targetSkillSlugs.flatMap((skillSlug) => {
+  const pairs = getDecisionReadyPairsForSkill(skillSlug);
+  assert.equal(
+    pairs.length,
+    expectedPairCounts.get(skillSlug),
+    `${skillSlug} should expose its approved manifest pair count.`
+  );
+
+  pairs.forEach((pair) => {
+    assert.equal(
+      pair.compareHref,
+      `/compare?ids=${pair.left.id},${pair.right.id}`,
+      "Compare links must preserve exact manifest pair order and IDs."
+    );
+    assert.ok(pair.differences.length > 0, "Each guide needs factual differences.");
+    assert.ok(
+      pair.left.detailHref.startsWith("/courses/") &&
+        pair.right.detailHref.startsWith("/courses/"),
+      "Each pair must link naturally to both canonical course details."
+    );
+  });
+
+  return pairs.map((pair) => [pair.left.id, pair.right.id]);
+});
+
+assert.deepEqual(
+  surfacedPairs,
+  decisionGradeManifest.readinessPairs,
+  "Every manifest pair should surface exactly once and in deterministic manifest order."
+);
+
+for (const skillSlug of targetSkillSlugs) {
+  const metadata = generateMetadata({ params: { skillSlug } });
+  const canonical = metadata.alternates?.canonical;
+
+  assert.equal(
+    canonical,
+    `${SITE_URL}/skills/${skillSlug}`,
+    `${skillSlug} should retain its canonical URL.`
+  );
+  assert.notEqual(metadata.robots, "noindex", `${skillSlug} must remain indexable.`);
+  assert.match(
+    String(metadata.description),
+    /source-backed pricing, workload, credentials/i,
+    `${skillSlug} metadata should express stable comparison intent.`
+  );
+  assert.doesNotMatch(
+    `${String(metadata.title)} ${String(metadata.description)}`,
+    /\$\d|USD\s*\d/i,
+    "Volatile exact prices must stay out of metadata."
+  );
+}
+
+assert.match(
+  String(generateMetadata({ params: { skillSlug: "ai" } }).title),
+  /^AI course comparison guide/,
+  "AI should retain its standard acronym casing in metadata and page copy."
+);
+
+assert.equal(
+  getDecisionReadyPairsForSkill("frontend").length,
+  0,
+  "Non-target skills must not receive unsupported decision-ready claims."
+);
+
+const sitemapEntries = sitemap();
+const sitemapUrls = sitemapEntries.map((entry) => entry.url).sort();
+const expectedSitemapUrls = [
+  `${SITE_URL}/`,
+  ...getSkillSummaries().map((skill) => `${SITE_URL}/skills/${skill.slug}`),
+  ...courses.map((course) => `${SITE_URL}/courses/${course.id}`)
+].sort();
+
+assert.deepEqual(
+  sitemapUrls,
+  expectedSitemapUrls,
+  "The sitemap should contain only the existing homepage, canonical skills, and course details."
+);
+assert.ok(
+  sitemapEntries.every((entry) => entry.lastModified == null),
+  "The sitemap must not add synthetic lastModified values."
+);
+assert.ok(
+  !sitemapUrls.some((url) => url.includes("/compare")),
+  "Compare must remain outside the sitemap."
+);
+
+const generatedSeoPages = getAllSeoPages();
+assert.equal(generatedSeoPages.length, 20, "All 20 generated SEO routes should remain gated.");
+
+for (const page of generatedSeoPages) {
+  const metadata = buildSeoPageMetadata(page);
+  const robots = metadata.robots;
+
+  assert.equal(
+    typeof robots === "object" ? robots?.index : undefined,
+    false,
+    `${page.slug} should remain noindex.`
+  );
+  assert.equal(
+    typeof robots === "object" ? robots?.follow : undefined,
+    true,
+    `${page.slug} should remain follow.`
+  );
+  assert.ok(
+    !sitemapUrls.includes(`${SITE_URL}/${page.slug}`),
+    `${page.slug} should remain outside the sitemap.`
+  );
+}
+
+console.log(
+  `[check:selective-seo] PASS — ${targetSkillSlugs.length} canonical skills, ${surfacedPairs.length} manifest pairs, ${generatedSeoPages.length} gated generated routes, and ${sitemapUrls.length} sitemap URLs verified.`
+);

--- a/src/components/DecisionReadyPairCard.tsx
+++ b/src/components/DecisionReadyPairCard.tsx
@@ -1,0 +1,115 @@
+import Link from "next/link";
+import type { DecisionReadyPair } from "@/lib/decision-ready-comparisons";
+
+type DecisionReadyPairCardProps = {
+  pair: DecisionReadyPair;
+};
+
+const CourseIdentity = ({
+  course
+}: {
+  course: DecisionReadyPair["left"];
+}) => (
+  <article className="min-w-0 rounded-xl border border-slate-200 bg-slate-50/80 p-4">
+    <p className="text-xs font-bold uppercase tracking-[0.16em] text-blue-700">
+      {course.platform}
+    </p>
+    <h3 className="mt-2 break-words text-base font-semibold leading-snug text-slate-950 sm:text-lg">
+      <Link href={course.detailHref} className="transition hover:text-blue-700">
+        {course.title}
+      </Link>
+    </h3>
+  </article>
+);
+
+export const DecisionReadyPairCard = ({ pair }: DecisionReadyPairCardProps) => (
+  <article className="min-w-0 rounded-2xl border border-slate-200 bg-white p-4 shadow-[0_18px_45px_-36px_rgba(15,23,42,0.45)] sm:p-6">
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <span className="rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.12em] text-emerald-800">
+        Comparison-ready data
+      </span>
+      <span className="text-xs font-medium text-slate-500">
+        Source-backed pair
+      </span>
+    </div>
+
+    <div className="mt-4 grid min-w-0 gap-2 sm:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] sm:items-stretch">
+      <CourseIdentity course={pair.left} />
+      <span className="flex items-center justify-center px-1 text-xs font-bold uppercase tracking-[0.16em] text-slate-400">
+        vs
+      </span>
+      <CourseIdentity course={pair.right} />
+    </div>
+
+    <div className="mt-5 grid gap-5 lg:grid-cols-[1.35fr_0.65fr]">
+      <div>
+        <h4 className="text-sm font-semibold text-slate-950">
+          Material differences to inspect
+        </h4>
+        <dl className="mt-3 space-y-3">
+          {pair.differences.map((row) => (
+            <div key={row.label} className="rounded-xl border border-slate-100 bg-slate-50/70 p-3">
+              <dt className="text-xs font-bold uppercase tracking-[0.12em] text-slate-500">
+                {row.label}
+              </dt>
+              <dd className="mt-2 grid min-w-0 gap-2 text-sm leading-relaxed text-slate-700 sm:grid-cols-2">
+                <span className="break-words">
+                  <strong className="text-slate-950">{pair.left.title}:</strong>{" "}
+                  {row.left}
+                </span>
+                <span className="break-words">
+                  <strong className="text-slate-950">{pair.right.title}:</strong>{" "}
+                  {row.right}
+                </span>
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+
+      <div>
+        <h4 className="text-sm font-semibold text-slate-950">
+          What remains uncertain
+        </h4>
+        {pair.uncertainties.length > 0 ? (
+          <ul className="mt-3 space-y-2 text-sm leading-relaxed text-amber-950">
+            {pair.uncertainties.map((row) => (
+              <li key={row.label} className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2.5">
+                <span className="font-semibold">{row.label}:</span>{" "}
+                {row.interpretation}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-3 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm leading-relaxed text-slate-600">
+            The displayed decision criteria are source-backed for both courses. Final provider terms can still change.
+          </p>
+        )}
+        <p className="mt-3 text-xs leading-relaxed text-slate-500">
+          Verify checkout totals, taxes, eligibility, regional terms, and current availability on the provider pages before enrolling.
+        </p>
+      </div>
+    </div>
+
+    <div className="mt-5 grid gap-2 border-t border-slate-200 pt-4 sm:flex sm:flex-wrap">
+      <Link
+        href={pair.compareHref}
+        className="inline-flex min-h-12 items-center justify-center rounded-xl bg-blue-700 px-5 py-2.5 text-center text-sm font-semibold text-white transition hover:bg-blue-600"
+      >
+        Open detailed comparison
+      </Link>
+      <Link
+        href={pair.left.detailHref}
+        className="inline-flex min-h-11 items-center justify-center rounded-xl border border-slate-300 px-4 py-2.5 text-center text-sm font-semibold text-slate-700 transition hover:border-slate-400"
+      >
+        View {pair.left.platform} course details
+      </Link>
+      <Link
+        href={pair.right.detailHref}
+        className="inline-flex min-h-11 items-center justify-center rounded-xl border border-slate-300 px-4 py-2.5 text-center text-sm font-semibold text-slate-700 transition hover:border-slate-400"
+      >
+        View {pair.right.platform} course details
+      </Link>
+    </div>
+  </article>
+);

--- a/src/components/SkillDecisionGuide.tsx
+++ b/src/components/SkillDecisionGuide.tsx
@@ -1,0 +1,44 @@
+import { DecisionReadyPairCard } from "@/components/DecisionReadyPairCard";
+import type { DecisionReadyPair } from "@/lib/decision-ready-comparisons";
+
+type SkillDecisionGuideProps = {
+  pairs: DecisionReadyPair[];
+  skillTitle: string;
+};
+
+export const SkillDecisionGuide = ({
+  pairs,
+  skillTitle
+}: SkillDecisionGuideProps) => {
+  if (pairs.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      aria-labelledby="skill-decision-guide-heading"
+      className="rounded-[1.75rem] border border-slate-800 bg-slate-950 p-4 shadow-[0_28px_70px_-42px_rgba(15,23,42,0.65)] sm:p-7 lg:p-8"
+    >
+      <div className="max-w-3xl">
+        <p className="text-xs font-bold uppercase tracking-[0.2em] text-blue-300">
+          {skillTitle} decision guide
+        </p>
+        <h2
+          id="skill-decision-guide-heading"
+          className="mt-2 text-2xl font-semibold tracking-tight text-white sm:text-3xl"
+        >
+          Start with comparison-ready course pairs
+        </h2>
+        <p className="mt-3 text-sm leading-relaxed text-slate-300 sm:text-base">
+          These are source-backed comparison entry points, not rankings. Review the most decision-relevant differences here, then open Compare for the full evidence and final verification checklist.
+        </p>
+      </div>
+
+      <div className="mt-6 grid gap-4">
+        {pairs.map((pair) => (
+          <DecisionReadyPairCard key={pair.key} pair={pair} />
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -1,2 +1,2 @@
 export const SITE_NAME = "Skills Compare";
-export const SITE_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://skillcompare.dev";
+export const SITE_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://skillcompare.com";

--- a/src/lib/decision-ready-comparisons.ts
+++ b/src/lib/decision-ready-comparisons.ts
@@ -1,0 +1,141 @@
+import decisionGradeManifest from "../../data/decision-grade-manifest.json";
+import { courses } from "@/lib/catalog-adapter";
+import {
+  buildComparisonRows,
+  getPairDecisionReadiness,
+  type ComparisonRow
+} from "@/lib/decision-support";
+import { slugify } from "@/utils/slugify";
+import type { Course } from "@/types/course";
+
+type ManifestPair = [string, string];
+
+type DecisionGuideCourse = Pick<Course, "id" | "title" | "platform"> & {
+  detailHref: string;
+};
+
+export type DecisionGuideRow = Pick<
+  ComparisonRow,
+  "label" | "left" | "right" | "interpretation"
+>;
+
+export type DecisionReadyPair = {
+  key: string;
+  compareHref: string;
+  left: DecisionGuideCourse;
+  right: DecisionGuideCourse;
+  differences: DecisionGuideRow[];
+  uncertainties: DecisionGuideRow[];
+};
+
+const manifestPairs = decisionGradeManifest.readinessPairs as ManifestPair[];
+const coursesById = new Map(courses.map((course) => [course.id, course]));
+
+const DECISION_GUIDE_PRIORITY = [
+  "Verified pricing",
+  "Offering / credential",
+  "Starting point",
+  "Workload",
+  "Cost model",
+  "Learning topics",
+  "Tools / technologies",
+  "Practical work"
+] as const;
+
+const decisionPriority = new Map<string, number>(
+  DECISION_GUIDE_PRIORITY.map((label, index) => [label, index])
+);
+
+const byDecisionPriority = (left: ComparisonRow, right: ComparisonRow) =>
+  (decisionPriority.get(left.label) ?? DECISION_GUIDE_PRIORITY.length) -
+  (decisionPriority.get(right.label) ?? DECISION_GUIDE_PRIORITY.length);
+
+const toGuideCourse = (course: Course): DecisionGuideCourse => ({
+  id: course.id,
+  title: course.title,
+  platform: course.platform,
+  detailHref: `/courses/${course.id}`
+});
+
+const hasSkill = (course: Course, skillSlug: string) =>
+  course.skillTags.some((tag) => slugify(tag) === skillSlug);
+
+const buildDecisionReadyPair = (
+  left: Course,
+  right: Course
+): DecisionReadyPair | null => {
+  if (!getPairDecisionReadiness(left, right).passes) {
+    return null;
+  }
+
+  const rows = buildComparisonRows(left, right);
+
+  return {
+    key: `${left.id}--${right.id}`,
+    compareHref: `/compare?ids=${left.id},${right.id}`,
+    left: toGuideCourse(left),
+    right: toGuideCourse(right),
+    differences: rows
+      .filter((row) => row.status === "Different")
+      .sort(byDecisionPriority)
+      .slice(0, 4),
+    uncertainties: rows
+      .filter((row) => row.status === "Insufficient data")
+      .sort(byDecisionPriority)
+  };
+};
+
+export const getDecisionReadyPairsForSkill = (
+  skillSlug: string
+): DecisionReadyPair[] =>
+  manifestPairs.flatMap(([leftId, rightId]) => {
+    const left = coursesById.get(leftId);
+    const right = coursesById.get(rightId);
+
+    if (
+      !left ||
+      !right ||
+      !hasSkill(left, skillSlug) ||
+      !hasSkill(right, skillSlug)
+    ) {
+      return [];
+    }
+
+    const pair = buildDecisionReadyPair(left, right);
+    return pair ? [pair] : [];
+  });
+
+export const getDecisionReadySkillSlugs = (): string[] => {
+  const slugs = new Set<string>();
+
+  manifestPairs.forEach(([leftId, rightId]) => {
+    const left = coursesById.get(leftId);
+    const right = coursesById.get(rightId);
+
+    if (!left || !right || !getPairDecisionReadiness(left, right).passes) {
+      return;
+    }
+
+    left.skillTags.forEach((tag) => {
+      const slug = slugify(tag);
+      if (hasSkill(right, slug)) {
+        slugs.add(slug);
+      }
+    });
+  });
+
+  return [...slugs];
+};
+
+export const getDecisionReadySkillIntro = ({
+  courseCount,
+  pairCount,
+  skillTitle
+}: {
+  courseCount: number;
+  pairCount: number;
+  skillTitle: string;
+}) =>
+  `Compare ${courseCount} ${skillTitle} courses, then open ${pairCount} comparison-ready ${
+    pairCount === 1 ? "pair" : "pairs"
+  } to inspect source-backed pricing, workload, credentials, starting points, and known data gaps.`;

--- a/src/lib/decision-ready-comparisons.ts
+++ b/src/lib/decision-ready-comparisons.ts
@@ -138,4 +138,4 @@ export const getDecisionReadySkillIntro = ({
 }) =>
   `Compare ${courseCount} ${skillTitle} courses, then open ${pairCount} comparison-ready ${
     pairCount === 1 ? "pair" : "pairs"
-  } to inspect source-backed pricing, workload, credentials, starting points, and known data gaps.`;
+  } to inspect source-backed pricing, decision differences, and known data gaps.`;

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -6,8 +6,15 @@ export const slugify = (value: string) =>
     .replace(/\s+/g, "-")
     .replace(/-+/g, "-");
 
+const TITLE_ACRONYMS: Record<string, string> = {
+  ai: "AI"
+};
+
 export const titleFromSlug = (slug: string) =>
   slug
     .split("-")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .map(
+      (word) =>
+        TITLE_ACRONYMS[word] ?? word.charAt(0).toUpperCase() + word.slice(1)
+    )
     .join(" ");


### PR DESCRIPTION
## Summary

Closes #111.

Implements selective decision-led SEO reactivation on the five canonical skill pages backed by accepted decision-grade comparisons:

- `/skills/ai`
- `/skills/cybersecurity`
- `/skills/data-analysis`
- `/skills/cloud-computing`
- `/skills/project-management`

The pages now surface all six manifest-approved pairs in deterministic manifest order, show compact source-backed differences and explicit insufficiencies, link both canonical course details, and funnel users into the existing exact Compare URLs. Project Management exposes both approved pairs, including Coursera vs edX, while keeping Google’s monthly pricing separate from AdelaideX’s one-time path.

## Architecture and growth efficiency

- One reusable model reads `data/decision-grade-manifest.json`, resolves catalog courses, reuses the existing readiness/comparison logic, and passes only UI-required serializable data.
- Shared pair-card and skill-guide components replace per-skill variants; there are no provider-specific branches or runtime content generation.
- Adding a sixth eligible skill later is primarily the existing approved catalog/manifest operation plus acceptance. No new page implementation is expected.
- Skill-page CTAs are internal Compare/course-detail links only. Provider URL resolution, disclosure, and outbound contexts remain centralized, so future affiliate activation is easier and does not require rewriting this acquisition surface.
- The pair model/card can be reused by a separately approved canonical pair surface without duplicating decision logic; this PR creates no pair routes.
- Recurring maintenance added: the existing source/catalog/manifest review plus one focused deterministic SEO-boundary check. No service, dependency, paid tooling, analytics, or infrastructure was added.

## Comparison links surfaced

1. AI For Everyone vs Deep Learning Specialization
2. Google Cybersecurity vs IBM Cybersecurity Analyst
3. Google Data Analytics vs Google Advanced Data Analytics
4. AWS Cloud Technical Essentials vs Introduction to Cloud Computing
5. Google Project Management vs UCI Project Management Principles and Practices
6. Google Project Management vs AdelaideX Introduction to Project Management

## SEO and indexing

- Refined target metadata and page-specific H1/intro copy around stable course-comparison intent; volatile prices remain out of metadata.
- Correct target canonicals and default indexability preserved.
- Sitemap remains exactly 28 URLs: homepage, 8 canonical skills, and 19 canonical course details.
- `/compare` and generated routes remain outside the sitemap.
- All 20 generated routes remain accessible with `noindex, follow`.
- No synthetic `lastModified`, duplicate canonical, new route type, or scaled SEO volume.
- `generate:seo` was not run because no generation input changed.

## Product acceptance

All five target pages passed at 1440 × 1000 and 390 × 844:

- value proposition and pair identity understandable without explanation
- correct course/platform names and exact Compare URLs
- useful factual differences with explicit uncertainty
- no ranking/recommendation language
- no horizontal overflow, broken controls, error overlays, or browser console errors
- mobile Compare targets render at 48 px
- Project Management shows both pairs and visibly distinguishes `$49/month` Google from `$149 total` AdelaideX economics

All six detailed Compare URLs also passed at both sizes with decision summary, snapshot, pricing, criteria, final verification, and provider actions present. Card selection, Compare navigation, and returning-selection persistence were regressed successfully.

## Validation

- ✅ `corepack pnpm validate:data` — 19 courses; all six pricing/readiness gates pass
- ✅ `corepack pnpm report:data-quality` — 17 partially verified, 2 explicitly pending, 0 source mismatches
- ✅ `corepack pnpm check:selective-seo` — 5 skills, 6 pairs, 20 gated generated routes, 28 sitemap URLs
- ⚠️ `corepack pnpm exec tsc --noEmit` — known Windows launcher-resolution failure before TypeScript ran
- ✅ `node node_modules/typescript/bin/tsc --noEmit` — documented repository-local fallback
- ✅ `corepack pnpm build`
- ✅ `git diff --check`
- ✅ staged whitespace check

Build emitted only the existing outdated Browserslist database notice; dependencies/tooling were intentionally unchanged.

## Documentation

Updated `ROADMAP`, `CURRENT_STATE`, and `MVP_READINESS`, and added the durable Phase 3B architecture/acceptance record. The issue #112 sequencing overlay is reflected: Pluralsight Cloud/Cybersecurity is the default next batch only if current official evidence clears the hard gate, with LinkedIn Learning as fallback; commission does not affect visible presentation.

This PR must remain draft. Do not merge from the coding-agent workflow.