### PR TITLE
Phase 1B.8: add Pluralsight Cloud and cybersecurity batch

### DIFF
--- a/data/decision-grade-manifest.json
+++ b/data/decision-grade-manifest.json
@@ -4,7 +4,6 @@
     "deep-learning-specialization-deeplearningai",
     "google-cybersecurity-google",
     "ibm-cybersecurity-analyst-ibm",
-    "introduction-information-security-pluralsight",
     "google-data-analytics-google",
     "google-advanced-data-analytics-google",
     "aws-cloud-technical-essentials-aws",
@@ -22,10 +21,6 @@
     [
       "google-cybersecurity-google",
       "ibm-cybersecurity-analyst-ibm"
-    ],
-    [
-      "google-cybersecurity-google",
-      "introduction-information-security-pluralsight"
     ],
     [
       "google-data-analytics-google",

--- a/data/decision-grade-manifest.json
+++ b/data/decision-grade-manifest.json
@@ -4,10 +4,12 @@
     "deep-learning-specialization-deeplearningai",
     "google-cybersecurity-google",
     "ibm-cybersecurity-analyst-ibm",
+    "introduction-information-security-pluralsight",
     "google-data-analytics-google",
     "google-advanced-data-analytics-google",
     "aws-cloud-technical-essentials-aws",
     "introduction-to-cloud-computing-ibm",
+    "aws-foundations-cloud-essentials-pluralsight",
     "google-project-management-google",
     "introduction-project-management-edx-adelaidex",
     "project-management-principles-practices-umci"
@@ -22,12 +24,20 @@
       "ibm-cybersecurity-analyst-ibm"
     ],
     [
+      "google-cybersecurity-google",
+      "introduction-information-security-pluralsight"
+    ],
+    [
       "google-data-analytics-google",
       "google-advanced-data-analytics-google"
     ],
     [
       "aws-cloud-technical-essentials-aws",
       "introduction-to-cloud-computing-ibm"
+    ],
+    [
+      "aws-cloud-technical-essentials-aws",
+      "aws-foundations-cloud-essentials-pluralsight"
     ],
     [
       "google-project-management-google",

--- a/data/normalized/course-source-metadata.json
+++ b/data/normalized/course-source-metadata.json
@@ -182,35 +182,6 @@
     "notes": "Sources: official Google Cybersecurity Professional Certificate page on Coursera and official Coursera Plus plan page, reviewed 2026-08-18. Verified the professional-certificate and Google credential context; 6 months at 7 hours/week workload wording; no prior experience requirement; learning topics; Linux, Python, Bash, SQL, SIEM, and intrusion-detection tools; and hands-on labs, practice-based assessments, and portfolio activities. Pricing paths: $49 USD/month for the certificate in the United States and Canada after an initial 7-day trial, with lower pricing possible elsewhere; and $59 USD/month for Coursera Plus catalog access, with the program page explicitly marking this certificate as included. The provider's under-$300 completion estimate was excluded because it depends on completion pace, and the temporary $239/year Coursera Plus promotion was excluded. durationHours remains null because the schedule is not converted into an exact total. Rating and review count remain unknown/null because they are volatile."
   },
   {
-    "courseId": "introduction-information-security-pluralsight",
-    "sourceUrl": "https://www.pluralsight.com/courses/information-security-introduction",
-    "sourceType": "official_provider_page",
-    "verificationStatus": "partially_verified",
-    "lastVerifiedAt": "2026-08-28",
-    "verifiedFields": {
-      "title": true,
-      "platform": true,
-      "sourceUrl": true,
-      "price": true,
-      "rating": false,
-      "reviewCount": false,
-      "duration": true,
-      "certificate": true,
-      "language": true,
-      "level": true,
-      "syllabus": true,
-      "prerequisites": true,
-      "offeringType": true,
-      "workload": true,
-      "toolsTechnologies": false,
-      "practicalWork": false,
-      "credential": true,
-      "costModel": true,
-      "pricingOptions": true
-    },
-    "notes": "Official sources reviewed 2026-08-28: the Pluralsight course page, public transactional checkout, individual-plan page, and Pluralsight certificate-of-completion help article. Verified a beginner Pluralsight video course created by Keith Watson; 2 hours 53 minutes; Security-library inclusion; beginner/new-to-cybersecurity starting-point guidance; information-security principles, governance, risk, compliance, asset protection, controls, auditing, monitoring, testing, incident/disaster preparation, and operations topics; and a course-completion certificate after 100% completion. No named tools or course-specific practical work are claimed. Pricing hard gate PASS: the current public USD checkout showed Security+ at $35/month or $294/year; Complete at $55/month or $468/year is retained only because the official plan page says Complete includes every specialty plan. The separate individual-pricing surface showed materially different figures, so the transactional checkout amounts are canonical and the conflict is preserved; localized checkout observed from Spain showed EUR amounts. Prices are modeled as platform subscriptions, not a course purchase or inferred completion total. Rating/review signals remain null, and promotional/strikethrough pricing is excluded."
-  },
-  {
     "courseId": "introduction-cyber-security-nyux-edx",
     "sourceUrl": "https://www.edx.org/learn/cybersecurity/new-york-university-introduction-to-cyber-security",
     "sourceType": "official_provider_page",
@@ -276,7 +247,7 @@
       "reviewCount": false,
       "duration": true,
       "certificate": true,
-      "language": true,
+      "language": false,
       "level": true,
       "syllabus": true,
       "prerequisites": false,
@@ -288,7 +259,7 @@
       "costModel": true,
       "pricingOptions": true
     },
-    "notes": "Official sources reviewed 2026-08-28: the Pluralsight course page, public transactional checkout, individual-plan page, and Pluralsight certificate-of-completion help article. Verified an AWS-authored beginner video course delivered on Pluralsight; 1 hour 6 minutes; Cloud-library inclusion; AWS Cloud architecture, terminology, Compute, Storage, Database, Networking, and Security categories; AWS Cloud as the only explicitly named technology; and a course-completion certificate after 100% completion. The page does not state prerequisites, named AWS services, labs, projects, or other course-specific practical work, so those remain empty/unverified. Pricing hard gate PASS: the current public USD checkout showed Cloud+ at $35/month or $294/year; Complete at $55/month or $468/year is retained only because the official plan page says Complete includes every specialty plan. The separate individual-pricing surface showed materially different figures, so the transactional checkout amounts are canonical and the conflict is preserved; localized checkout observed from Spain showed EUR amounts. Prices are modeled as platform subscriptions, not a course purchase or inferred completion total. Rating/review signals remain null, and promotional/strikethrough pricing is excluded."
+    "notes": "Official sources reviewed 2026-08-28: the Pluralsight course page, public transactional checkout, individual-plan page, and Pluralsight certificate-of-completion help article. Verified an AWS-authored beginner video course delivered on Pluralsight; 1 hour 6 minutes; Cloud-library inclusion; AWS Cloud architecture, terminology, Compute, Storage, Database, Networking, and Security categories; AWS Cloud as the only explicitly named technology; and a course-completion certificate after 100% completion. The page does not explicitly state the primary taught language, prerequisites, named AWS services, labs, projects, or other course-specific practical work, so those remain unknown or empty and unverified. Pricing hard gate PASS: the current public USD checkout showed Cloud+ at $35/month or $294/year; Complete at $55/month or $468/year is retained only because the official plan page says Complete includes every specialty plan. The separate individual-pricing surface showed materially different figures, so the transactional checkout amounts are canonical and the conflict is preserved; localized checkout observed from Spain showed EUR amounts. Prices are modeled as platform subscriptions, not a course purchase or inferred completion total. Rating/review signals remain null, and promotional/strikethrough pricing is excluded."
   },
   {
     "courseId": "google-cloud-fundamentals-core-infrastructure-google",

--- a/data/normalized/course-source-metadata.json
+++ b/data/normalized/course-source-metadata.json
@@ -182,6 +182,35 @@
     "notes": "Sources: official Google Cybersecurity Professional Certificate page on Coursera and official Coursera Plus plan page, reviewed 2026-08-18. Verified the professional-certificate and Google credential context; 6 months at 7 hours/week workload wording; no prior experience requirement; learning topics; Linux, Python, Bash, SQL, SIEM, and intrusion-detection tools; and hands-on labs, practice-based assessments, and portfolio activities. Pricing paths: $49 USD/month for the certificate in the United States and Canada after an initial 7-day trial, with lower pricing possible elsewhere; and $59 USD/month for Coursera Plus catalog access, with the program page explicitly marking this certificate as included. The provider's under-$300 completion estimate was excluded because it depends on completion pace, and the temporary $239/year Coursera Plus promotion was excluded. durationHours remains null because the schedule is not converted into an exact total. Rating and review count remain unknown/null because they are volatile."
   },
   {
+    "courseId": "introduction-information-security-pluralsight",
+    "sourceUrl": "https://www.pluralsight.com/courses/information-security-introduction",
+    "sourceType": "official_provider_page",
+    "verificationStatus": "partially_verified",
+    "lastVerifiedAt": "2026-08-28",
+    "verifiedFields": {
+      "title": true,
+      "platform": true,
+      "sourceUrl": true,
+      "price": true,
+      "rating": false,
+      "reviewCount": false,
+      "duration": true,
+      "certificate": true,
+      "language": true,
+      "level": true,
+      "syllabus": true,
+      "prerequisites": true,
+      "offeringType": true,
+      "workload": true,
+      "toolsTechnologies": false,
+      "practicalWork": false,
+      "credential": true,
+      "costModel": true,
+      "pricingOptions": true
+    },
+    "notes": "Official sources reviewed 2026-08-28: the Pluralsight course page, public transactional checkout, individual-plan page, and Pluralsight certificate-of-completion help article. Verified a beginner Pluralsight video course created by Keith Watson; 2 hours 53 minutes; Security-library inclusion; beginner/new-to-cybersecurity starting-point guidance; information-security principles, governance, risk, compliance, asset protection, controls, auditing, monitoring, testing, incident/disaster preparation, and operations topics; and a course-completion certificate after 100% completion. No named tools or course-specific practical work are claimed. Pricing hard gate PASS: the current public USD checkout showed Security+ at $35/month or $294/year; Complete at $55/month or $468/year is retained only because the official plan page says Complete includes every specialty plan. The separate individual-pricing surface showed materially different figures, so the transactional checkout amounts are canonical and the conflict is preserved; localized checkout observed from Spain showed EUR amounts. Prices are modeled as platform subscriptions, not a course purchase or inferred completion total. Rating/review signals remain null, and promotional/strikethrough pricing is excluded."
+  },
+  {
     "courseId": "introduction-cyber-security-nyux-edx",
     "sourceUrl": "https://www.edx.org/learn/cybersecurity/new-york-university-introduction-to-cyber-security",
     "sourceType": "official_provider_page",
@@ -231,6 +260,35 @@
       "pricingOptions": true
     },
     "notes": "Sources: official AWS Cloud Technical Essentials page on Coursera and official Coursera Plus plan page, reviewed 2026-08-18. Verified the single-course and shareable-course-certificate context; 2 weeks at 10 hours/week workload wording; no prior cloud or AWS knowledge requirement together with the provider's technical-background guidance and preparatory-course recommendation for learners new to cloud or coming from business; AWS compute, storage, database, networking, security, monitoring, and optimization topics; named AWS services; four hands-on labs, a step-by-step application build, and a self-graded capstone; and paid certificate context. Pricing path: the normal $59 USD/month Coursera Plus rate for catalog access, with the course page explicitly linking its inclusion to Coursera Plus. The temporary Coursera Plus 40%-off first-three-month promotion was excluded as the canonical commitment, and exact direct certificate pricing was not public. durationHours changed from 20 to null because multiplying the provider's cadence would create a synthetic exact total. Rating and review count remain unknown/null because they are volatile."
+  },
+  {
+    "courseId": "aws-foundations-cloud-essentials-pluralsight",
+    "sourceUrl": "https://www.pluralsight.com/courses/aws-foundations-getting-started-aws-cloud-essentials",
+    "sourceType": "official_provider_page",
+    "verificationStatus": "partially_verified",
+    "lastVerifiedAt": "2026-08-28",
+    "verifiedFields": {
+      "title": true,
+      "platform": true,
+      "sourceUrl": true,
+      "price": true,
+      "rating": false,
+      "reviewCount": false,
+      "duration": true,
+      "certificate": true,
+      "language": true,
+      "level": true,
+      "syllabus": true,
+      "prerequisites": false,
+      "offeringType": true,
+      "workload": true,
+      "toolsTechnologies": true,
+      "practicalWork": false,
+      "credential": true,
+      "costModel": true,
+      "pricingOptions": true
+    },
+    "notes": "Official sources reviewed 2026-08-28: the Pluralsight course page, public transactional checkout, individual-plan page, and Pluralsight certificate-of-completion help article. Verified an AWS-authored beginner video course delivered on Pluralsight; 1 hour 6 minutes; Cloud-library inclusion; AWS Cloud architecture, terminology, Compute, Storage, Database, Networking, and Security categories; AWS Cloud as the only explicitly named technology; and a course-completion certificate after 100% completion. The page does not state prerequisites, named AWS services, labs, projects, or other course-specific practical work, so those remain empty/unverified. Pricing hard gate PASS: the current public USD checkout showed Cloud+ at $35/month or $294/year; Complete at $55/month or $468/year is retained only because the official plan page says Complete includes every specialty plan. The separate individual-pricing surface showed materially different figures, so the transactional checkout amounts are canonical and the conflict is preserved; localized checkout observed from Spain showed EUR amounts. Prices are modeled as platform subscriptions, not a course purchase or inferred completion total. Rating/review signals remain null, and promotional/strikethrough pricing is excluded."
   },
   {
     "courseId": "google-cloud-fundamentals-core-infrastructure-google",

--- a/data/normalized/courses.json
+++ b/data/normalized/courses.json
@@ -418,134 +418,6 @@
     "source": "coursera-curated"
   },
   {
-    "id": "introduction-information-security-pluralsight",
-    "platform": "pluralsight",
-    "title": "Introduction to Information Security",
-    "url": "https://www.pluralsight.com/courses/information-security-introduction",
-    "skillSlug": "cybersecurity",
-    "level": "beginner",
-    "durationHours": 2.8833333333333333,
-    "language": "en",
-    "priceModel": "subscription",
-    "priceAmount": 35,
-    "currency": "USD",
-    "priceInterval": "month",
-    "rating": null,
-    "reviewCount": null,
-    "certificate": true,
-    "lastUpdatedAt": null,
-    "shortDescription": "Short Pluralsight introduction to organizational information-security programs, controls, risk, auditing, incidents, and operations.",
-    "syllabusBullets": [
-      "Security principles, governance, risk management, and compliance",
-      "Asset protection, security controls, architecture, and security operations centers",
-      "Auditing, monitoring, and testing security controls",
-      "Incident management, continuity planning, disaster preparation, and day-to-day security operations"
-    ],
-    "prerequisitesBullets": [
-      "Designed for learners new to cybersecurity or interested in getting started"
-    ],
-    "offeringType": "course",
-    "workload": {
-      "durationQuantity": 2.8833333333333333,
-      "durationUnit": "hour",
-      "hoursPerWeek": null,
-      "text": "2 hours 53 minutes"
-    },
-    "toolsTechnologies": [],
-    "practicalWorkBullets": [],
-    "credential": {
-      "type": "course_certificate",
-      "text": "Pluralsight certificate of completion for a completed video course"
-    },
-    "costModel": {
-      "type": "subscription",
-      "text": "The Security+ or Complete individual subscription includes the Security library; a free trial may provide temporary course access"
-    },
-    "pricingOptions": [
-      {
-        "id": "pluralsight-security-plus-monthly",
-        "model": "platform_subscription",
-        "amount": 35,
-        "currency": "USD",
-        "normalizedUsdAmount": 35,
-        "cadence": "month",
-        "scope": "Pluralsight Security+ individual plan access, including the Security library and this course",
-        "normalizationBasis": "provider_published_usd",
-        "actionUrl": "https://www.pluralsight.com/commerce/browse",
-        "evidenceUrls": [
-          "https://www.pluralsight.com/courses/information-security-introduction",
-          "https://www.pluralsight.com/commerce/browse",
-          "https://www.pluralsight.com/individuals/pricing"
-        ],
-        "observedAt": "2026-08-28",
-        "referenceMarket": "United States",
-        "accessContext": "public_provider_checkout",
-        "conditions": "Public transactional checkout showed the non-promotional USD rate; amounts and currency localize by market; taxes, trial eligibility, and renewal terms may vary"
-      },
-      {
-        "id": "pluralsight-security-plus-annual",
-        "model": "platform_subscription",
-        "amount": 294,
-        "currency": "USD",
-        "normalizedUsdAmount": 294,
-        "cadence": "year",
-        "scope": "Pluralsight Security+ annual individual plan access, including the Security library and this course",
-        "normalizationBasis": "provider_published_usd",
-        "actionUrl": "https://www.pluralsight.com/commerce/browse",
-        "evidenceUrls": [
-          "https://www.pluralsight.com/courses/information-security-introduction",
-          "https://www.pluralsight.com/commerce/browse",
-          "https://www.pluralsight.com/individuals/pricing"
-        ],
-        "observedAt": "2026-08-28",
-        "referenceMarket": "United States",
-        "accessContext": "public_provider_checkout",
-        "conditions": "Public transactional checkout showed the non-promotional USD rate; amounts and currency localize by market; taxes, trial eligibility, and renewal terms may vary"
-      },
-      {
-        "id": "pluralsight-complete-monthly",
-        "model": "platform_subscription",
-        "amount": 55,
-        "currency": "USD",
-        "normalizedUsdAmount": 55,
-        "cadence": "month",
-        "scope": "Pluralsight Complete individual plan access, including every specialty plan and this Security course",
-        "normalizationBasis": "provider_published_usd",
-        "actionUrl": "https://www.pluralsight.com/commerce/browse",
-        "evidenceUrls": [
-          "https://www.pluralsight.com/courses/information-security-introduction",
-          "https://www.pluralsight.com/commerce/browse",
-          "https://www.pluralsight.com/individuals/pricing"
-        ],
-        "observedAt": "2026-08-28",
-        "referenceMarket": "United States",
-        "accessContext": "public_provider_checkout",
-        "conditions": "Complete entitlement is stated on the official plan page; checkout showed the non-promotional USD rate; amounts and currency localize by market; taxes and renewal terms may vary"
-      },
-      {
-        "id": "pluralsight-complete-annual",
-        "model": "platform_subscription",
-        "amount": 468,
-        "currency": "USD",
-        "normalizedUsdAmount": 468,
-        "cadence": "year",
-        "scope": "Pluralsight Complete annual individual plan access, including every specialty plan and this Security course",
-        "normalizationBasis": "provider_published_usd",
-        "actionUrl": "https://www.pluralsight.com/commerce/browse",
-        "evidenceUrls": [
-          "https://www.pluralsight.com/courses/information-security-introduction",
-          "https://www.pluralsight.com/commerce/browse",
-          "https://www.pluralsight.com/individuals/pricing"
-        ],
-        "observedAt": "2026-08-28",
-        "referenceMarket": "United States",
-        "accessContext": "public_provider_checkout",
-        "conditions": "Complete entitlement is stated on the official plan page; checkout showed the non-promotional USD rate; amounts and currency localize by market; taxes and renewal terms may vary"
-      }
-    ],
-    "source": "other"
-  },
-  {
     "id": "introduction-cyber-security-nyux-edx",
     "platform": "edx",
     "title": "Introduction to Cyber Security",
@@ -663,7 +535,7 @@
     "skillSlug": "cloud-computing",
     "level": "beginner",
     "durationHours": 1.1,
-    "language": "en",
+    "language": "unknown",
     "priceModel": "subscription",
     "priceAmount": 35,
     "currency": "USD",

--- a/data/normalized/courses.json
+++ b/data/normalized/courses.json
@@ -418,6 +418,134 @@
     "source": "coursera-curated"
   },
   {
+    "id": "introduction-information-security-pluralsight",
+    "platform": "pluralsight",
+    "title": "Introduction to Information Security",
+    "url": "https://www.pluralsight.com/courses/information-security-introduction",
+    "skillSlug": "cybersecurity",
+    "level": "beginner",
+    "durationHours": 2.8833333333333333,
+    "language": "en",
+    "priceModel": "subscription",
+    "priceAmount": 35,
+    "currency": "USD",
+    "priceInterval": "month",
+    "rating": null,
+    "reviewCount": null,
+    "certificate": true,
+    "lastUpdatedAt": null,
+    "shortDescription": "Short Pluralsight introduction to organizational information-security programs, controls, risk, auditing, incidents, and operations.",
+    "syllabusBullets": [
+      "Security principles, governance, risk management, and compliance",
+      "Asset protection, security controls, architecture, and security operations centers",
+      "Auditing, monitoring, and testing security controls",
+      "Incident management, continuity planning, disaster preparation, and day-to-day security operations"
+    ],
+    "prerequisitesBullets": [
+      "Designed for learners new to cybersecurity or interested in getting started"
+    ],
+    "offeringType": "course",
+    "workload": {
+      "durationQuantity": 2.8833333333333333,
+      "durationUnit": "hour",
+      "hoursPerWeek": null,
+      "text": "2 hours 53 minutes"
+    },
+    "toolsTechnologies": [],
+    "practicalWorkBullets": [],
+    "credential": {
+      "type": "course_certificate",
+      "text": "Pluralsight certificate of completion for a completed video course"
+    },
+    "costModel": {
+      "type": "subscription",
+      "text": "The Security+ or Complete individual subscription includes the Security library; a free trial may provide temporary course access"
+    },
+    "pricingOptions": [
+      {
+        "id": "pluralsight-security-plus-monthly",
+        "model": "platform_subscription",
+        "amount": 35,
+        "currency": "USD",
+        "normalizedUsdAmount": 35,
+        "cadence": "month",
+        "scope": "Pluralsight Security+ individual plan access, including the Security library and this course",
+        "normalizationBasis": "provider_published_usd",
+        "actionUrl": "https://www.pluralsight.com/commerce/browse",
+        "evidenceUrls": [
+          "https://www.pluralsight.com/courses/information-security-introduction",
+          "https://www.pluralsight.com/commerce/browse",
+          "https://www.pluralsight.com/individuals/pricing"
+        ],
+        "observedAt": "2026-08-28",
+        "referenceMarket": "United States",
+        "accessContext": "public_provider_checkout",
+        "conditions": "Public transactional checkout showed the non-promotional USD rate; amounts and currency localize by market; taxes, trial eligibility, and renewal terms may vary"
+      },
+      {
+        "id": "pluralsight-security-plus-annual",
+        "model": "platform_subscription",
+        "amount": 294,
+        "currency": "USD",
+        "normalizedUsdAmount": 294,
+        "cadence": "year",
+        "scope": "Pluralsight Security+ annual individual plan access, including the Security library and this course",
+        "normalizationBasis": "provider_published_usd",
+        "actionUrl": "https://www.pluralsight.com/commerce/browse",
+        "evidenceUrls": [
+          "https://www.pluralsight.com/courses/information-security-introduction",
+          "https://www.pluralsight.com/commerce/browse",
+          "https://www.pluralsight.com/individuals/pricing"
+        ],
+        "observedAt": "2026-08-28",
+        "referenceMarket": "United States",
+        "accessContext": "public_provider_checkout",
+        "conditions": "Public transactional checkout showed the non-promotional USD rate; amounts and currency localize by market; taxes, trial eligibility, and renewal terms may vary"
+      },
+      {
+        "id": "pluralsight-complete-monthly",
+        "model": "platform_subscription",
+        "amount": 55,
+        "currency": "USD",
+        "normalizedUsdAmount": 55,
+        "cadence": "month",
+        "scope": "Pluralsight Complete individual plan access, including every specialty plan and this Security course",
+        "normalizationBasis": "provider_published_usd",
+        "actionUrl": "https://www.pluralsight.com/commerce/browse",
+        "evidenceUrls": [
+          "https://www.pluralsight.com/courses/information-security-introduction",
+          "https://www.pluralsight.com/commerce/browse",
+          "https://www.pluralsight.com/individuals/pricing"
+        ],
+        "observedAt": "2026-08-28",
+        "referenceMarket": "United States",
+        "accessContext": "public_provider_checkout",
+        "conditions": "Complete entitlement is stated on the official plan page; checkout showed the non-promotional USD rate; amounts and currency localize by market; taxes and renewal terms may vary"
+      },
+      {
+        "id": "pluralsight-complete-annual",
+        "model": "platform_subscription",
+        "amount": 468,
+        "currency": "USD",
+        "normalizedUsdAmount": 468,
+        "cadence": "year",
+        "scope": "Pluralsight Complete annual individual plan access, including every specialty plan and this Security course",
+        "normalizationBasis": "provider_published_usd",
+        "actionUrl": "https://www.pluralsight.com/commerce/browse",
+        "evidenceUrls": [
+          "https://www.pluralsight.com/courses/information-security-introduction",
+          "https://www.pluralsight.com/commerce/browse",
+          "https://www.pluralsight.com/individuals/pricing"
+        ],
+        "observedAt": "2026-08-28",
+        "referenceMarket": "United States",
+        "accessContext": "public_provider_checkout",
+        "conditions": "Complete entitlement is stated on the official plan page; checkout showed the non-promotional USD rate; amounts and currency localize by market; taxes and renewal terms may vary"
+      }
+    ],
+    "source": "other"
+  },
+  {
     "id": "introduction-cyber-security-nyux-edx",
     "platform": "edx",
     "title": "Introduction to Cyber Security",
@@ -526,6 +654,134 @@
       }
     ],
     "source": "coursera-curated"
+  },
+  {
+    "id": "aws-foundations-cloud-essentials-pluralsight",
+    "platform": "pluralsight",
+    "title": "AWS Foundations: Getting Started with the AWS Cloud Essentials",
+    "url": "https://www.pluralsight.com/courses/aws-foundations-getting-started-aws-cloud-essentials",
+    "skillSlug": "cloud-computing",
+    "level": "beginner",
+    "durationHours": 1.1,
+    "language": "en",
+    "priceModel": "subscription",
+    "priceAmount": 35,
+    "currency": "USD",
+    "priceInterval": "month",
+    "rating": null,
+    "reviewCount": null,
+    "certificate": true,
+    "lastUpdatedAt": null,
+    "shortDescription": "AWS-authored Pluralsight course introducing AWS Cloud architecture, terminology, and core service categories.",
+    "syllabusBullets": [
+      "AWS Cloud architecture and foundational terminology",
+      "AWS Compute and Storage service categories",
+      "AWS Database and Networking service categories",
+      "AWS Security service categories"
+    ],
+    "prerequisitesBullets": [],
+    "offeringType": "course",
+    "workload": {
+      "durationQuantity": 1.1,
+      "durationUnit": "hour",
+      "hoursPerWeek": null,
+      "text": "1 hour 6 minutes"
+    },
+    "toolsTechnologies": [
+      "AWS Cloud"
+    ],
+    "practicalWorkBullets": [],
+    "credential": {
+      "type": "course_certificate",
+      "text": "Pluralsight certificate of completion for a completed video course"
+    },
+    "costModel": {
+      "type": "subscription",
+      "text": "The Cloud+ or Complete individual subscription includes the Cloud library; a free trial may provide temporary course access"
+    },
+    "pricingOptions": [
+      {
+        "id": "pluralsight-cloud-plus-monthly",
+        "model": "platform_subscription",
+        "amount": 35,
+        "currency": "USD",
+        "normalizedUsdAmount": 35,
+        "cadence": "month",
+        "scope": "Pluralsight Cloud+ individual plan access, including the Cloud library and this course",
+        "normalizationBasis": "provider_published_usd",
+        "actionUrl": "https://www.pluralsight.com/commerce/browse",
+        "evidenceUrls": [
+          "https://www.pluralsight.com/courses/aws-foundations-getting-started-aws-cloud-essentials",
+          "https://www.pluralsight.com/commerce/browse",
+          "https://www.pluralsight.com/individuals/pricing"
+        ],
+        "observedAt": "2026-08-28",
+        "referenceMarket": "United States",
+        "accessContext": "public_provider_checkout",
+        "conditions": "Public transactional checkout showed the non-promotional USD rate; amounts and currency localize by market; taxes, trial eligibility, and renewal terms may vary"
+      },
+      {
+        "id": "pluralsight-cloud-plus-annual",
+        "model": "platform_subscription",
+        "amount": 294,
+        "currency": "USD",
+        "normalizedUsdAmount": 294,
+        "cadence": "year",
+        "scope": "Pluralsight Cloud+ annual individual plan access, including the Cloud library and this course",
+        "normalizationBasis": "provider_published_usd",
+        "actionUrl": "https://www.pluralsight.com/commerce/browse",
+        "evidenceUrls": [
+          "https://www.pluralsight.com/courses/aws-foundations-getting-started-aws-cloud-essentials",
+          "https://www.pluralsight.com/commerce/browse",
+          "https://www.pluralsight.com/individuals/pricing"
+        ],
+        "observedAt": "2026-08-28",
+        "referenceMarket": "United States",
+        "accessContext": "public_provider_checkout",
+        "conditions": "Public transactional checkout showed the non-promotional USD rate; amounts and currency localize by market; taxes, trial eligibility, and renewal terms may vary"
+      },
+      {
+        "id": "pluralsight-complete-monthly",
+        "model": "platform_subscription",
+        "amount": 55,
+        "currency": "USD",
+        "normalizedUsdAmount": 55,
+        "cadence": "month",
+        "scope": "Pluralsight Complete individual plan access, including every specialty plan and this Cloud course",
+        "normalizationBasis": "provider_published_usd",
+        "actionUrl": "https://www.pluralsight.com/commerce/browse",
+        "evidenceUrls": [
+          "https://www.pluralsight.com/courses/aws-foundations-getting-started-aws-cloud-essentials",
+          "https://www.pluralsight.com/commerce/browse",
+          "https://www.pluralsight.com/individuals/pricing"
+        ],
+        "observedAt": "2026-08-28",
+        "referenceMarket": "United States",
+        "accessContext": "public_provider_checkout",
+        "conditions": "Complete entitlement is stated on the official plan page; checkout showed the non-promotional USD rate; amounts and currency localize by market; taxes and renewal terms may vary"
+      },
+      {
+        "id": "pluralsight-complete-annual",
+        "model": "platform_subscription",
+        "amount": 468,
+        "currency": "USD",
+        "normalizedUsdAmount": 468,
+        "cadence": "year",
+        "scope": "Pluralsight Complete annual individual plan access, including every specialty plan and this Cloud course",
+        "normalizationBasis": "provider_published_usd",
+        "actionUrl": "https://www.pluralsight.com/commerce/browse",
+        "evidenceUrls": [
+          "https://www.pluralsight.com/courses/aws-foundations-getting-started-aws-cloud-essentials",
+          "https://www.pluralsight.com/commerce/browse",
+          "https://www.pluralsight.com/individuals/pricing"
+        ],
+        "observedAt": "2026-08-28",
+        "referenceMarket": "United States",
+        "accessContext": "public_provider_checkout",
+        "conditions": "Complete entitlement is stated on the official plan page; checkout showed the non-promotional USD rate; amounts and currency localize by market; taxes and renewal terms may vary"
+      }
+    ],
+    "source": "other"
   },
   {
     "id": "google-cloud-fundamentals-core-infrastructure-google",

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -16,11 +16,11 @@ Recent product review exposed an important distinction: source-trusted catalog d
 
 Key outcomes:
 
-- Exactly two current Pluralsight courses are added: AWS Foundations: Getting Started with the AWS Cloud Essentials and Introduction to Information Security.
-- Each independently passes the actionable-pricing hard gate and 5/7 decision dimensions. Cloud lacks verified prerequisites and course-specific practical work; Cybersecurity lacks named tools and course-specific practical work.
-- Current USD checkout commitments are modeled as platform subscriptions: Cloud+/Security+ at `$35/month` or `$294/year`, and Complete at `$55/month` or `$468/year`. The conflicting individual-pricing surface and market localization remain explicit provenance conditions.
-- The normalized catalog now contains 21 courses; 13 are decision-grade across eight approved pairs with exact manifest/migration alignment.
-- Pluralsight required only one shared platform mapping. Course cards, details, Compare, centralized outbound behavior, and both canonical skill guides remain provider-neutral; Cloud and Cybersecurity automatically surface two pairs each.
+- Exactly one current Pluralsight course is added: AWS Foundations: Getting Started with the AWS Cloud Essentials. It passes the actionable-pricing hard gate and 5/7 decision dimensions; primary taught language, prerequisites, and course-specific practical work remain unverified.
+- Introduction to Information Security is blocked and intentionally omitted because its official course page appears active while the current official author page labels it `RETIRED`; no substitute Cybersecurity course was added.
+- Current USD checkout commitments are modeled as platform subscriptions: Cloud+ at `$35/month` or `$294/year`, and Complete at `$55/month` or `$468/year`. The conflicting individual-pricing surface and market localization remain explicit provenance conditions.
+- The normalized catalog now contains 20 courses; 12 are decision-grade across seven approved pairs with exact manifest/migration alignment.
+- Pluralsight required only one shared platform mapping. Course cards, details, Compare, centralized outbound behavior, and canonical skill guides remain provider-neutral; Cloud Computing automatically surfaces two pairs while Cybersecurity retains its incumbent pair.
 - Official-source, gate, provider-neutrality, SEO/indexing, and desktop/mobile acceptance evidence is recorded in `docs/decision-grade-phase-1b8-pluralsight-provider.md`.
 
 ### Phase 3B — Selective Decision-led SEO Reactivation — Issue #111
@@ -28,11 +28,11 @@ Key outcomes:
 Key outcomes:
 
 - The five canonical skills with accepted decision-grade pairs (`ai`, `cybersecurity`, `data-analysis`, `cloud-computing`, and `project-management`) now expose crawlable, people-first decision guides without creating new routes or scaled SEO volume.
-- One deterministic manifest-driven model preserves readiness-pair order, maps verified catalog facts through the existing decision-support layer, and supplies reusable pair cards. Project Management, Cloud Computing, and Cybersecurity therefore surface their additional approved pairs automatically.
+- One deterministic manifest-driven model preserves readiness-pair order, maps verified catalog facts through the existing decision-support layer, and supplies reusable pair cards. Project Management and Cloud Computing therefore surface their additional approved pairs automatically.
 - Each pair links to the exact stable Compare URL and both canonical course-detail pages. The skill acquisition surface does not add outbound provider behavior, affiliate links, rankings, or provider-specific branches.
-- Target metadata reflects stable course-comparison intent without volatile prices. The sitemap remains limited to the homepage, eight canonical skills, and the current 21 course-detail pages; all 20 generated SEO templates remain `noindex, follow` and outside the sitemap.
+- Target metadata reflects stable course-comparison intent without volatile prices. The sitemap remains limited to the homepage, eight canonical skills, and the current 20 course-detail pages; all 20 generated SEO templates remain `noindex, follow` and outside the sitemap.
 - A focused regression check covers target-skill/pair mapping, canonical metadata, generated-route robots directives, sitemap boundaries, and non-target exclusion.
-- Issue #116 completed issue #112's bounded Pluralsight Cloud/Cybersecurity sequence only after both candidates cleared the existing hard gate. No further provider batch is authorized, and commission does not influence visible presentation.
+- Issue #116 completed issue #112's bounded Pluralsight Cloud/Cybersecurity evaluation: Cloud cleared the existing hard gate and Cybersecurity was blocked by conflicting official availability evidence. No further provider batch is authorized, and commission does not influence visible presentation.
 
 ### Phase 1B.7 — Multi-provider Acceptance + Cross-platform Project Management — Issue #108
 
@@ -122,8 +122,8 @@ Earlier completed initiatives, including Phase 1 Source Verification Batches A/B
 ## Phase Status
 
 - **Phase 0 — MVP:** complete for the current MVP scope.
-- **Phase 1A — Source Trust:** complete for the original 19-course curated MVP catalog; the two Phase 1B.8 additions have current official-source records.
-- **Phase 1B — Decision-Grade Data:** Phase 1B.1 through Phase 1B.8 are implemented; 13 courses across eight approved pairs are decision-grade, and independent product review must approve any later batch.
+- **Phase 1A — Source Trust:** complete for the original 19-course curated MVP catalog; the one Phase 1B.8 addition has a current official-source record.
+- **Phase 1B — Decision-Grade Data:** Phase 1B.1 through Phase 1B.8 are implemented; 12 courses across seven approved pairs are decision-grade, and independent product review must approve any later batch.
 - **Phase 2 — Monetization:** gated / not started. It activates only when a real auditable affiliate/referral program exists and does not block Phase 3.
 - **Phase 3 — Discovery and SEO:** active. The indexable-surface foundation and selective Phase 3B decision guides on five canonical skills are implemented; generated SEO templates remain gated pending stronger product/search evidence.
 - **Phase 4 — Recommendation:** later, gated behind explicit criteria and trustworthy signals.
@@ -131,12 +131,12 @@ Earlier completed initiatives, including Phase 1 Source Verification Batches A/B
 
 ## Catalog and Trust State
 
-- The normalized catalog contains 21 curated courses.
-- 19 courses are currently `partially_verified`.
+- The normalized catalog contains 20 curated courses.
+- 18 courses are currently `partially_verified`.
 - 2 courses remain `pending` with explicit source blockers rather than unreviewed status.
 - Source URL mismatches: 0 after the completed verification batches.
-- Pricing remains unknown or unverified for the 8 non-migrated courses; the 13 approved decision-grade records now have actionable source-backed USD pricing paths. Most ratings and review counts remain unknown by design.
-- The 13 approved decision-grade records preserve provider-described workloads, including exact video-course durations and longer schedules, without inferring completion totals.
+- Pricing remains unknown or unverified for the 8 non-migrated courses; the 12 approved decision-grade records now have actionable source-backed USD pricing paths. Most ratings and review counts remain unknown by design.
+- The 12 approved decision-grade records preserve provider-described workloads, including exact video-course durations and longer schedules, without inferring completion totals.
 - The current normalized `language` field represents the primary taught language when clearly supported by an official source. Additional dubbing/subtitle/language availability remains provenance context unless a later explicit schema initiative changes that model.
 - `report:data-quality` remains part of normal validation.
 - Official provider pages remain the final source for volatile enrollment terms, but Skills Compare should perform the basic comparison work rather than merely redirecting users to two provider pages.

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,6 +1,6 @@
 # Current State
 
-Last updated after implementing Phase 3B selective decision-led SEO reactivation for independent product review.
+Last updated after implementing the bounded Phase 1B.8 Pluralsight provider batch for independent product review.
 
 ## Product State
 
@@ -12,16 +12,27 @@ Recent product review exposed an important distinction: source-trusted catalog d
 
 ## Latest Completed Initiatives
 
+### Phase 1B.8 — Pluralsight Provider Batch — Issue #116
+
+Key outcomes:
+
+- Exactly two current Pluralsight courses are added: AWS Foundations: Getting Started with the AWS Cloud Essentials and Introduction to Information Security.
+- Each independently passes the actionable-pricing hard gate and 5/7 decision dimensions. Cloud lacks verified prerequisites and course-specific practical work; Cybersecurity lacks named tools and course-specific practical work.
+- Current USD checkout commitments are modeled as platform subscriptions: Cloud+/Security+ at `$35/month` or `$294/year`, and Complete at `$55/month` or `$468/year`. The conflicting individual-pricing surface and market localization remain explicit provenance conditions.
+- The normalized catalog now contains 21 courses; 13 are decision-grade across eight approved pairs with exact manifest/migration alignment.
+- Pluralsight required only one shared platform mapping. Course cards, details, Compare, centralized outbound behavior, and both canonical skill guides remain provider-neutral; Cloud and Cybersecurity automatically surface two pairs each.
+- Official-source, gate, provider-neutrality, SEO/indexing, and desktop/mobile acceptance evidence is recorded in `docs/decision-grade-phase-1b8-pluralsight-provider.md`.
+
 ### Phase 3B — Selective Decision-led SEO Reactivation — Issue #111
 
 Key outcomes:
 
 - The five canonical skills with accepted decision-grade pairs (`ai`, `cybersecurity`, `data-analysis`, `cloud-computing`, and `project-management`) now expose crawlable, people-first decision guides without creating new routes or scaled SEO volume.
-- One deterministic manifest-driven model preserves readiness-pair order, maps verified catalog facts through the existing decision-support layer, and supplies reusable pair cards. Project Management therefore surfaces both approved pairs automatically, including the Coursera-versus-edX option.
+- One deterministic manifest-driven model preserves readiness-pair order, maps verified catalog facts through the existing decision-support layer, and supplies reusable pair cards. Project Management, Cloud Computing, and Cybersecurity therefore surface their additional approved pairs automatically.
 - Each pair links to the exact stable Compare URL and both canonical course-detail pages. The skill acquisition surface does not add outbound provider behavior, affiliate links, rankings, or provider-specific branches.
-- Target metadata now reflects stable course-comparison intent without volatile prices. The sitemap remains limited to the homepage, eight canonical skills, and 19 course-detail pages; all 20 generated SEO templates remain `noindex, follow` and outside the sitemap.
+- Target metadata reflects stable course-comparison intent without volatile prices. The sitemap remains limited to the homepage, eight canonical skills, and the current 21 course-detail pages; all 20 generated SEO templates remain `noindex, follow` and outside the sitemap.
 - A focused regression check covers target-skill/pair mapping, canonical metadata, generated-route robots directives, sitemap boundaries, and non-target exclusion.
-- Issue #112 supersedes the earlier default-next-provider note: after review, Pluralsight Cloud/Cybersecurity is the default next batch only if current official pricing and entitlement evidence clears the hard gate; LinkedIn Learning remains the fallback. Commission does not influence visible presentation.
+- Issue #116 completed issue #112's bounded Pluralsight Cloud/Cybersecurity sequence only after both candidates cleared the existing hard gate. No further provider batch is authorized, and commission does not influence visible presentation.
 
 ### Phase 1B.7 — Multi-provider Acceptance + Cross-platform Project Management — Issue #108
 
@@ -111,8 +122,8 @@ Earlier completed initiatives, including Phase 1 Source Verification Batches A/B
 ## Phase Status
 
 - **Phase 0 — MVP:** complete for the current MVP scope.
-- **Phase 1A — Source Trust:** complete for the current 19-course curated MVP catalog; ongoing maintenance only.
-- **Phase 1B — Decision-Grade Data:** Phase 1B.1 through Phase 1B.7 are implemented; 11 courses across six approved pairs are decision-grade, and independent product review must approve any later batch.
+- **Phase 1A — Source Trust:** complete for the original 19-course curated MVP catalog; the two Phase 1B.8 additions have current official-source records.
+- **Phase 1B — Decision-Grade Data:** Phase 1B.1 through Phase 1B.8 are implemented; 13 courses across eight approved pairs are decision-grade, and independent product review must approve any later batch.
 - **Phase 2 — Monetization:** gated / not started. It activates only when a real auditable affiliate/referral program exists and does not block Phase 3.
 - **Phase 3 — Discovery and SEO:** active. The indexable-surface foundation and selective Phase 3B decision guides on five canonical skills are implemented; generated SEO templates remain gated pending stronger product/search evidence.
 - **Phase 4 — Recommendation:** later, gated behind explicit criteria and trustworthy signals.
@@ -120,12 +131,12 @@ Earlier completed initiatives, including Phase 1 Source Verification Batches A/B
 
 ## Catalog and Trust State
 
-- The normalized catalog contains 19 curated courses.
-- 17 courses are currently `partially_verified`.
+- The normalized catalog contains 21 curated courses.
+- 19 courses are currently `partially_verified`.
 - 2 courses remain `pending` with explicit source blockers rather than unreviewed status.
 - Source URL mismatches: 0 after the completed verification batches.
-- Pricing remains unknown or unverified for the 8 non-migrated courses; the 11 approved decision-grade records now have actionable source-backed USD pricing paths. Most ratings and review counts remain unknown by design.
-- The 11 approved decision-grade records preserve provider-described workload schedules such as months plus hours per week while exact `durationHours` remains null unless the source explicitly states a total.
+- Pricing remains unknown or unverified for the 8 non-migrated courses; the 13 approved decision-grade records now have actionable source-backed USD pricing paths. Most ratings and review counts remain unknown by design.
+- The 13 approved decision-grade records preserve provider-described workloads, including exact video-course durations and longer schedules, without inferring completion totals.
 - The current normalized `language` field represents the primary taught language when clearly supported by an official source. Additional dubbing/subtitle/language availability remains provenance context unless a later explicit schema initiative changes that model.
 - `report:data-quality` remains part of normal validation.
 - Official provider pages remain the final source for volatile enrollment terms, but Skills Compare should perform the basic comparison work rather than merely redirecting users to two provider pages.
@@ -183,7 +194,7 @@ Phase 1B.7 completed the required cumulative review. All five incumbent comparis
 
 ## Parallel Ongoing Work
 
-Phase 1A source quality remains an ongoing maintenance concern, but verification should be driven by concrete decision-value needs rather than by a goal of maximizing verified-field counts. Phase 3B is bounded to existing canonical skill hubs; additional indexable volume still requires product and search evidence. The next provider-batch default is Pluralsight Cloud/Cybersecurity only if the existing evidence hard gate is satisfied, with LinkedIn Learning as fallback. Monetization remains gated behind a real program and disclosure design, and recommendation remains gated behind trustworthy signals and explicit criteria.
+Phase 1A source quality remains an ongoing maintenance concern, but verification should be driven by concrete decision-value needs rather than by a goal of maximizing verified-field counts. Phase 3B is bounded to existing canonical skill hubs; additional indexable volume still requires product and search evidence. Phase 1B.8 completes the currently authorized provider batch, so any later provider or course requires a new explicit product decision. Monetization remains gated behind a real program and disclosure design, and recommendation remains gated behind trustworthy signals and explicit criteria.
 
 ## Operational Note
 

--- a/docs/MVP_READINESS.md
+++ b/docs/MVP_READINESS.md
@@ -4,11 +4,11 @@
 
 - Skills Compare is an English-first product for finding skills, reviewing relevant online courses, comparing two options, and opening the original provider page.
 - Phase 0 is complete for the current MVP scope.
-- Phase 1A source trust is complete for the original 19-course catalog; Phase 1B.8 adds two current official-source Pluralsight records and expands the approved decision-grade set to exactly 13 courses and eight pairs for independent product review.
+- Phase 1A source trust is complete for the original 19-course catalog; Phase 1B.8 adds one current official-source Pluralsight Cloud record and expands the approved decision-grade set to exactly 12 courses and seven pairs. The evaluated Cybersecurity candidate is intentionally omitted because official Pluralsight pages conflict on whether it is retired.
 - Phase 2 monetization is gated until a real auditable affiliate/referral program exists and does not block Phase 3.
 - Phase 3 Discovery and SEO has its indexable-surface foundation plus selective decision guides on the five canonical skills with approved readiness pairs; scaled/generated expansion remains gated.
-- The normalized catalog contains 21 curated courses.
-- 19 courses are `partially_verified`; 2 remain `pending` because the exact recorded offering could not be confirmed from a current official source.
+- The normalized catalog contains 20 curated courses.
+- 18 courses are `partially_verified`; 2 remain `pending` because the exact recorded offering could not be confirmed from a current official source.
 - Source URL mismatches are 0 after Phase 1 Source Verification — Coverage Batch B.
 - Generated SEO pages, sitemap support, and internal SEO links are present as an initial foundation, but the current generated SEO surface is not treated as automatically index-worthy.
 - Provider CTA copy and external-link disclosure copy are centralized.
@@ -17,17 +17,17 @@
 - A data quality report is available with `corepack pnpm report:data-quality` and includes verification-status counts, verified-field coverage, fully pending courses, partially verified courses, and unknown field counts.
 - Mobile Selection and Discovery UX is merged: compare selection persists for up to 24 hours, returning selections are surfaced, and the compare bar is available globally outside the compare page.
 - Decision-focused visual polish is merged across the core Search -> Compare -> Decide journey.
-- Decision Data Contract v2 preserves provider-backed offering, workload, tool, practical-work, credential, and cost-model signals for the 13 explicitly approved courses.
-- Structured pricing preserves source-backed payable paths, USD amounts, cadence, scope, provenance, freshness, and regional/access context for the same 13-course set.
+- Decision Data Contract v2 preserves provider-backed offering, workload, tool, practical-work, credential, and cost-model signals for the 12 explicitly approved courses.
+- Structured pricing preserves source-backed payable paths, USD amounts, cadence, scope, provenance, freshness, and regional/access context for the same 12-course set.
 - Compare presents decision differences and a source-backed at-a-glance snapshot before detailed pricing, criteria, curriculum, and final provider verification.
-- Canonical AI, Cybersecurity, Data Analysis, Cloud Computing, and Project Management pages now surface all eight manifest-approved pairs in deterministic order, with compact source-backed tradeoffs and explicit uncertainty before the detailed Compare flow.
+- Canonical AI, Cybersecurity, Data Analysis, Cloud Computing, and Project Management pages now surface all seven manifest-approved pairs in deterministic order, with compact source-backed tradeoffs and explicit uncertainty before the detailed Compare flow.
 
 ## Trust and Data Quality Reality
 
 - Phase 1 manual verification reviewed the full 19-course curated catalog at least at the record level.
 - Verification remains conservative and can be partial when a current official page does not support a field.
 - Stable fields such as title, platform/source URL, level, primary taught language, certificate visibility, workload/duration signals, learning topics, and prerequisites are marked verified only when clearly supported.
-- Prices remain unverified or unknown for the 8 non-migrated courses; the 13 approved decision-grade courses have actionable source-backed USD pricing paths. Ratings, review counts, and some durations remain unknown by design.
+- Prices remain unverified or unknown for the 8 non-migrated courses; the 12 approved decision-grade courses have actionable source-backed USD pricing paths. Ratings, review counts, some durations, and the surviving Pluralsight course's primary taught language remain unknown by design.
 - Monthly or weekly workload estimates are not converted into invented exact `durationHours`; those values remain null unless the official source provides a sufficiently exact total.
 - The normalized `language` field represents the primary taught language when clearly supported. Additional dubbing, subtitle, translation, or language availability remains provenance context unless a future explicit schema initiative expands the model.
 - `introduction-cyber-security-nyux-edx` remains pending because the recorded edX page is unavailable and no current official page clearly represents the exact same NYUx offering.
@@ -69,8 +69,8 @@
 - Google Project Management Professional Certificate vs Project Management Principles and Practices Specialization passes 6/7 plus the pricing hard gate, with tools/technologies explicitly insufficient for the pair.
 - Google Project Management Professional Certificate vs AdelaideX: Introduction to Project Management passes 6/7 plus the pricing hard gate, with edX tools/technologies explicitly insufficient for the pair.
 - AWS Cloud Technical Essentials vs AWS Foundations: Getting Started with the AWS Cloud Essentials passes 5/7 plus the pricing hard gate, with Pluralsight prerequisites and practical work explicitly insufficient.
-- Google Cybersecurity Professional Certificate vs Introduction to Information Security passes 5/7 plus the pricing hard gate, with Pluralsight tools/technologies and practical work explicitly insufficient.
-- The schema migration is limited to the 13 records in `data/decision-grade-manifest.json`. Independent product review must decide whether another small, explicit batch is justified.
+- Introduction to Information Security is blocked and intentionally omitted because its official course page appears active while the current official author page labels it `RETIRED`; no substitute Cybersecurity course was added.
+- The schema migration is limited to the 12 records in `data/decision-grade-manifest.json`. Independent product review must decide whether another small, explicit batch is justified.
 - Exact actionable pricing is required for every approved decision-grade pair. Provider checkout remains the final source for transaction-specific taxes, eligibility, regional variation, and availability.
 
 ## Validation Workflow

--- a/docs/MVP_READINESS.md
+++ b/docs/MVP_READINESS.md
@@ -4,11 +4,11 @@
 
 - Skills Compare is an English-first product for finding skills, reviewing relevant online courses, comparing two options, and opening the original provider page.
 - Phase 0 is complete for the current MVP scope.
-- Phase 1A source trust is complete for the current 19-course catalog; Phase 1B.7 expands the approved decision-grade set to exactly 11 courses and six pairs, including the first Coursera-versus-edX pair, and awaits independent product review before any later batch.
+- Phase 1A source trust is complete for the original 19-course catalog; Phase 1B.8 adds two current official-source Pluralsight records and expands the approved decision-grade set to exactly 13 courses and eight pairs for independent product review.
 - Phase 2 monetization is gated until a real auditable affiliate/referral program exists and does not block Phase 3.
 - Phase 3 Discovery and SEO has its indexable-surface foundation plus selective decision guides on the five canonical skills with approved readiness pairs; scaled/generated expansion remains gated.
-- The normalized catalog contains 19 curated courses.
-- 17 courses are `partially_verified`; 2 remain `pending` because the exact recorded offering could not be confirmed from a current official source.
+- The normalized catalog contains 21 curated courses.
+- 19 courses are `partially_verified`; 2 remain `pending` because the exact recorded offering could not be confirmed from a current official source.
 - Source URL mismatches are 0 after Phase 1 Source Verification — Coverage Batch B.
 - Generated SEO pages, sitemap support, and internal SEO links are present as an initial foundation, but the current generated SEO surface is not treated as automatically index-worthy.
 - Provider CTA copy and external-link disclosure copy are centralized.
@@ -17,17 +17,17 @@
 - A data quality report is available with `corepack pnpm report:data-quality` and includes verification-status counts, verified-field coverage, fully pending courses, partially verified courses, and unknown field counts.
 - Mobile Selection and Discovery UX is merged: compare selection persists for up to 24 hours, returning selections are surfaced, and the compare bar is available globally outside the compare page.
 - Decision-focused visual polish is merged across the core Search -> Compare -> Decide journey.
-- Decision Data Contract v2 preserves provider-backed offering, workload, tool, practical-work, credential, and cost-model signals for the 11 explicitly approved courses.
-- Structured pricing preserves source-backed payable paths, USD amounts, cadence, scope, provenance, freshness, and regional/access context for the same 11-course set.
+- Decision Data Contract v2 preserves provider-backed offering, workload, tool, practical-work, credential, and cost-model signals for the 13 explicitly approved courses.
+- Structured pricing preserves source-backed payable paths, USD amounts, cadence, scope, provenance, freshness, and regional/access context for the same 13-course set.
 - Compare presents decision differences and a source-backed at-a-glance snapshot before detailed pricing, criteria, curriculum, and final provider verification.
-- Canonical AI, Cybersecurity, Data Analysis, Cloud Computing, and Project Management pages now surface all six manifest-approved pairs in deterministic order, with compact source-backed tradeoffs and explicit uncertainty before the detailed Compare flow.
+- Canonical AI, Cybersecurity, Data Analysis, Cloud Computing, and Project Management pages now surface all eight manifest-approved pairs in deterministic order, with compact source-backed tradeoffs and explicit uncertainty before the detailed Compare flow.
 
 ## Trust and Data Quality Reality
 
 - Phase 1 manual verification reviewed the full 19-course curated catalog at least at the record level.
 - Verification remains conservative and can be partial when a current official page does not support a field.
 - Stable fields such as title, platform/source URL, level, primary taught language, certificate visibility, workload/duration signals, learning topics, and prerequisites are marked verified only when clearly supported.
-- Prices remain unverified or unknown for the 8 non-migrated courses; the 11 approved decision-grade courses have actionable source-backed USD pricing paths. Ratings, review counts, and some durations remain unknown by design.
+- Prices remain unverified or unknown for the 8 non-migrated courses; the 13 approved decision-grade courses have actionable source-backed USD pricing paths. Ratings, review counts, and some durations remain unknown by design.
 - Monthly or weekly workload estimates are not converted into invented exact `durationHours`; those values remain null unless the official source provides a sufficiently exact total.
 - The normalized `language` field represents the primary taught language when clearly supported. Additional dubbing, subtitle, translation, or language availability remains provenance context unless a future explicit schema initiative expands the model.
 - `introduction-cyber-security-nyux-edx` remains pending because the recorded edX page is unavailable and no current official page clearly represents the exact same NYUx offering.
@@ -68,7 +68,9 @@
 - AWS Cloud Technical Essentials vs Introduction to Cloud Computing passes 7/7 plus the pricing hard gate.
 - Google Project Management Professional Certificate vs Project Management Principles and Practices Specialization passes 6/7 plus the pricing hard gate, with tools/technologies explicitly insufficient for the pair.
 - Google Project Management Professional Certificate vs AdelaideX: Introduction to Project Management passes 6/7 plus the pricing hard gate, with edX tools/technologies explicitly insufficient for the pair.
-- The schema migration is limited to the 11 records in `data/decision-grade-manifest.json`. Independent product review must decide whether another small, explicit batch is justified.
+- AWS Cloud Technical Essentials vs AWS Foundations: Getting Started with the AWS Cloud Essentials passes 5/7 plus the pricing hard gate, with Pluralsight prerequisites and practical work explicitly insufficient.
+- Google Cybersecurity Professional Certificate vs Introduction to Information Security passes 5/7 plus the pricing hard gate, with Pluralsight tools/technologies and practical work explicitly insufficient.
+- The schema migration is limited to the 13 records in `data/decision-grade-manifest.json`. Independent product review must decide whether another small, explicit batch is justified.
 - Exact actionable pricing is required for every approved decision-grade pair. Provider checkout remains the final source for transaction-specific taxes, eligibility, regional variation, and availability.
 
 ## Validation Workflow
@@ -84,4 +86,4 @@ Use the documented repository-local TypeScript fallback only when the normal pnp
 
 ## Active Near-Term Gate
 
-Independent product review must evaluate the selective Phase 3B implementation before any broader acquisition surface is considered. Any later catalog batch remains explicit and auditable. Under issue #112's sequencing overlay, Pluralsight Cloud/Cybersecurity is the default next provider target only if current official pricing and entitlement evidence satisfies the existing hard gate; LinkedIn Learning remains the fallback. Phase 2 monetization remains gated until a real program exists.
+Independent product review must evaluate the Phase 1B.8 Pluralsight evidence and presentation before any later catalog batch or broader acquisition surface is considered. Any later batch remains explicit and auditable. Phase 2 monetization remains gated until a real program exists.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,7 +24,7 @@ Future work in this area should be limited to concrete usability defects or regr
 
 ## Phase 1 — Real Data
 
-**Status: Phase 1A source trust complete; Phase 1B.8 adds the bounded Pluralsight Cloud and Cybersecurity provider batch for independent product review.**
+**Status: Phase 1A source trust complete; Phase 1B.8 adds the bounded Pluralsight Cloud course while retaining the Cybersecurity availability blocker found in independent review.**
 
 Goal: make the catalog both trustworthy and useful enough to support real user decisions.
 
@@ -53,7 +53,7 @@ Completed:
 - **Phase 1B.5 — Decision-Grade Rollout Batch 1** in issue #101: exactly four additional courses across Data Analysis and Cloud Computing now use the approved contract. Both new pairs pass pricing plus 7/7 source-backed dimensions, and an explicit eight-course/four-pair manifest keeps unrelated catalog records outside the migration.
 - **Phase 1B.6 — Decision-Grade Rollout Batch 2** in issue #106: the Google Project Management Professional Certificate and UCI Project Management Principles and Practices Specialization now use the approved contract. The pair passes pricing plus 6/7 source-backed dimensions, with UCI tools/technologies explicitly insufficient, and the manifest now contains exactly ten courses across five pairs.
 - **Phase 1B.7 — Multi-provider Acceptance + Cross-platform Project Management** in issue #108: all five incumbent pairs pass cumulative desktop/mobile product acceptance, the current public AdelaideX course page establishes a non-promotional `$149 USD` one-time Premium certificate path, and Google Project Management vs AdelaideX passes pricing plus 6/7 dimensions with edX tools/technologies explicitly insufficient. The manifest now contains exactly 11 courses across six approved pairs.
-- **Phase 1B.8 — Pluralsight Provider Batch** in issue #116: two current Pluralsight video courses independently clear the unchanged pricing and 5/7 gates. The catalog now contains 21 courses; the approved set contains 13 courses across eight pairs. Cloud and Cybersecurity canonical guides surface the new pairs automatically without provider-specific page code.
+- **Phase 1B.8 — Pluralsight Provider Batch** in issue #116: one current Pluralsight Cloud video course clears the unchanged pricing and 5/7 gates. The Cybersecurity candidate is blocked and intentionally omitted because official Pluralsight pages conflict on whether it is retired; no substitute was added. The catalog now contains 20 courses; the approved set contains 12 courses across seven pairs. The Cloud canonical guide surfaces the new pair automatically without provider-specific page code.
 
 Do not migrate the remaining catalog automatically. Any later rollout requires another explicit, auditable batch decision.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,7 +24,7 @@ Future work in this area should be limited to concrete usability defects or regr
 
 ## Phase 1 — Real Data
 
-**Status: Phase 1A source trust complete; Phase 1B.7 multi-provider acceptance and the bounded AdelaideX migration are implemented and awaiting independent product review.**
+**Status: Phase 1A source trust complete; Phase 1B.8 adds the bounded Pluralsight Cloud and Cybersecurity provider batch for independent product review.**
 
 Goal: make the catalog both trustworthy and useful enough to support real user decisions.
 
@@ -53,6 +53,7 @@ Completed:
 - **Phase 1B.5 — Decision-Grade Rollout Batch 1** in issue #101: exactly four additional courses across Data Analysis and Cloud Computing now use the approved contract. Both new pairs pass pricing plus 7/7 source-backed dimensions, and an explicit eight-course/four-pair manifest keeps unrelated catalog records outside the migration.
 - **Phase 1B.6 — Decision-Grade Rollout Batch 2** in issue #106: the Google Project Management Professional Certificate and UCI Project Management Principles and Practices Specialization now use the approved contract. The pair passes pricing plus 6/7 source-backed dimensions, with UCI tools/technologies explicitly insufficient, and the manifest now contains exactly ten courses across five pairs.
 - **Phase 1B.7 — Multi-provider Acceptance + Cross-platform Project Management** in issue #108: all five incumbent pairs pass cumulative desktop/mobile product acceptance, the current public AdelaideX course page establishes a non-promotional `$149 USD` one-time Premium certificate path, and Google Project Management vs AdelaideX passes pricing plus 6/7 dimensions with edX tools/technologies explicitly insufficient. The manifest now contains exactly 11 courses across six approved pairs.
+- **Phase 1B.8 — Pluralsight Provider Batch** in issue #116: two current Pluralsight video courses independently clear the unchanged pricing and 5/7 gates. The catalog now contains 21 courses; the approved set contains 13 courses across eight pairs. Cloud and Cybersecurity canonical guides surface the new pairs automatically without provider-specific page code.
 
 Do not migrate the remaining catalog automatically. Any later rollout requires another explicit, auditable batch decision.
 
@@ -116,8 +117,7 @@ Do not build Phase 5 architecture to solve hypothetical scale.
 ## Immediate Sequence
 
 1. Maintain conservative Phase 1A source trust without reopening verification work for its own sake.
-2. Independently review the selective Phase 3B canonical-skill implementation and its acquisition-to-Compare flow.
-3. Do not begin catalog-wide migration or add courses to the decision-grade manifest without a new product decision.
-4. After Phase 3B review, use issue #112's operating-leverage overlay for the next provider batch: Pluralsight Cloud/Cybersecurity is the default only if current official pricing and entitlement evidence clears the existing hard gate; LinkedIn Learning is the provider-neutral fallback if it does not.
-5. Keep generated SEO templates `noindex, follow` and avoid new pair routes or scaled SEO volume until product and search evidence justify them.
-6. Activate Phase 2 monetization only when a real program and appropriate disclosures are ready; commission must never affect visible ordering or factual presentation.
+2. Independently review the bounded Phase 1B.8 Pluralsight evidence, provider-neutral presentation, and acquisition-to-Compare regressions.
+3. Do not begin catalog-wide migration or add another provider/course to the decision-grade manifest without a new product decision.
+4. Keep generated SEO templates `noindex, follow` and avoid new pair routes or scaled SEO volume until product and search evidence justify them.
+5. Activate Phase 2 monetization only when a real program and appropriate disclosures are ready; commission must never affect visible ordering or factual presentation.

--- a/docs/decision-grade-phase-1b8-pluralsight-provider.md
+++ b/docs/decision-grade-phase-1b8-pluralsight-provider.md
@@ -1,0 +1,77 @@
+# Phase 1B.8 Pluralsight Provider Batch
+
+Reviewed on 2026-08-28. Issue #116 is limited to two current Pluralsight courses, one Cloud Computing pair, and one Cybersecurity pair. Current public official Pluralsight sources were used; affiliate links, rankings, new route types, analytics, dependencies, and infrastructure remain out of scope.
+
+## Official evidence and pricing conflict
+
+Course and entitlement sources:
+
+- [AWS Foundations: Getting Started with the AWS Cloud Essentials](https://www.pluralsight.com/courses/aws-foundations-getting-started-aws-cloud-essentials): AWS-authored beginner video course, 1 hour 6 minutes, included in the Cloud library, covering AWS Cloud architecture and Compute, Storage, Database, Networking, and Security categories.
+- [Introduction to Information Security](https://www.pluralsight.com/courses/information-security-introduction): beginner video course, 2 hours 53 minutes, included in the Security library, covering governance, risk, compliance, asset protection, controls, auditing, monitoring, testing, incidents, continuity, and operations.
+- [Certificate of completion](https://help.pluralsight.com/hc/en-us/articles/24418760491924-Certificate-of-completion): a learner who completes 100% of a video course can generate a Pluralsight certificate of completion. This is not presented as a professional certification or Professional Certificate.
+- [Individual plans](https://www.pluralsight.com/individuals/pricing): specialty plans include the matching domain library, and Complete includes every specialty plan's content.
+- [Public transactional checkout](https://www.pluralsight.com/commerce/browse): the current USD surface showed Cloud+ and Security+ at `$35/month` or `$294/year`, and Complete at `$55/month` or `$468/year`.
+
+The individual-pricing page exposed materially different figures from the public transactional checkout. The conflict is preserved in provenance. Per issue #116, the current public transaction surface supplies the canonical non-promotional USD commitments; promotional or strikethrough figures are excluded. The checkout localizes amounts and currency by market—live review from Spain showed EUR—so every stored USD path identifies the United States reference market and requires final checkout verification.
+
+## Independent gate results
+
+### Cloud candidate
+
+`aws-foundations-cloud-essentials-pluralsight`: pricing **PASS**.
+
+- Offering / credential: source-backed course plus Pluralsight video-course completion certificate.
+- Workload: source-backed 1 hour 6 minutes.
+- Starting point: insufficient. The page says Beginner but does not state prerequisites.
+- Learning topics: source-backed AWS Cloud architecture and five service categories.
+- Tools / technologies: source-backed only for the explicitly named AWS Cloud platform; no individual AWS services are invented.
+- Practical work: insufficient. No course-specific lab, project, or applied activity is stated.
+- Cost model: source-backed Cloud+ or Complete platform subscription; no course purchase price or completion total is inferred.
+
+`aws-cloud-technical-essentials-aws` vs this course: pricing **PASS** + **5/7 PASS**. The comparison is useful because it distinguishes a two-week Coursera course with named AWS services, labs, and a capstone from a 1-hour-6-minute Pluralsight overview delivered through a different platform subscription.
+
+### Cybersecurity candidate
+
+`introduction-information-security-pluralsight`: pricing **PASS**.
+
+- Offering / credential: source-backed course plus Pluralsight video-course completion certificate.
+- Workload: source-backed 2 hours 53 minutes.
+- Starting point: source-backed beginner guidance for learners new to cybersecurity or interested in getting started.
+- Learning topics: source-backed information-security program, control, risk, audit, incident, continuity, and operations topics.
+- Tools / technologies: insufficient. No named tools are stated.
+- Practical work: insufficient. No course-specific lab, project, or applied activity is stated.
+- Cost model: source-backed Security+ or Complete platform subscription; no course purchase price or completion total is inferred.
+
+`google-cybersecurity-google` vs this course: pricing **PASS** + **5/7 PASS**. The UI factually distinguishes a broader six-month Professional Certificate with named tools and practical work from a 2-hour-53-minute introductory course; it does not imply equivalence or rank either option.
+
+## Migration and provider neutrality
+
+- Catalog: 21 courses.
+- Approved decision-grade set: 13 courses.
+- Readiness manifest: eight pairs; all six incumbent pairs and IDs are preserved.
+- Manifest/migration alignment remains exact.
+- The only runtime provider adaptation is the shared catalog mapping for the existing `Pluralsight` platform value. No provider-specific page, component branch, or schema expansion was required.
+- Existing centralized provider/pricing actions and disclosure copy are reused with direct official URLs. No affiliate parameter or commission-based ordering is present.
+- Course cards, course details, skill guides, snapshots, detailed pricing, criteria, and provider actions correctly render platform subscription cadence/scope, AWS-authored-versus-Pluralsight-delivered wording, course-completion certificate context, offering-size differences, and explicit unknown tools/practical-work behavior.
+
+## Phase 3B and indexing regression
+
+The manifest-driven canonical guides automatically add the new pair to both `/skills/cloud-computing` and `/skills/cybersecurity`; each now surfaces two pairs with exact Compare URLs. No hand-authored Pluralsight SEO copy or new route exists.
+
+The existing generated data was refreshed because the catalog input changed, but it remains exactly 20 routes with `noindex, follow`. The sitemap remains limited to the homepage, eight canonical skills, and 21 canonical course details (30 URLs total). `/compare` remains outside the sitemap, and metadata contains no volatile Pluralsight price.
+
+## Product acceptance
+
+- Desktop (1440 × 1000): both changed canonical skill pages, both Pluralsight course details, and both new comparisons passed with correct links, facts, pricing paths, insufficiencies, and provider actions.
+- Mobile (390 × 844): the same surfaces passed; titles and long pricing scopes wrap, skill-guide Compare actions remain 48 px high, and no horizontal overflow or error overlay appeared.
+- All six incumbent comparisons plus both new comparisons passed the full decision hierarchy at both sizes: deterministic summary, snapshot, verified pricing, criteria, detailed content, final verification, and two provider actions.
+- Browser console errors: none.
+
+## Validation
+
+- `corepack pnpm validate:data`: pass; 21 courses and all eight pair gates validated.
+- `corepack pnpm report:data-quality`: pass; 19 partially verified, 2 pending, 0 source mismatches, and exact 13-course manifest alignment.
+- `corepack pnpm check:selective-seo`: pass; five canonical skills, eight manifest pairs, 20 gated generated routes, and 30 sitemap URLs.
+- `corepack pnpm exec tsc --noEmit`: the known Windows launcher-resolution failure occurred before TypeScript ran; `node node_modules/typescript/bin/tsc --noEmit` passed.
+- `corepack pnpm build`: pass.
+- `git diff --check`: pass.

--- a/docs/decision-grade-phase-1b8-pluralsight-provider.md
+++ b/docs/decision-grade-phase-1b8-pluralsight-provider.md
@@ -1,16 +1,17 @@
 # Phase 1B.8 Pluralsight Provider Batch
 
-Reviewed on 2026-08-28. Issue #116 is limited to two current Pluralsight courses, one Cloud Computing pair, and one Cybersecurity pair. Current public official Pluralsight sources were used; affiliate links, rankings, new route types, analytics, dependencies, and infrastructure remain out of scope.
+Reviewed on 2026-08-28. Issue #116 evaluated exactly two Pluralsight candidates for one Cloud Computing pair and one Cybersecurity pair. Only the Cloud candidate cleared the unchanged gates. The Cybersecurity candidate is intentionally omitted because current official Pluralsight surfaces conflict on whether it is retired. Affiliate links, rankings, new route types, analytics, dependencies, and infrastructure remain out of scope.
 
 ## Official evidence and pricing conflict
 
 Course and entitlement sources:
 
 - [AWS Foundations: Getting Started with the AWS Cloud Essentials](https://www.pluralsight.com/courses/aws-foundations-getting-started-aws-cloud-essentials): AWS-authored beginner video course, 1 hour 6 minutes, included in the Cloud library, covering AWS Cloud architecture and Compute, Storage, Database, Networking, and Security categories.
-- [Introduction to Information Security](https://www.pluralsight.com/courses/information-security-introduction): beginner video course, 2 hours 53 minutes, included in the Security library, covering governance, risk, compliance, asset protection, controls, auditing, monitoring, testing, incidents, continuity, and operations.
+- [Introduction to Information Security](https://www.pluralsight.com/courses/information-security-introduction): the course page presents an apparently active beginner course included in the Security library.
+- [Keith Watson author page](https://www.pluralsight.com/authors/keith-watson): the same official provider explicitly labels Introduction to Information Security `RETIRED`, creating a material first-party availability conflict.
 - [Certificate of completion](https://help.pluralsight.com/hc/en-us/articles/24418760491924-Certificate-of-completion): a learner who completes 100% of a video course can generate a Pluralsight certificate of completion. This is not presented as a professional certification or Professional Certificate.
 - [Individual plans](https://www.pluralsight.com/individuals/pricing): specialty plans include the matching domain library, and Complete includes every specialty plan's content.
-- [Public transactional checkout](https://www.pluralsight.com/commerce/browse): the current USD surface showed Cloud+ and Security+ at `$35/month` or `$294/year`, and Complete at `$55/month` or `$468/year`.
+- [Public transactional checkout](https://www.pluralsight.com/commerce/browse): the current USD surface showed Cloud+ at `$35/month` or `$294/year`, and Complete at `$55/month` or `$468/year`.
 
 The individual-pricing page exposed materially different figures from the public transactional checkout. The conflict is preserved in provenance. Per issue #116, the current public transaction surface supplies the canonical non-promotional USD commitments; promotional or strikethrough figures are excluded. The checkout localizes amounts and currency by market—live review from Spain showed EUR—so every stored USD path identifies the United States reference market and requires final checkout verification.
 
@@ -22,6 +23,7 @@ The individual-pricing page exposed materially different figures from the public
 
 - Offering / credential: source-backed course plus Pluralsight video-course completion certificate.
 - Workload: source-backed 1 hour 6 minutes.
+- Primary taught language: unknown and unverified. The official pages reviewed do not explicitly state it.
 - Starting point: insufficient. The page says Beginner but does not state prerequisites.
 - Learning topics: source-backed AWS Cloud architecture and five service categories.
 - Tools / technologies: source-backed only for the explicitly named AWS Cloud platform; no individual AWS services are invented.
@@ -32,46 +34,42 @@ The individual-pricing page exposed materially different figures from the public
 
 ### Cybersecurity candidate
 
-`introduction-information-security-pluralsight`: pricing **PASS**.
+`introduction-information-security-pluralsight`: availability/source hard gate **BLOCKED**.
 
-- Offering / credential: source-backed course plus Pluralsight video-course completion certificate.
-- Workload: source-backed 2 hours 53 minutes.
-- Starting point: source-backed beginner guidance for learners new to cybersecurity or interested in getting started.
-- Learning topics: source-backed information-security program, control, risk, audit, incident, continuity, and operations topics.
-- Tools / technologies: insufficient. No named tools are stated.
-- Practical work: insufficient. No course-specific lab, project, or applied activity is stated.
-- Cost model: source-backed Security+ or Complete platform subscription; no course purchase price or completion total is inferred.
-
-`google-cybersecurity-google` vs this course: pricing **PASS** + **5/7 PASS**. The UI factually distinguishes a broader six-month Professional Certificate with named tools and practical work from a 2-hour-53-minute introductory course; it does not imply equivalence or rank either option.
+- The official course page presents the course and Security-library access as active.
+- The current official Keith Watson author page explicitly labels the same course `RETIRED`.
+- This material first-party conflict prevents a safe claim that the offering is current, regardless of the otherwise sufficient decision dimensions or subscription pricing evidence.
+- The candidate is intentionally absent from the normalized catalog, source-metadata records, approved-course manifest, readiness pairs, generated SEO data, and public product surfaces.
+- No substitute Cybersecurity course was added.
 
 ## Migration and provider neutrality
 
-- Catalog: 21 courses.
-- Approved decision-grade set: 13 courses.
-- Readiness manifest: eight pairs; all six incumbent pairs and IDs are preserved.
+- Catalog: 20 courses.
+- Approved decision-grade set: 12 courses.
+- Readiness manifest: seven pairs; all six incumbent pairs and IDs are preserved.
 - Manifest/migration alignment remains exact.
 - The only runtime provider adaptation is the shared catalog mapping for the existing `Pluralsight` platform value. No provider-specific page, component branch, or schema expansion was required.
 - Existing centralized provider/pricing actions and disclosure copy are reused with direct official URLs. No affiliate parameter or commission-based ordering is present.
-- Course cards, course details, skill guides, snapshots, detailed pricing, criteria, and provider actions correctly render platform subscription cadence/scope, AWS-authored-versus-Pluralsight-delivered wording, course-completion certificate context, offering-size differences, and explicit unknown tools/practical-work behavior.
+- Course cards, course details, skill guides, snapshots, detailed pricing, criteria, and provider actions correctly render platform subscription cadence/scope, AWS-authored-versus-Pluralsight-delivered wording, course-completion certificate context, offering-size differences, and explicit unknown language/prerequisites/practical-work behavior.
 
 ## Phase 3B and indexing regression
 
-The manifest-driven canonical guides automatically add the new pair to both `/skills/cloud-computing` and `/skills/cybersecurity`; each now surfaces two pairs with exact Compare URLs. No hand-authored Pluralsight SEO copy or new route exists.
+The manifest-driven canonical guide automatically adds the new pair to `/skills/cloud-computing`, which now surfaces two pairs with exact Compare URLs. `/skills/cybersecurity` retains its single incumbent pair. No hand-authored Pluralsight SEO copy or new route exists.
 
-The existing generated data was refreshed because the catalog input changed, but it remains exactly 20 routes with `noindex, follow`. The sitemap remains limited to the homepage, eight canonical skills, and 21 canonical course details (30 URLs total). `/compare` remains outside the sitemap, and metadata contains no volatile Pluralsight price.
+The existing generated data was refreshed because the catalog input changed, but it remains exactly 20 routes with `noindex, follow`. The sitemap remains limited to the homepage, eight canonical skills, and 20 canonical course details (29 URLs total). `/compare` remains outside the sitemap, and metadata contains no volatile Pluralsight price.
 
 ## Product acceptance
 
-- Desktop (1440 × 1000): both changed canonical skill pages, both Pluralsight course details, and both new comparisons passed with correct links, facts, pricing paths, insufficiencies, and provider actions.
-- Mobile (390 × 844): the same surfaces passed; titles and long pricing scopes wrap, skill-guide Compare actions remain 48 px high, and no horizontal overflow or error overlay appeared.
-- All six incumbent comparisons plus both new comparisons passed the full decision hierarchy at both sizes: deterministic summary, snapshot, verified pricing, criteria, detailed content, final verification, and two provider actions.
+- Desktop (1440 × 1000) and mobile (390 × 844) acceptance evidence remains applicable to the surviving Cloud skill page, Pluralsight course detail, and new comparison: links, facts, pricing paths, insufficiencies, and provider actions passed without horizontal overflow or error overlays.
+- All six incumbent comparisons plus the surviving Cloud comparison passed the full decision hierarchy at both sizes: deterministic summary, snapshot, verified pricing, criteria, detailed content, final verification, and two provider actions.
+- The rejected Cybersecurity candidate and comparison are no longer public surfaces.
 - Browser console errors: none.
 
 ## Validation
 
-- `corepack pnpm validate:data`: pass; 21 courses and all eight pair gates validated.
-- `corepack pnpm report:data-quality`: pass; 19 partially verified, 2 pending, 0 source mismatches, and exact 13-course manifest alignment.
-- `corepack pnpm check:selective-seo`: pass; five canonical skills, eight manifest pairs, 20 gated generated routes, and 30 sitemap URLs.
+- `corepack pnpm validate:data`: pass; 20 courses and all seven pair gates validated.
+- `corepack pnpm report:data-quality`: pass; 18 partially verified, 2 pending, 0 source mismatches, and exact 12-course manifest alignment.
+- `corepack pnpm check:selective-seo`: pass; five canonical skills, seven manifest pairs, 20 gated generated routes, and 29 sitemap URLs.
 - `corepack pnpm exec tsc --noEmit`: the known Windows launcher-resolution failure occurred before TypeScript ran; `node node_modules/typescript/bin/tsc --noEmit` passed.
 - `corepack pnpm build`: pass.
 - `git diff --check`: pass.

--- a/scripts/check-selective-seo.ts
+++ b/scripts/check-selective-seo.ts
@@ -24,7 +24,7 @@ const targetSkillSlugs = [
 
 const expectedPairCounts = new Map([
   ["ai", 1],
-  ["cybersecurity", 2],
+  ["cybersecurity", 1],
   ["data-analysis", 1],
   ["cloud-computing", 2],
   ["project-management", 2]

--- a/scripts/check-selective-seo.ts
+++ b/scripts/check-selective-seo.ts
@@ -24,9 +24,9 @@ const targetSkillSlugs = [
 
 const expectedPairCounts = new Map([
   ["ai", 1],
-  ["cybersecurity", 1],
+  ["cybersecurity", 2],
   ["data-analysis", 1],
-  ["cloud-computing", 1],
+  ["cloud-computing", 2],
   ["project-management", 2]
 ]);
 

--- a/src/data/generated/seoPages.json
+++ b/src/data/generated/seoPages.json
@@ -99,9 +99,9 @@
     "pageType": "best-courses",
     "intent": "course-discovery",
     "title": "Compare Cloud Computing Courses",
-    "metaDescription": "Explore 3 Cloud Computing course options for course discovery and compare format, level, certificate availability, and pricing details.",
+    "metaDescription": "Explore 4 Cloud Computing course options for course discovery and compare format, level, certificate availability, and pricing details.",
     "h1": "Compare Cloud Computing Courses",
-    "intro": "This page lists 3 Cloud Computing course options from the current Skills Compare catalog for course discovery. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
+    "intro": "This page lists 4 Cloud Computing course options from the current Skills Compare catalog for course discovery. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
     "faq": [
       {
         "question": "How should I choose a Cloud Computing course?",
@@ -118,6 +118,7 @@
     ],
     "courseIds": [
       "aws-cloud-technical-essentials-aws",
+      "aws-foundations-cloud-essentials-pluralsight",
       "google-cloud-fundamentals-core-infrastructure-google",
       "introduction-to-cloud-computing-ibm"
     ]
@@ -129,9 +130,9 @@
     "pageType": "best-courses",
     "intent": "course-discovery",
     "title": "Compare Cybersecurity Courses",
-    "metaDescription": "Explore 3 Cybersecurity course options for course discovery and compare format, level, certificate availability, and pricing details.",
+    "metaDescription": "Explore 4 Cybersecurity course options for course discovery and compare format, level, certificate availability, and pricing details.",
     "h1": "Compare Cybersecurity Courses",
-    "intro": "This page lists 3 Cybersecurity course options from the current Skills Compare catalog for course discovery. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
+    "intro": "This page lists 4 Cybersecurity course options from the current Skills Compare catalog for course discovery. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
     "faq": [
       {
         "question": "How should I choose a Cybersecurity course?",
@@ -149,6 +150,7 @@
     "courseIds": [
       "ibm-cybersecurity-analyst-ibm",
       "google-cybersecurity-google",
+      "introduction-information-security-pluralsight",
       "introduction-cyber-security-nyux-edx"
     ]
   },
@@ -220,9 +222,9 @@
     "pageType": "certification",
     "intent": "credential-path",
     "title": "Certification Cloud Computing Courses",
-    "metaDescription": "Explore 3 Cloud Computing course options for credential path and compare format, level, certificate availability, and pricing details.",
+    "metaDescription": "Explore 4 Cloud Computing course options for credential path and compare format, level, certificate availability, and pricing details.",
     "h1": "Cloud Computing Certification Courses",
-    "intro": "This page lists 3 Cloud Computing course options from the current Skills Compare catalog for credential path. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
+    "intro": "This page lists 4 Cloud Computing course options from the current Skills Compare catalog for credential path. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
     "faq": [
       {
         "question": "How should I choose a Cloud Computing course?",
@@ -239,6 +241,7 @@
     ],
     "courseIds": [
       "aws-cloud-technical-essentials-aws",
+      "aws-foundations-cloud-essentials-pluralsight",
       "google-cloud-fundamentals-core-infrastructure-google",
       "introduction-to-cloud-computing-ibm"
     ]
@@ -250,9 +253,9 @@
     "pageType": "for-beginners",
     "intent": "beginner-path",
     "title": "Beginner Cloud Computing Courses",
-    "metaDescription": "Explore 3 Cloud Computing course options for beginner path and compare format, level, certificate availability, and pricing details.",
+    "metaDescription": "Explore 4 Cloud Computing course options for beginner path and compare format, level, certificate availability, and pricing details.",
     "h1": "Cloud Computing Courses for Beginners",
-    "intro": "This page lists 3 Cloud Computing course options from the current Skills Compare catalog for beginner path. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
+    "intro": "This page lists 4 Cloud Computing course options from the current Skills Compare catalog for beginner path. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
     "faq": [
       {
         "question": "How should I choose a Cloud Computing course?",
@@ -269,6 +272,7 @@
     ],
     "courseIds": [
       "aws-cloud-technical-essentials-aws",
+      "aws-foundations-cloud-essentials-pluralsight",
       "google-cloud-fundamentals-core-infrastructure-google",
       "introduction-to-cloud-computing-ibm"
     ]
@@ -280,9 +284,9 @@
     "pageType": "certification",
     "intent": "credential-path",
     "title": "Certification Cybersecurity Courses",
-    "metaDescription": "Explore 3 Cybersecurity course options for credential path and compare format, level, certificate availability, and pricing details.",
+    "metaDescription": "Explore 4 Cybersecurity course options for credential path and compare format, level, certificate availability, and pricing details.",
     "h1": "Cybersecurity Certification Courses",
-    "intro": "This page lists 3 Cybersecurity course options from the current Skills Compare catalog for credential path. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
+    "intro": "This page lists 4 Cybersecurity course options from the current Skills Compare catalog for credential path. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
     "faq": [
       {
         "question": "How should I choose a Cybersecurity course?",
@@ -300,6 +304,7 @@
     "courseIds": [
       "ibm-cybersecurity-analyst-ibm",
       "google-cybersecurity-google",
+      "introduction-information-security-pluralsight",
       "introduction-cyber-security-nyux-edx"
     ]
   },
@@ -310,9 +315,9 @@
     "pageType": "for-beginners",
     "intent": "beginner-path",
     "title": "Beginner Cybersecurity Courses",
-    "metaDescription": "Explore 3 Cybersecurity course options for beginner path and compare format, level, certificate availability, and pricing details.",
+    "metaDescription": "Explore 4 Cybersecurity course options for beginner path and compare format, level, certificate availability, and pricing details.",
     "h1": "Cybersecurity Courses for Beginners",
-    "intro": "This page lists 3 Cybersecurity course options from the current Skills Compare catalog for beginner path. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
+    "intro": "This page lists 4 Cybersecurity course options from the current Skills Compare catalog for beginner path. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
     "faq": [
       {
         "question": "How should I choose a Cybersecurity course?",
@@ -330,6 +335,7 @@
     "courseIds": [
       "ibm-cybersecurity-analyst-ibm",
       "google-cybersecurity-google",
+      "introduction-information-security-pluralsight",
       "introduction-cyber-security-nyux-edx"
     ]
   },
@@ -433,9 +439,9 @@
     "pageType": "learn",
     "intent": "learning-plan",
     "title": "Learn Cloud Computing Courses",
-    "metaDescription": "Explore 3 Cloud Computing course options for learning plan and compare format, level, certificate availability, and pricing details.",
+    "metaDescription": "Explore 4 Cloud Computing course options for learning plan and compare format, level, certificate availability, and pricing details.",
     "h1": "Learn Cloud Computing",
-    "intro": "This page lists 3 Cloud Computing course options from the current Skills Compare catalog for learning plan. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
+    "intro": "This page lists 4 Cloud Computing course options from the current Skills Compare catalog for learning plan. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
     "faq": [
       {
         "question": "How should I choose a Cloud Computing course?",
@@ -452,6 +458,7 @@
     ],
     "courseIds": [
       "aws-cloud-technical-essentials-aws",
+      "aws-foundations-cloud-essentials-pluralsight",
       "google-cloud-fundamentals-core-infrastructure-google",
       "introduction-to-cloud-computing-ibm"
     ]
@@ -463,9 +470,9 @@
     "pageType": "learn",
     "intent": "learning-plan",
     "title": "Learn Cybersecurity Courses",
-    "metaDescription": "Explore 3 Cybersecurity course options for learning plan and compare format, level, certificate availability, and pricing details.",
+    "metaDescription": "Explore 4 Cybersecurity course options for learning plan and compare format, level, certificate availability, and pricing details.",
     "h1": "Learn Cybersecurity",
-    "intro": "This page lists 3 Cybersecurity course options from the current Skills Compare catalog for learning plan. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
+    "intro": "This page lists 4 Cybersecurity course options from the current Skills Compare catalog for learning plan. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
     "faq": [
       {
         "question": "How should I choose a Cybersecurity course?",
@@ -483,6 +490,7 @@
     "courseIds": [
       "ibm-cybersecurity-analyst-ibm",
       "google-cybersecurity-google",
+      "introduction-information-security-pluralsight",
       "introduction-cyber-security-nyux-edx"
     ]
   },

--- a/src/data/generated/seoPages.json
+++ b/src/data/generated/seoPages.json
@@ -130,9 +130,9 @@
     "pageType": "best-courses",
     "intent": "course-discovery",
     "title": "Compare Cybersecurity Courses",
-    "metaDescription": "Explore 4 Cybersecurity course options for course discovery and compare format, level, certificate availability, and pricing details.",
+    "metaDescription": "Explore 3 Cybersecurity course options for course discovery and compare format, level, certificate availability, and pricing details.",
     "h1": "Compare Cybersecurity Courses",
-    "intro": "This page lists 4 Cybersecurity course options from the current Skills Compare catalog for course discovery. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
+    "intro": "This page lists 3 Cybersecurity course options from the current Skills Compare catalog for course discovery. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
     "faq": [
       {
         "question": "How should I choose a Cybersecurity course?",
@@ -150,7 +150,6 @@
     "courseIds": [
       "ibm-cybersecurity-analyst-ibm",
       "google-cybersecurity-google",
-      "introduction-information-security-pluralsight",
       "introduction-cyber-security-nyux-edx"
     ]
   },
@@ -284,9 +283,9 @@
     "pageType": "certification",
     "intent": "credential-path",
     "title": "Certification Cybersecurity Courses",
-    "metaDescription": "Explore 4 Cybersecurity course options for credential path and compare format, level, certificate availability, and pricing details.",
+    "metaDescription": "Explore 3 Cybersecurity course options for credential path and compare format, level, certificate availability, and pricing details.",
     "h1": "Cybersecurity Certification Courses",
-    "intro": "This page lists 4 Cybersecurity course options from the current Skills Compare catalog for credential path. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
+    "intro": "This page lists 3 Cybersecurity course options from the current Skills Compare catalog for credential path. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
     "faq": [
       {
         "question": "How should I choose a Cybersecurity course?",
@@ -304,7 +303,6 @@
     "courseIds": [
       "ibm-cybersecurity-analyst-ibm",
       "google-cybersecurity-google",
-      "introduction-information-security-pluralsight",
       "introduction-cyber-security-nyux-edx"
     ]
   },
@@ -315,9 +313,9 @@
     "pageType": "for-beginners",
     "intent": "beginner-path",
     "title": "Beginner Cybersecurity Courses",
-    "metaDescription": "Explore 4 Cybersecurity course options for beginner path and compare format, level, certificate availability, and pricing details.",
+    "metaDescription": "Explore 3 Cybersecurity course options for beginner path and compare format, level, certificate availability, and pricing details.",
     "h1": "Cybersecurity Courses for Beginners",
-    "intro": "This page lists 4 Cybersecurity course options from the current Skills Compare catalog for beginner path. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
+    "intro": "This page lists 3 Cybersecurity course options from the current Skills Compare catalog for beginner path. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
     "faq": [
       {
         "question": "How should I choose a Cybersecurity course?",
@@ -335,7 +333,6 @@
     "courseIds": [
       "ibm-cybersecurity-analyst-ibm",
       "google-cybersecurity-google",
-      "introduction-information-security-pluralsight",
       "introduction-cyber-security-nyux-edx"
     ]
   },
@@ -470,9 +467,9 @@
     "pageType": "learn",
     "intent": "learning-plan",
     "title": "Learn Cybersecurity Courses",
-    "metaDescription": "Explore 4 Cybersecurity course options for learning plan and compare format, level, certificate availability, and pricing details.",
+    "metaDescription": "Explore 3 Cybersecurity course options for learning plan and compare format, level, certificate availability, and pricing details.",
     "h1": "Learn Cybersecurity",
-    "intro": "This page lists 4 Cybersecurity course options from the current Skills Compare catalog for learning plan. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
+    "intro": "This page lists 3 Cybersecurity course options from the current Skills Compare catalog for learning plan. Use the course details to review level, duration, certificate availability, and pricing model before enrolling.",
     "faq": [
       {
         "question": "How should I choose a Cybersecurity course?",
@@ -490,7 +487,6 @@
     "courseIds": [
       "ibm-cybersecurity-analyst-ibm",
       "google-cybersecurity-google",
-      "introduction-information-security-pluralsight",
       "introduction-cyber-security-nyux-edx"
     ]
   },

--- a/src/lib/catalog-adapter.ts
+++ b/src/lib/catalog-adapter.ts
@@ -16,6 +16,9 @@ const mapPlatform = (platform: string): Course["platform"] | null => {
   if (normalized === "edx") {
     return "edX";
   }
+  if (normalized === "pluralsight") {
+    return "Pluralsight";
+  }
   if (
     normalized === "microsoft learn" ||
     normalized === "microsoft-learn" ||

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -1,7 +1,7 @@
 export type Course = {
   id: string;
   title: string;
-  platform: "Coursera" | "Udemy" | "Microsoft Learn" | "edX";
+  platform: "Coursera" | "Udemy" | "Microsoft Learn" | "edX" | "Pluralsight";
   skillTags: string[];
   level: "Beginner" | "Intermediate" | "Advanced" | "Mixed" | "Unknown";
   priceModel: "free" | "paid_once" | "subscription" | "unknown";


### PR DESCRIPTION
## Summary

Closes #116.

Completes the bounded Phase 1B.8 Pluralsight Cloud + Cybersecurity evaluation with truthful partial success.

- Added `aws-foundations-cloud-essentials-pluralsight`.
- Blocked `introduction-information-security-pluralsight` because current official Pluralsight surfaces conflict on availability: the course page appears active while the current official author page labels it `RETIRED`.
- No substitute Cybersecurity course was added.

Final catalog shape: 20 courses, 12 decision-grade courses, 7 approved pairs, 29 sitemap URLs.

## Cloud result

The surviving Cloud candidate passes the unchanged actionable-pricing hard gate + 5/7 Decision Data Contract v2 dimensions. Current official evidence supports the course format, 1h 6m workload, beginner level, AWS Cloud learning topics, AWS Cloud technology context, certificate-of-completion context, and Cloud+/Complete subscription entitlement. Primary taught language, prerequisites, and course-specific practical work remain unknown/unverified where the official page does not state them.

Current public USD transactional checkout evidence reviewed 2026-08-28 showed Cloud+ at `$35/month` or `$294/year`, and Complete at `$55/month` or `$468/year`. A materially conflicting individual-pricing surface is preserved in provenance; the transactional checkout is used under #116's rule, with United States reference-market and localization caveats. No promotional price or inferred completion total is used.

## Cybersecurity result

The candidate is intentionally absent from the normalized catalog, source-metadata records, approved manifest, readiness pairs, generated SEO data, and public surfaces because the first-party retirement conflict prevents a safe current-availability claim.

## Provider neutrality / SEO

- One shared `Pluralsight` platform mapping; no provider-specific page/component branch or schema redesign.
- Existing centralized provider/pricing actions and disclosure behavior are reused.
- No affiliate URLs, commission ordering, external analytics, dependencies, or infrastructure changes.
- Cloud Computing automatically surfaces the new approved pair from the manifest; Cybersecurity retains its incumbent pair.
- Generated SEO remains exactly 20 `noindex, follow` routes.
- Sitemap remains homepage + 8 canonical skills + 20 canonical course details = 29 URLs.

Durable evidence: `docs/decision-grade-phase-1b8-pluralsight-provider.md`.

## Validation

- ✅ `corepack pnpm validate:data` — 20 courses; all 7 pair gates pass
- ✅ `corepack pnpm report:data-quality` — 18 partially verified, 2 pending, 0 source mismatches; 12-course manifest alignment
- ✅ `corepack pnpm check:selective-seo` — 5 skills, 7 pairs, 20 gated routes, 29 sitemap URLs
- ⚠️ canonical TypeScript command hit the known Windows launcher-resolution failure before TypeScript ran
- ✅ documented repository-local TypeScript fallback passed
- ✅ `corepack pnpm build`
- ✅ `corepack pnpm generate:seo` after catalog input change
- ✅ `git diff --check`
- ✅ CI, PR Policy, and Vercel preview