### PR TITLE
Production hygiene: indexing, placeholders, headings, and true 404s

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -48,9 +48,9 @@ export default function HomeClient() {
             <p className="text-xs font-bold uppercase tracking-[0.22em] text-blue-700 sm:text-sm">
               Start with a skill
             </p>
-            <h2 className="max-w-4xl text-4xl font-semibold leading-[1.08] tracking-[-0.035em] text-slate-950 sm:text-5xl lg:text-6xl">
+            <h1 className="max-w-4xl text-4xl font-semibold leading-[1.08] tracking-[-0.035em] text-slate-950 sm:text-5xl lg:text-6xl">
               Compare courses before you commit.
-            </h2>
+            </h1>
             <p className="max-w-2xl text-base leading-relaxed text-slate-600 sm:text-lg">
               Search a skill, review course facts, and compare two options side by side.
             </p>
@@ -101,9 +101,9 @@ export default function HomeClient() {
             <p className="text-xs font-bold uppercase tracking-[0.2em] text-slate-500">
               Available skills
             </p>
-            <h3 className="mt-2 text-2xl font-semibold tracking-tight text-slate-950 sm:text-3xl">
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-slate-950 sm:text-3xl">
               Explore the current catalog
-            </h3>
+            </h2>
           </div>
           <p className="max-w-md text-sm leading-relaxed text-slate-500">
             Choose a skill to see factual course options and build a two-course comparison.

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { notFound } from "next/navigation";
 import { blogPosts, getBlogPost } from "@/lib/blog";
 import { AdPlaceholder } from "@/components/AdPlaceholder";
 import { buildPageMetadata } from "@/lib/metadata";
@@ -13,12 +14,7 @@ export const generateStaticParams = () => blogPosts.map((post) => ({ slug: post.
 export const generateMetadata = ({ params }: BlogPostPageProps): Metadata => {
   const post = getBlogPost(params.slug);
   if (!post) {
-    return buildPageMetadata({
-      title: "Article not found | Blog",
-      description: "Article unavailable.",
-      path: `/blog/${params.slug}`,
-      type: "article"
-    });
+    notFound();
   }
   return buildPageMetadata({
     title: `${post.title} | Compare courses`,
@@ -32,25 +28,20 @@ export default function BlogPostPage({ params }: BlogPostPageProps) {
   const post = getBlogPost(params.slug);
 
   if (!post) {
-    return (
-      <section className="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center text-slate-600">
-        <p>Article not found.</p>
-        <Link href="/blog" className="mt-4 inline-flex rounded-lg border border-blue-200 px-4 py-2 text-sm font-semibold text-blue-700">Back to blog</Link>
-      </section>
-    );
+    notFound();
   }
 
   return (
     <article className="mx-auto flex max-w-3xl flex-col gap-6 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6">
       <header className="space-y-2">
         <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Practical guide</p>
-        <h2 className="break-words text-2xl font-semibold text-slate-900 sm:text-3xl">{post.title}</h2>
+        <h1 className="break-words text-2xl font-semibold text-slate-900 sm:text-3xl">{post.title}</h1>
         <p className="text-slate-600">{post.description}</p>
       </header>
       <p className="rounded-lg bg-slate-50 px-4 py-3 text-sm leading-relaxed text-slate-700">{post.intro}</p>
       {post.sections.map((section, index) => (
         <section key={section.heading} className="space-y-3">
-          <h3 className="text-xl font-semibold text-slate-800">{section.heading}</h3>
+          <h2 className="text-xl font-semibold text-slate-800">{section.heading}</h2>
           <ul className="grid gap-2 text-slate-600">
             {section.points.map((point) => (
               <li key={point} className="rounded-lg bg-slate-50 px-3 py-2">{point}</li>
@@ -60,7 +51,7 @@ export default function BlogPostPage({ params }: BlogPostPageProps) {
         </section>
       ))}
       <section className="space-y-3">
-        <h3 className="text-xl font-semibold text-slate-800">Common mistakes to avoid</h3>
+        <h2 className="text-xl font-semibold text-slate-800">Common mistakes to avoid</h2>
         <ul className="grid gap-2 text-slate-600">
           {post.commonMistakes.map((mistake) => (
             <li key={mistake} className="rounded-lg bg-amber-50 px-3 py-2 text-amber-800">{mistake}</li>
@@ -69,7 +60,7 @@ export default function BlogPostPage({ params }: BlogPostPageProps) {
       </section>
 
       <section className="space-y-3">
-        <h3 className="text-xl font-semibold text-slate-800">Helpful next steps in Skills Compare</h3>
+        <h2 className="text-xl font-semibold text-slate-800">Helpful next steps in Skills Compare</h2>
         <ul className="grid gap-2 text-slate-600 sm:grid-cols-2">
           {post.internalLinks.map((item) => (
             <li key={item.href}>
@@ -82,7 +73,7 @@ export default function BlogPostPage({ params }: BlogPostPageProps) {
       </section>
 
       <section className="space-y-3">
-        <h3 className="text-xl font-semibold text-slate-800">Final checklist</h3>
+        <h2 className="text-xl font-semibold text-slate-800">Final checklist</h2>
         <ul className="grid gap-2 text-slate-600">
           {post.checklist.map((item) => (
             <li key={item} className="rounded-lg bg-emerald-50 px-3 py-2 text-emerald-800">{item}</li>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -14,13 +14,13 @@ export default function BlogPage() {
   return (
     <section className="flex flex-col gap-8">
       <div className="space-y-2">
-        <h2 className="text-2xl font-semibold text-slate-900 sm:text-3xl">Comparison blog</h2>
+        <h1 className="text-2xl font-semibold text-slate-900 sm:text-3xl">Comparison blog</h1>
         <p className="text-slate-600">Practical content to help you decide between courses with clear data.</p>
       </div>
       <div className="grid gap-4">
         {blogPosts.map((post) => (
           <article key={post.slug} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5">
-            <h3 className="text-xl font-semibold text-slate-900">{post.title}</h3>
+            <h2 className="text-xl font-semibold text-slate-900">{post.title}</h2>
             <p className="mt-2 text-slate-600">{post.description}</p>
             <Link href={`/blog/${post.slug}`} className="mt-4 inline-flex min-h-10 items-center rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-blue-700 hover:border-slate-300">Read article</Link>
           </article>

--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -49,7 +49,7 @@ const PricingCommitmentCard = ({ course }: { course: Course }) => {
 
   return (
     <article className="min-w-0 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
-      <h4 className="break-words text-lg font-semibold text-slate-950">{course.title}</h4>
+      <h3 className="break-words text-lg font-semibold text-slate-950">{course.title}</h3>
       {pricingOptions.length > 0 ? (
         <div className="mt-4 space-y-4">
           {pricingOptions.map((option, index) => (
@@ -142,9 +142,9 @@ const CourseSnapshotCard = ({ course }: { course: Course }) => {
   return (
     <article className="min-w-0 rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_18px_45px_-36px_rgba(15,23,42,0.45)] sm:p-6">
       <div className="flex min-w-0 flex-col gap-3 border-b border-slate-100 pb-5">
-        <h4 className="break-words text-xl font-semibold tracking-tight text-slate-950">
+        <h3 className="break-words text-xl font-semibold tracking-tight text-slate-950">
           {course.title}
-        </h4>
+        </h3>
         <div className="flex flex-wrap gap-2 text-xs font-semibold">
           <span className="rounded-full bg-blue-50 px-3 py-1.5 text-blue-700">
             {snapshot.offeringType}
@@ -300,9 +300,9 @@ export default function CompareClient() {
   if (!hasTwoCourses) {
     return (
       <section className="flex flex-col items-center gap-4 rounded-2xl border border-dashed border-slate-300 bg-white p-10 text-center">
-        <h2 className="text-2xl font-semibold text-slate-900">
+        <h1 className="text-2xl font-semibold text-slate-900">
           Select exactly 2 courses to compare
-        </h2>
+        </h1>
         <p className="text-slate-600">
           We need two valid selected courses to show a side-by-side comparison.
         </p>
@@ -332,9 +332,9 @@ export default function CompareClient() {
         <p className="text-xs font-bold uppercase tracking-[0.22em] text-blue-700">
           Course comparison
         </p>
-        <h2 className="max-w-5xl break-words text-3xl font-semibold leading-tight tracking-[-0.03em] text-slate-950 sm:text-4xl lg:text-5xl">
+        <h1 className="max-w-5xl break-words text-3xl font-semibold leading-tight tracking-[-0.03em] text-slate-950 sm:text-4xl lg:text-5xl">
           {leftCourse.title} vs {rightCourse.title}
-        </h2>
+        </h1>
         <p className="max-w-3xl text-base leading-relaxed text-slate-600 sm:text-lg">
           Compare current payment commitments, practical differences, and uncertainty before using provider checkout for final confirmation.
         </p>
@@ -346,9 +346,9 @@ export default function CompareClient() {
             <p className="text-xs font-bold uppercase tracking-[0.18em] text-blue-300">
               Decision summary
             </p>
-            <h3 className="mt-2 text-2xl font-semibold tracking-tight text-white sm:text-3xl">
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-white sm:text-3xl">
               What changes your decision?
-            </h3>
+            </h2>
           </div>
           <p className="max-w-md text-sm leading-relaxed text-slate-300">
             This summary is deterministic. It highlights factual fit signals and uncertainty; it does not rank courses.
@@ -367,7 +367,7 @@ export default function CompareClient() {
             </ul>
           </div>
           <div className="rounded-2xl border border-white/10 bg-white/[0.05] p-4 sm:p-5">
-            <h4 className="font-semibold text-white">What remains uncertain</h4>
+            <h3 className="font-semibold text-white">What remains uncertain</h3>
             <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed text-slate-300 marker:text-amber-300">
               {decisionSummary.uncertainty.map((item) => (
                 <li key={item}>{item}</li>
@@ -375,7 +375,7 @@ export default function CompareClient() {
             </ul>
           </div>
           <div className="rounded-2xl border border-white/10 bg-white/[0.05] p-4 sm:p-5">
-            <h4 className="font-semibold text-white">Shared context</h4>
+            <h3 className="font-semibold text-white">Shared context</h3>
             <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed text-slate-400 marker:text-slate-500">
               {decisionSummary.similarities.map((item) => (
                 <li key={item}>{item}</li>
@@ -390,12 +390,12 @@ export default function CompareClient() {
           <p className="text-xs font-bold uppercase tracking-[0.18em] text-blue-700">
             At a glance
           </p>
-          <h3
+          <h2
             id="course-snapshot-heading"
             className="mt-2 text-2xl font-semibold tracking-tight text-slate-950 sm:text-3xl"
           >
             Course snapshot
-          </h3>
+          </h2>
           <p className="mt-2 text-sm leading-relaxed text-slate-600">
             Start with the verified facts most likely to shape the choice, then inspect the evidence and detailed criteria below.
           </p>
@@ -411,9 +411,9 @@ export default function CompareClient() {
           <p className="text-xs font-bold uppercase tracking-[0.18em] text-blue-700">
             Pricing commitments
           </p>
-          <h3 className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
             Current verified pricing
-          </h3>
+          </h2>
           <p className="mt-2 text-sm leading-relaxed text-slate-600">
             All comparable commitments are shown in USD. Course or program paths appear before broader platform-subscription alternatives when both are verified; trials may change the amount due at checkout today.
           </p>
@@ -426,7 +426,7 @@ export default function CompareClient() {
 
       <section className="overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-[0_18px_45px_-36px_rgba(15,23,42,0.45)]">
         <div className="border-b border-slate-200 bg-slate-50/80 px-5 py-5 sm:px-6">
-          <h3 className="text-xl font-semibold tracking-tight text-slate-950">Criteria that matter</h3>
+          <h2 className="text-xl font-semibold tracking-tight text-slate-950">Criteria that matter</h2>
           <p className="mt-1 text-sm text-slate-600">
             Each row includes a status and interpretation so you do not have to infer the tradeoff from raw facts alone.
           </p>
@@ -459,12 +459,12 @@ export default function CompareClient() {
           <p className="text-xs font-bold uppercase tracking-[0.18em] text-blue-700">
             Detailed course content
           </p>
-          <h3
+          <h2
             id="course-content-heading"
             className="mt-2 text-2xl font-semibold tracking-tight text-slate-950"
           >
             Inspect what each course covers
-          </h3>
+          </h2>
           <p className="mt-2 text-sm leading-relaxed text-slate-600">
             Review curriculum, starting-point detail, named tools, and practical work after the decision-level comparison.
           </p>
@@ -480,16 +480,16 @@ export default function CompareClient() {
           <p className="text-xs font-bold uppercase tracking-[0.18em] text-blue-700">
             Final verification
           </p>
-          <h3 className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
             Verify current terms, then act
-          </h3>
+          </h2>
           <p className="mt-2 text-sm leading-relaxed text-slate-600">
             Provider pages are the final source for checkout totals, taxes, eligibility, regional terms, and availability.
           </p>
         </div>
 
         <div className="mt-5 rounded-2xl border border-amber-200 bg-amber-50 p-4 sm:p-5">
-          <h4 className="text-lg font-semibold text-amber-950">Data to verify before enrolling</h4>
+          <h3 className="text-lg font-semibold text-amber-950">Data to verify before enrolling</h3>
           <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed text-amber-900">
             {pendingRisks.map((risk) => (
               <li key={risk}>{risk}</li>
@@ -498,7 +498,7 @@ export default function CompareClient() {
         </div>
 
         <div className="mt-5 rounded-2xl border border-slate-200 bg-slate-50/70 p-4 sm:p-5">
-          <h4 className="text-lg font-semibold text-slate-900">Before you choose</h4>
+          <h3 className="text-lg font-semibold text-slate-900">Before you choose</h3>
           <div className="mt-4 grid gap-3 md:grid-cols-2">
             {decisionChecklist.map((item) => (
               <div key={item} className="flex gap-3 rounded-xl border border-slate-100 bg-white p-3.5 text-sm text-slate-700">

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -5,19 +5,25 @@ import { Suspense } from "react";
 import CompareClient from "./CompareClient";
 import { buildPageMetadata } from "@/lib/metadata";
 
-export const metadata: Metadata = buildPageMetadata({
-  title: "Compare two online courses | Skills Compare",
-  description:
-    "Course comparison page to compare two online courses by price, duration, level, certificate and platform.",
-  path: "/compare"
-});
+export const metadata: Metadata = {
+  ...buildPageMetadata({
+    title: "Compare two online courses | Skills Compare",
+    description:
+      "Course comparison page to compare two online courses by price, duration, level, certificate and platform.",
+    path: "/compare"
+  }),
+  robots: {
+    index: false,
+    follow: true
+  }
+};
 
 export default function ComparePage() {
   return (
     <Suspense
       fallback={
         <section className="flex flex-col items-center gap-4 rounded-2xl border border-dashed border-slate-300 bg-white p-10 text-center">
-          <h2 className="text-2xl font-semibold text-slate-900">Loading...</h2>
+          <h1 className="text-2xl font-semibold text-slate-900">Loading...</h1>
           <p className="text-slate-600">Preparing comparison.</p>
         </section>
       }

--- a/app/courses/[courseId]/CourseDetailClient.tsx
+++ b/app/courses/[courseId]/CourseDetailClient.tsx
@@ -34,9 +34,9 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
   if (!course) {
     return (
       <section className="flex flex-col items-center gap-4 rounded-2xl border border-dashed border-slate-300 bg-white p-10 text-center">
-        <h2 className="text-2xl font-semibold text-slate-900">
+        <h1 className="text-2xl font-semibold text-slate-900">
           Course not found
-        </h2>
+        </h1>
         <p className="text-slate-600">
           Check the course ID or return to home.
         </p>
@@ -96,7 +96,7 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
         </p>
         <div className="mt-3 grid gap-6 lg:grid-cols-[1fr_0.42fr] lg:items-start lg:gap-10">
           <div>
-            <h2 className="break-words text-3xl font-semibold leading-tight tracking-[-0.03em] text-slate-950 sm:text-4xl lg:text-5xl">{course.title}</h2>
+            <h1 className="break-words text-3xl font-semibold leading-tight tracking-[-0.03em] text-slate-950 sm:text-4xl lg:text-5xl">{course.title}</h1>
             <p className="mt-4 max-w-3xl text-base leading-relaxed text-slate-600 sm:text-lg">
               {course.shortDescription ?? "Description unavailable."}
             </p>
@@ -169,9 +169,9 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
             Decision summary
           </p>
-          <h3 className="mt-2 text-lg font-semibold text-slate-900">
+          <h2 className="mt-2 text-lg font-semibold text-slate-900">
             What this course can help you evaluate
-          </h3>
+          </h2>
           <ul className="mt-4 space-y-2 text-sm leading-relaxed text-slate-600">
             {getCourseDecisionSummary(course).known.map((item) => (
               <li key={item} className="rounded-lg bg-slate-50 px-3 py-2">
@@ -194,9 +194,9 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
       </div>
 
       <div className="rounded-2xl border border-amber-200 bg-amber-50/60 p-4 sm:p-6">
-        <h3 className="text-lg font-semibold text-slate-900">
+        <h2 className="text-lg font-semibold text-slate-900">
           Verify before enrolling
-        </h3>
+        </h2>
         <p className="mt-2 text-sm leading-relaxed text-amber-900">
           {PROVIDER_DETAILS_NOTICE}
         </p>
@@ -210,9 +210,9 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
       </div>
 
       <div className="rounded-2xl border border-blue-200/80 bg-white p-5 shadow-[0_18px_45px_-36px_rgba(37,99,235,0.35)] sm:p-6">
-        <h3 className="text-lg font-semibold text-slate-900">
+        <h2 className="text-lg font-semibold text-slate-900">
           Compare for better context
-        </h3>
+        </h2>
         <p className="mt-2 text-sm leading-relaxed text-slate-600">
           {selectedIds.length < 2
             ? "Add this course, then choose one more option for side-by-side context."
@@ -271,7 +271,7 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
         <div className="grid gap-6 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6 md:grid-cols-2">
           {hasLearningBullets ? (
             <div>
-              <h3 className="text-lg font-semibold text-slate-900">What you will learn</h3>
+              <h2 className="text-lg font-semibold text-slate-900">What you will learn</h2>
               <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-600">
                 {course.syllabusBullets.map((item) => (
                   <li key={item}>{item}</li>
@@ -281,7 +281,7 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
           ) : null}
           {hasPrerequisites ? (
             <div>
-              <h3 className="text-lg font-semibold text-slate-900">Prerequisites</h3>
+              <h2 className="text-lg font-semibold text-slate-900">Prerequisites</h2>
               <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-600">
                 {course.prerequisitesBullets.map((item) => (
                   <li key={item}>{item}</li>
@@ -293,7 +293,7 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
       ) : null}
 
       <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6">
-        <h3 className="text-lg font-semibold text-slate-900">Key facts</h3>
+        <h2 className="text-lg font-semibold text-slate-900">Key facts</h2>
         <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {keyFacts.map((fact) => (
             <div key={fact.label} className="rounded-lg bg-slate-50 px-4 py-3">

--- a/app/courses/[courseId]/page.tsx
+++ b/app/courses/[courseId]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 import { courses } from "@/lib/catalog-adapter";
 import { buildPageMetadata } from "@/lib/metadata";
 import CourseDetailClient from "./CourseDetailClient";
@@ -15,12 +16,7 @@ export async function generateMetadata({
   const course = courses.find((item) => item.id === params.courseId);
 
   if (!course) {
-    return buildPageMetadata({
-      title: "Course not found | Skills Compare",
-      description:
-        "Check the Skills Compare catalog to find available online courses.",
-      path: `/courses/${params.courseId}`
-    });
+    notFound();
   }
 
   return buildPageMetadata({
@@ -33,5 +29,9 @@ export async function generateMetadata({
 }
 
 export default function CourseDetailPage({ params }: CoursePageProps) {
+  if (!courses.some((course) => course.id === params.courseId)) {
+    notFound();
+  }
+
   return <CourseDetailClient courseId={params.courseId} />;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,7 +35,7 @@ export default function RootLayout({
                 <p className="truncate text-xs font-semibold uppercase tracking-[0.24em] text-slate-500 sm:text-sm">
                   Skills Compare
                 </p>
-                <h1 className="truncate text-base font-semibold tracking-tight sm:text-xl">Find the right course</h1>
+                <p className="truncate text-base font-semibold tracking-tight sm:text-xl">Find the right course</p>
               </Link>
               <nav className="flex shrink-0 items-center gap-1 rounded-full border border-slate-200/80 bg-white/80 p-1 text-xs font-semibold text-slate-600 shadow-sm backdrop-blur sm:gap-2 sm:text-sm">
                 <Link href="/compare" className="rounded-full px-3 py-2 transition hover:bg-slate-100 hover:text-slate-950 sm:px-4">Compare</Link>

--- a/app/skills/[skillSlug]/page.tsx
+++ b/app/skills/[skillSlug]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 import { getCoursesForSkill, getSkillSummary } from "@/lib/skill-catalog";
 import {
   getDecisionReadyPairsForSkill,
@@ -17,12 +18,7 @@ export const generateMetadata = ({ params }: SkillPageProps): Metadata => {
   const skill = getSkillSummary(params.skillSlug);
 
   if (!skill) {
-    return buildPageMetadata({
-      title: "Skill not found | Skills Compare",
-      description:
-        "Review real alternatives in the Skills Compare catalog to compare online courses.",
-      path: `/skills/${params.skillSlug}`
-    });
+    notFound();
   }
 
   const courseCount = getCoursesForSkill(skill.slug).length;
@@ -49,6 +45,10 @@ export const generateMetadata = ({ params }: SkillPageProps): Metadata => {
 
 export default function SkillPage({ params }: SkillPageProps) {
   const skill = getSkillSummary(params.skillSlug);
+  if (!skill) {
+    notFound();
+  }
+
   const decisionReadyPairs = getDecisionReadyPairsForSkill(params.skillSlug);
   const decisionIntro =
     skill && decisionReadyPairs.length > 0

--- a/scripts/check-selective-seo.ts
+++ b/scripts/check-selective-seo.ts
@@ -1,9 +1,17 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 import decisionGradeManifest from "../data/decision-grade-manifest.json";
+import BlogPostPage from "../app/blog/[slug]/page";
+import { metadata as compareMetadata } from "../app/compare/page";
+import CourseDetailPage from "../app/courses/[courseId]/page";
 import robots from "../app/robots";
 import sitemap from "../app/sitemap";
-import { generateMetadata } from "../app/skills/[skillSlug]/page";
+import SkillPage, {
+  generateMetadata as generateSkillMetadata
+} from "../app/skills/[skillSlug]/page";
+import { AdPlaceholder } from "../src/components/AdPlaceholder";
 import { SITE_URL } from "../src/config/siteConfig";
 import { courses } from "../src/lib/catalog-adapter";
 import {
@@ -48,6 +56,70 @@ assert.deepEqual(
   "robots.txt must allow crawling and advertise the production sitemap."
 );
 
+const compareRobots = compareMetadata.robots;
+assert.equal(
+  typeof compareRobots === "object" ? compareRobots?.index : undefined,
+  false,
+  "Compare must emit noindex."
+);
+assert.equal(
+  typeof compareRobots === "object" ? compareRobots?.follow : undefined,
+  true,
+  "Compare must allow link following."
+);
+assert.equal(
+  compareMetadata.alternates?.canonical,
+  `${SITE_URL}/compare`,
+  "Compare must preserve its route canonical for query-based comparisons."
+);
+
+const isNextNotFound = (error: unknown) =>
+  error instanceof Error &&
+  (error as Error & { digest?: string }).digest === "NEXT_NOT_FOUND";
+
+assert.throws(
+  () => BlogPostPage({ params: { slug: "missing-blog-post" } }),
+  isNextNotFound,
+  "Invalid blog slugs must use the Next.js not-found path."
+);
+assert.throws(
+  () => CourseDetailPage({ params: { courseId: "missing-course" } }),
+  isNextNotFound,
+  "Invalid course IDs must use the Next.js not-found path."
+);
+assert.throws(
+  () => SkillPage({ params: { skillSlug: "missing-skill" } }),
+  isNextNotFound,
+  "Invalid skill slugs must use the Next.js not-found path."
+);
+
+assert.equal(
+  AdPlaceholder({}),
+  null,
+  "Inactive monetization placeholders must not render visible output."
+);
+
+const headingSources = {
+  layout: readFileSync(resolve("app/layout.tsx"), "utf8"),
+  home: readFileSync(resolve("app/HomeClient.tsx"), "utf8"),
+  compare: readFileSync(resolve("app/compare/CompareClient.tsx"), "utf8"),
+  blog: readFileSync(resolve("app/blog/page.tsx"), "utf8"),
+  blogPost: readFileSync(resolve("app/blog/[slug]/page.tsx"), "utf8"),
+  course: readFileSync(resolve("app/courses/[courseId]/CourseDetailClient.tsx"), "utf8"),
+  skill: readFileSync(resolve("app/skills/[skillSlug]/SkillClient.tsx"), "utf8")
+};
+
+assert.doesNotMatch(
+  headingSources.layout,
+  /<h1\b/,
+  "Global site chrome must not own page-level H1 semantics."
+);
+for (const [surface, source] of Object.entries(headingSources).filter(
+  ([surface]) => surface !== "layout"
+)) {
+  assert.match(source, /<h1\b/, `${surface} must provide a meaningful H1.`);
+}
+
 assert.deepEqual(
   getDecisionReadySkillSlugs(),
   targetSkillSlugs,
@@ -86,7 +158,7 @@ assert.deepEqual(
 );
 
 for (const skillSlug of targetSkillSlugs) {
-  const metadata = generateMetadata({ params: { skillSlug } });
+  const metadata = generateSkillMetadata({ params: { skillSlug } });
   const canonical = metadata.alternates?.canonical;
 
   assert.equal(
@@ -108,7 +180,7 @@ for (const skillSlug of targetSkillSlugs) {
 }
 
 assert.match(
-  String(generateMetadata({ params: { skillSlug: "ai" } }).title),
+  String(generateSkillMetadata({ params: { skillSlug: "ai" } }).title),
   /^AI course comparison guide/,
   "AI should retain its standard acronym casing in metadata and page copy."
 );

--- a/src/components/AdPlaceholder.tsx
+++ b/src/components/AdPlaceholder.tsx
@@ -2,15 +2,6 @@ type AdPlaceholderProps = {
   className?: string;
 };
 
-export function AdPlaceholder({ className = "" }: AdPlaceholderProps) {
-  return (
-    <aside
-      aria-label="Reserved space"
-      className={`rounded-xl border border-dashed border-slate-200 bg-transparent px-3 py-2 ${className}`}
-    >
-      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
-        Reserved space
-      </p>
-    </aside>
-  );
+export function AdPlaceholder(_props: AdPlaceholderProps) {
+  return null;
 }


### PR DESCRIPTION
Closes #119

## Summary
- add `noindex, follow` to `/compare` while preserving its canonical and sitemap exclusion
- render the shared inactive monetization placeholder as `null`
- move page-level H1 ownership out of global chrome and into representative content roots
- return true Next.js 404 responses for invalid skill, course, and blog routes
- extend the existing selective SEO check with the focused issue #119 assertions

## Validation
- `corepack pnpm validate:data` — pass (20 courses; all 7 approved pair gates)
- `corepack pnpm report:data-quality` — pass (18 partially verified, 2 pending, 0 source URL mismatches)
- `corepack pnpm exec tsc --noEmit` — Windows launcher-resolution failure only; documented fallback `node node_modules/typescript/bin/tsc --noEmit` passed
- `corepack pnpm build` — pass (31 static pages generated)
- `corepack pnpm check:selective-seo` — pass (5 canonical skills, 7 pairs, 20 generated routes gated, 29 sitemap URLs)
- `git diff --check` — pass

## Focused production checks
- desktop/mobile smoke passed for homepage, canonical skill, empty and populated Compare, blog index, blog article, and course detail
- each rendered representative page had one meaningful H1, no horizontal overflow, no error overlay, and no visible `Reserved space`
- `/compare` and query comparisons emitted `noindex, follow` with canonical `https://skillcompare.com/compare`
- invalid skill, course, and blog paths returned HTTP 404 with `noindex` and no canonical
- one existing unrelated `/favicon.ico` 404 was observed on first load; no favicon change is included in this bounded PR

Changed files: 11. No dependencies, analytics, ads, affiliates, new routes, sitemap expansion, robots.txt change, or SEO generation.