### PR TITLE
Pricing evidence semantics: exact, starting-at, and free

### DIFF
--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -7,12 +7,12 @@ import { AdPlaceholder } from "@/components/AdPlaceholder";
 import {
   buildComparisonRows,
   formatPricingOption,
+  formatSourcePricingAmount,
   getActionablePricingOptions,
   getCourseSnapshot,
   getDecisionSummary,
   getPendingDataRisks,
-  isDurationPending,
-  isExactPricePending
+  isDurationPending
 } from "@/lib/decision-support";
 import { courses } from "@/lib/catalog-adapter";
 import { trackOutboundCourseClick } from "@/lib/outbound-tracking";
@@ -41,7 +41,8 @@ const pricingModelLabels = {
   one_time: "One-time",
   subscription: "Program subscription",
   platform_subscription: "Platform subscription",
-  free_audit: "Free / audit"
+  free_audit: "Free / audit",
+  free: "Free"
 };
 
 const PricingCommitmentCard = ({ course }: { course: Course }) => {
@@ -71,9 +72,7 @@ const PricingCommitmentCard = ({ course }: { course: Course }) => {
               <dl className="mt-3 grid gap-2 text-xs leading-relaxed text-slate-600 sm:grid-cols-2">
                 <div>
                   <dt className="font-semibold text-slate-800">Source amount</dt>
-                  <dd>
-                    {option.amount} {option.currency}
-                  </dd>
+                  <dd>{formatSourcePricingAmount(option)}</dd>
                 </div>
                 <div>
                   <dt className="font-semibold text-slate-800">USD basis</dt>
@@ -415,7 +414,7 @@ export default function CompareClient() {
             Current verified pricing
           </h2>
           <p className="mt-2 text-sm leading-relaxed text-slate-600">
-            All comparable commitments are shown in USD. Course or program paths appear before broader platform-subscription alternatives when both are verified; trials may change the amount due at checkout today.
+            Published economic paths are shown in USD with any starting-price qualifier preserved. Qualified amounts are not treated as exact checkout commitments; trials and market terms may also change the amount due today.
           </p>
         </div>
         <div className="mt-5 grid gap-4 lg:grid-cols-2">

--- a/app/courses/[courseId]/CourseDetailClient.tsx
+++ b/app/courses/[courseId]/CourseDetailClient.tsx
@@ -9,8 +9,8 @@ import {
   getActionablePricingOptions,
   getCourseDecisionSummary,
   getCourseFitBullets,
-  isDurationPending,
-  isExactPricePending
+  hasStartingAtPricing,
+  isDurationPending
 } from "@/lib/decision-support";
 import { trackOutboundCourseClick } from "@/lib/outbound-tracking";
 import {
@@ -69,9 +69,11 @@ export default function CourseDetailClient({ courseId }: CourseDetailClientProps
     course.rating == null
       ? "Rating and review count are unavailable, so Skills Compare cannot use social proof as a decision signal."
       : "Rating is available, but review totals can change.",
-    isExactPricePending(course)
+    primaryPricingOption == null
       ? "Exact price is pending, so total cost must be confirmed on the provider page."
-      : "Catalog price is available, but final provider terms should still be confirmed.",
+      : hasStartingAtPricing(course)
+        ? "A provider-published starting price is available, but the final market and checkout amount must still be confirmed."
+        : "Catalog price is available, but final provider terms should still be confirmed.",
     isDurationPending(course)
       ? "Duration is pending, so workload risk is higher until you verify the provider page."
       : "Duration is listed, but current workload should still be checked before committing.",

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,6 +1,6 @@
 # Current State
 
-Last updated after implementing the bounded Phase 1B.8 Pluralsight provider batch for independent product review.
+Last updated after implementing the bounded issue #121 pricing-contract evolution for independent product review.
 
 ## Product State
 
@@ -11,6 +11,15 @@ The current UI is English-first. The product supports skill discovery, curated c
 Recent product review exposed an important distinction: source-trusted catalog data is not automatically decision-useful data. The product must not only avoid inventing facts; it must preserve enough structured provider-backed information to help a user actually choose between courses.
 
 ## Latest Completed Initiatives
+
+### Pricing Evidence Semantics — Issue #121
+
+Key outcomes:
+
+- Existing decision-grade exact prices retain their display and comparison semantics without catalog data churn.
+- Provider-published `starting at` amounts are actionable only when current, official, source-backed, scoped, and qualified wherever displayed; they do not establish exact-price Same/Different results.
+- Genuinely free access is represented by a distinct `free` pricing option and can clear the hard gate at $0. Zero paid/subscription combinations and contradictory qualified-free combinations fail schema validation.
+- The catalog remains at 20 courses and the approved set remains 12 courses across seven pairs. No LinkedIn, Microsoft, or other provider records were ingested.
 
 ### Phase 1B.8 — Pluralsight Provider Batch — Issue #116
 
@@ -135,7 +144,7 @@ Earlier completed initiatives, including Phase 1 Source Verification Batches A/B
 - 18 courses are currently `partially_verified`.
 - 2 courses remain `pending` with explicit source blockers rather than unreviewed status.
 - Source URL mismatches: 0 after the completed verification batches.
-- Pricing remains unknown or unverified for the 8 non-migrated courses; the 12 approved decision-grade records now have actionable source-backed USD pricing paths. Most ratings and review counts remain unknown by design.
+- Pricing remains unknown or unverified for the 8 non-migrated courses; the 12 approved decision-grade records retain their current exact actionable source-backed USD pricing paths. The contract can also represent official qualified starting prices and genuinely free access in a future explicitly approved batch. Most ratings and review counts remain unknown by design.
 - The 12 approved decision-grade records preserve provider-described workloads, including exact video-course durations and longer schedules, without inferring completion totals.
 - The current normalized `language` field represents the primary taught language when clearly supported by an official source. Additional dubbing/subtitle/language availability remains provenance context unless a later explicit schema initiative changes that model.
 - `report:data-quality` remains part of normal validation.

--- a/docs/MVP_READINESS.md
+++ b/docs/MVP_READINESS.md
@@ -18,7 +18,7 @@
 - Mobile Selection and Discovery UX is merged: compare selection persists for up to 24 hours, returning selections are surfaced, and the compare bar is available globally outside the compare page.
 - Decision-focused visual polish is merged across the core Search -> Compare -> Decide journey.
 - Decision Data Contract v2 preserves provider-backed offering, workload, tool, practical-work, credential, and cost-model signals for the 12 explicitly approved courses.
-- Structured pricing preserves source-backed payable paths, USD amounts, cadence, scope, provenance, freshness, and regional/access context for the same 12-course set.
+- Structured pricing preserves source-backed exact, provider-qualified starting-at, and genuinely free paths with USD amounts, cadence, scope, provenance, freshness, and regional/access context. The current 12-course decision-grade set retains its existing exact paths.
 - Compare presents decision differences and a source-backed at-a-glance snapshot before detailed pricing, criteria, curriculum, and final provider verification.
 - Canonical AI, Cybersecurity, Data Analysis, Cloud Computing, and Project Management pages now surface all seven manifest-approved pairs in deterministic order, with compact source-backed tradeoffs and explicit uncertainty before the detailed Compare flow.
 
@@ -71,7 +71,7 @@
 - AWS Cloud Technical Essentials vs AWS Foundations: Getting Started with the AWS Cloud Essentials passes 5/7 plus the pricing hard gate, with Pluralsight prerequisites and practical work explicitly insufficient.
 - Introduction to Information Security is blocked and intentionally omitted because its official course page appears active while the current official author page labels it `RETIRED`; no substitute Cybersecurity course was added.
 - The schema migration is limited to the 12 records in `data/decision-grade-manifest.json`. Independent product review must decide whether another small, explicit batch is justified.
-- Exact actionable pricing is required for every approved decision-grade pair. Provider checkout remains the final source for transaction-specific taxes, eligibility, regional variation, and availability.
+- An official actionable exact, provider-qualified starting-at, or genuinely free pricing path is required for every approved decision-grade pair. Qualified starting amounts do not establish exact-price Same/Different results. Provider checkout remains the final source for transaction-specific taxes, eligibility, regional variation, and availability.
 
 ## Validation Workflow
 

--- a/docs/PRODUCT_DECISIONS.md
+++ b/docs/PRODUCT_DECISIONS.md
@@ -46,11 +46,13 @@ Do not manufacture a winner when the available evidence does not justify one.
 
 ## Pricing as Decision Data
 
-- For the Phase 1B.3 pilot, a comparison is not decision-ready unless both courses have at least one actionable, source-backed payable pricing path displayed in USD.
-- Preserve amount, cadence, payment model, scope, source, observation date, and regional or access context. Do not collapse genuinely distinct paths into one scalar claim.
+- A comparison is not decision-ready unless both courses have at least one current, official, actionable pricing path: an exact source-backed price, a provider-published `starting at` price with its qualifier preserved, or genuinely free access represented explicitly as free/$0.
+- Preserve amount, exact-versus-starting-at semantics, cadence, payment model, scope, source, observation date, and regional or access context. Do not collapse genuinely distinct paths into one scalar claim.
 - Course- or program-specific paths appear before verified platform-subscription alternatives.
 - Currency-converted amounts must preserve the original amount and render with approximation semantics.
-- Promotional prices, inferred completion totals, and generic provider-wide starting prices are not canonical course prices.
+- A provider-published starting price establishes an actionable economic path, not an exact checkout commitment. When either side is qualified, exact-price Same/Different status remains insufficient; independently verified cost-model comparisons can remain factual.
+- Genuinely free access is a distinct pricing semantic. Zero paid, subscription, or platform-subscription amounts are invalid and do not pass the pricing gate.
+- Promotional prices, inferred completion totals, generic provider ranges without actionable course access context, and Skills Compare-generated estimates are not canonical course prices.
 - Pricing remains a hard gate in addition to, not instead of, the existing 5/7 Phase 1B.2 decision-dimension gate.
 
 ## Language

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,7 +24,7 @@ Future work in this area should be limited to concrete usability defects or regr
 
 ## Phase 1 — Real Data
 
-**Status: Phase 1A source trust complete; Phase 1B.8 adds the bounded Pluralsight Cloud course while retaining the Cybersecurity availability blocker found in independent review.**
+**Status: Phase 1A source trust complete; Phase 1B.8 adds the bounded Pluralsight Cloud course, and issue #121 evolves the provider-neutral pricing contract without adding providers or courses.**
 
 Goal: make the catalog both trustworthy and useful enough to support real user decisions.
 
@@ -54,6 +54,7 @@ Completed:
 - **Phase 1B.6 — Decision-Grade Rollout Batch 2** in issue #106: the Google Project Management Professional Certificate and UCI Project Management Principles and Practices Specialization now use the approved contract. The pair passes pricing plus 6/7 source-backed dimensions, with UCI tools/technologies explicitly insufficient, and the manifest now contains exactly ten courses across five pairs.
 - **Phase 1B.7 — Multi-provider Acceptance + Cross-platform Project Management** in issue #108: all five incumbent pairs pass cumulative desktop/mobile product acceptance, the current public AdelaideX course page establishes a non-promotional `$149 USD` one-time Premium certificate path, and Google Project Management vs AdelaideX passes pricing plus 6/7 dimensions with edX tools/technologies explicitly insufficient. The manifest now contains exactly 11 courses across six approved pairs.
 - **Phase 1B.8 — Pluralsight Provider Batch** in issue #116: one current Pluralsight Cloud video course clears the unchanged pricing and 5/7 gates. The Cybersecurity candidate is blocked and intentionally omitted because official Pluralsight pages conflict on whether it is retired; no substitute was added. The catalog now contains 20 courses; the approved set contains 12 courses across seven pairs. The Cloud canonical guide surfaces the new pair automatically without provider-specific page code.
+- **Pricing evidence semantics** in issue #121: exact pricing remains backward compatible, official provider-published `starting at` paths can clear the pricing gate without becoming exact commitments, and genuinely free access has a distinct zero-price semantic. Qualified amounts remain ineligible for exact-price Same/Different claims, and no provider/course ingestion is included.
 
 Do not migrate the remaining catalog automatically. Any later rollout requires another explicit, auditable batch decision.
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "validate:data": "tsx scripts/validate-data.ts",
     "report:data-quality": "node scripts/report-data-quality.js",
+    "check:pricing-contract": "tsx scripts/check-pricing-contract.ts",
     "check:selective-seo": "tsx scripts/check-selective-seo.ts",
     "ingest:edx": "tsx scripts/ingest-edx.ts",
     "ingest:coursera": "tsx scripts/ingest-coursera.ts",

--- a/scripts/check-pricing-contract.ts
+++ b/scripts/check-pricing-contract.ts
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+
+import { formatPriceText } from "../src/lib/catalog-adapter";
+import {
+  buildComparisonRows,
+  formatPricingOption,
+  formatSourcePricingAmount,
+  getActionablePricingOptions,
+  getCourseDecisionSummary,
+  getCourseSnapshot,
+  type PricingOption
+} from "../src/lib/decision-support";
+import { isActionablePricingOption } from "../src/lib/pricing-contract";
+import { CourseSchema, type Course as NormalizedCourse } from "../src/lib/schema/course";
+import type { Course } from "../src/types/course";
+
+type RawPricingOption = Omit<PricingOption, "qualifier"> & {
+  qualifier?: PricingOption["qualifier"];
+};
+
+const exactPaidOption: RawPricingOption = {
+  id: "exact-monthly",
+  model: "subscription",
+  amount: 39.99,
+  currency: "USD",
+  normalizedUsdAmount: 39.99,
+  cadence: "month",
+  scope: "Certificate access",
+  normalizationBasis: "provider_published_usd",
+  actionUrl: "https://example.com/checkout",
+  evidenceUrls: ["https://example.com/pricing"],
+  observedAt: "2026-08-28",
+  referenceMarket: "United States",
+  accessContext: "public_provider_page",
+  conditions: "Final taxes and checkout terms may vary."
+};
+
+const makeNormalizedCourse = (pricingOption: RawPricingOption) => ({
+  id: `fixture-${pricingOption.id}`,
+  platform: "Fixture provider",
+  title: "Pricing fixture",
+  url: "https://example.com/course",
+  skillSlug: "fixture",
+  level: "beginner" as const,
+  durationHours: null,
+  language: "English",
+  priceModel: pricingOption.model === "free" ? ("free" as const) : ("subscription" as const),
+  priceAmount: pricingOption.amount,
+  currency: pricingOption.currency,
+  priceInterval: pricingOption.cadence === "month" ? ("month" as const) : null,
+  rating: null,
+  reviewCount: null,
+  certificate: pricingOption.model === "free" ? false : true,
+  lastUpdatedAt: null,
+  shortDescription: null,
+  syllabusBullets: [],
+  prerequisitesBullets: [],
+  offeringType: "course" as const,
+  workload: null,
+  toolsTechnologies: [],
+  practicalWorkBullets: [],
+  credential: null,
+  costModel: {
+    type: pricingOption.model === "free" ? ("free" as const) : ("subscription" as const),
+    text: pricingOption.model === "free" ? "Free access" : "Subscription access"
+  },
+  pricingOptions: [pricingOption],
+  source: "manual" as const
+});
+
+const parseOption = (rawOption: RawPricingOption) => {
+  const parsed = CourseSchema.parse(makeNormalizedCourse(rawOption));
+  return { course: parsed, option: parsed.pricingOptions[0] };
+};
+
+const makeRuntimeCourse = (
+  normalized: NormalizedCourse,
+  option: PricingOption,
+  id: string
+): Course => ({
+  id,
+  title: normalized.title,
+  platform: "Coursera",
+  skillTags: [normalized.skillSlug],
+  level: "Beginner",
+  priceModel: normalized.priceModel,
+  priceAmount: normalized.priceAmount,
+  currency: normalized.currency,
+  priceInterval: normalized.priceInterval,
+  priceText: formatPriceText(normalized),
+  durationHours: normalized.durationHours,
+  durationText: "Workload pending verification",
+  rating: null,
+  reviewCount: null,
+  language: normalized.language,
+  certificate: normalized.certificate,
+  shortDescription: normalized.shortDescription,
+  syllabusBullets: normalized.syllabusBullets,
+  prerequisitesBullets: normalized.prerequisitesBullets,
+  offeringType: normalized.offeringType,
+  workload: normalized.workload,
+  toolsTechnologies: normalized.toolsTechnologies,
+  practicalWorkBullets: normalized.practicalWorkBullets,
+  credential: normalized.credential,
+  costModel: normalized.costModel,
+  pricingOptions: [option],
+  externalUrl: normalized.url,
+  verifiedFields: {
+    platform: true,
+    price: true,
+    pricingOptions: true,
+    offeringType: true,
+    costModel: true,
+    language: true,
+    level: true
+  }
+});
+
+const exact = parseOption(exactPaidOption);
+assert.equal(exact.option.qualifier, "exact", "existing options must default to exact");
+assert.equal(
+  formatPricingOption(exact.option),
+  "$39.99/month — Certificate access"
+);
+assert.equal(
+  formatPriceText(exact.course),
+  "Program subscription: $39.99/month — Certificate access"
+);
+
+const exactCourse = makeRuntimeCourse(exact.course, exact.option, "exact-course");
+assert.equal(getActionablePricingOptions(exactCourse).length, 1);
+assert.match(getCourseDecisionSummary(exactCourse).known.join(" "), /\$39\.99\/month/);
+assert.equal(
+  buildComparisonRows(exactCourse, { ...exactCourse, id: "exact-course-2" })[0]?.status,
+  "Same",
+  "existing exact-price Same behavior must remain unchanged"
+);
+
+const starting = parseOption({
+  ...exactPaidOption,
+  id: "starting-monthly",
+  scope: "Premium Career",
+  qualifier: "starting_at"
+});
+assert.equal(
+  formatPricingOption(starting.option),
+  "Starting at $39.99/month — Premium Career"
+);
+assert.equal(
+  formatPriceText(starting.course),
+  "Program subscription: Starting at $39.99/month — Premium Career"
+);
+assert.equal(formatSourcePricingAmount(starting.option), "Starting at 39.99 USD");
+
+const startingCourse = makeRuntimeCourse(
+  starting.course,
+  starting.option,
+  "starting-course"
+);
+assert.equal(getActionablePricingOptions(startingCourse).length, 1);
+assert.match(
+  getCourseDecisionSummary(startingCourse).known.join(" "),
+  /Starting at \$39\.99\/month/
+);
+assert.match(
+  getCourseSnapshot(startingCourse).pricing.join(" "),
+  /Starting at \$39\.99\/month/
+);
+assert.equal(
+  buildComparisonRows(startingCourse, exactCourse)[0]?.status,
+  "Insufficient data",
+  "a starting-at amount must not establish exact-price sameness or difference"
+);
+
+const free = parseOption({
+  ...exactPaidOption,
+  id: "official-free",
+  model: "free",
+  amount: 0,
+  normalizedUsdAmount: 0,
+  cadence: "other",
+  scope: "Microsoft Learn training",
+  referenceMarket: null,
+  conditions: "Access remains subject to provider availability."
+});
+assert.equal(formatPricingOption(free.option), "Free — Microsoft Learn training");
+assert.equal(formatSourcePricingAmount(free.option), "Free ($0 USD)");
+assert.equal(formatPriceText(free.course), "Free — Microsoft Learn training");
+
+const freeCourse = makeRuntimeCourse(free.course, free.option, "free-course");
+assert.equal(getActionablePricingOptions(freeCourse).length, 1);
+assert.equal(isActionablePricingOption(free.option), true);
+
+const invalidZeroPaid = CourseSchema.safeParse(
+  makeNormalizedCourse({
+    ...exactPaidOption,
+    id: "invalid-zero-paid",
+    amount: 0,
+    normalizedUsdAmount: 0
+  })
+);
+assert.equal(invalidZeroPaid.success, false, "zero paid pricing must fail the schema");
+
+const invalidQualifiedFree = CourseSchema.safeParse(
+  makeNormalizedCourse({
+    ...exactPaidOption,
+    id: "invalid-qualified-free",
+    model: "free",
+    amount: 0,
+    normalizedUsdAmount: 0,
+    cadence: "other",
+    qualifier: "starting_at"
+  })
+);
+assert.equal(
+  invalidQualifiedFree.success,
+  false,
+  "free pricing must not carry a starting-at qualifier"
+);
+
+console.log("[check:pricing-contract] Exact, starting-at, free, invalid-zero, and Compare regressions passed.");

--- a/scripts/report-data-quality.js
+++ b/scripts/report-data-quality.js
@@ -68,15 +68,29 @@ const decisionDimensions = [
     verified.costModel === true && course.costModel != null]
 ];
 
+const isActionablePricingOption = (option) => {
+  const isFree =
+    option.model === "free" &&
+    option.amount === 0 &&
+    option.normalizedUsdAmount === 0;
+  const isPaid =
+    option.model !== "free" &&
+    option.model !== "free_audit" &&
+    option.amount > 0 &&
+    option.normalizedUsdAmount > 0;
+
+  return (
+    (isFree || isPaid) &&
+    Boolean(option.actionUrl) &&
+    option.evidenceUrls?.length > 0 &&
+    Boolean(option.observedAt)
+  );
+};
+
 const hasActionablePricing = (course, verified) =>
   verified.price === true &&
   verified.pricingOptions === true &&
-  course.pricingOptions?.some(
-    (option) =>
-      option.amount > 0 &&
-      option.normalizedUsdAmount > 0 &&
-      option.evidenceUrls?.length > 0
-  );
+  course.pricingOptions?.some(isActionablePricingOption);
 
 const coursesPath = resolve(process.cwd(), "data", "normalized", "courses.json");
 const metadataPath = resolve(
@@ -192,7 +206,11 @@ try {
     console.log(`  - insufficient: ${insufficient.length > 0 ? insufficient.join(", ") : "none"}`);
     [left, right].forEach((course) => {
       (course.pricingOptions ?? []).forEach((option) => {
-        console.log(`  - ${course.id}/${option.id}: ${option.amount} ${option.currency} -> ${option.normalizedUsdAmount} USD; ${option.model}; ${option.cadence}; ${option.scope}; observed ${option.observedAt}; market ${option.referenceMarket ?? "not restricted"}; access ${option.accessContext}; evidence ${option.evidenceUrls.join(", ")}`);
+        const sourceAmount =
+          option.model === "free"
+            ? "Free (0 USD)"
+            : `${option.qualifier === "starting_at" ? "Starting at " : ""}${option.amount} ${option.currency}`;
+        console.log(`  - ${course.id}/${option.id}: ${sourceAmount} -> ${option.normalizedUsdAmount} USD; ${option.model}; ${option.cadence}; ${option.scope}; observed ${option.observedAt}; market ${option.referenceMarket ?? "not restricted"}; access ${option.accessContext}; evidence ${option.evidenceUrls.join(", ")}`);
       });
     });
   });

--- a/scripts/validate-data.ts
+++ b/scripts/validate-data.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { CourseSchema } from "../src/lib/schema/course";
+import { isActionablePricingOption } from "../src/lib/pricing-contract";
 
 const coursesPath = resolve(process.cwd(), "data", "normalized", "courses.json");
 const metadataPath = resolve(
@@ -157,11 +158,7 @@ const hasActionablePricing = (courseId: string) => {
   }
 
   return course.pricingOptions.some(
-    (option) =>
-      option.amount > 0 &&
-      option.normalizedUsdAmount > 0 &&
-      Boolean(option.actionUrl) &&
-      option.evidenceUrls.length > 0
+    (option) => isActionablePricingOption(option)
   );
 };
 

--- a/src/lib/catalog-adapter.ts
+++ b/src/lib/catalog-adapter.ts
@@ -2,6 +2,7 @@ import normalizedCatalog from "../../data/normalized/courses.json";
 import sourceMetadata from "../../data/normalized/course-source-metadata.json";
 import { courses as fallbackCourses } from "@/data/courses";
 import { CourseSchema, type Course as NormalizedCourse } from "@/lib/schema/course";
+import { formatPricingOption } from "@/lib/decision-support";
 import type { Course } from "@/types/course";
 
 const mapPlatform = (platform: string): Course["platform"] | null => {
@@ -70,33 +71,20 @@ const formatDurationText = (
   return `${durationHours} hours`;
 };
 
-const formatPriceText = (course: NormalizedCourse): string => {
+export const formatPriceText = (course: NormalizedCourse): string => {
   const primaryPricingOption = course.pricingOptions[0];
 
   if (primaryPricingOption) {
-    const approximation =
-      primaryPricingOption.normalizationBasis === "currency_converted" ? "≈ " : "";
-    const amount = new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-      maximumFractionDigits: Number.isInteger(primaryPricingOption.normalizedUsdAmount)
-        ? 0
-        : 2
-    }).format(primaryPricingOption.normalizedUsdAmount);
-    const cadence = {
-      one_time: " total",
-      month: "/month",
-      year: "/year",
-      other: ""
-    }[primaryPricingOption.cadence];
     const model = {
       one_time: "One-time",
       subscription: "Program subscription",
       platform_subscription: "Platform subscription",
-      free_audit: "Free / audit"
+      free_audit: null,
+      free: null
     }[primaryPricingOption.model];
+    const formattedOption = formatPricingOption(primaryPricingOption);
 
-    return `${model}: ${approximation}${amount}${cadence} — ${primaryPricingOption.scope}`;
+    return model ? `${model}: ${formattedOption}` : formattedOption;
   }
 
   if (course.priceModel === "free") {

--- a/src/lib/decision-support.ts
+++ b/src/lib/decision-support.ts
@@ -1,4 +1,8 @@
 import type { Course } from "@/types/course";
+import {
+  isActionablePricingOption,
+  isQualifiedPricingOption
+} from "@/lib/pricing-contract";
 
 export type RowStatus = "Same" | "Different" | "Insufficient data";
 
@@ -55,24 +59,21 @@ export const isCostModelPending = (course: Course) =>
 
 export const getActionablePricingOptions = (course: Course) =>
   isFieldVerified(course, "price") && isFieldVerified(course, "pricingOptions")
-    ? (course.pricingOptions ?? []).filter(
-        (option) =>
-          option.amount > 0 &&
-          option.normalizedUsdAmount > 0 &&
-          Boolean(option.actionUrl) &&
-          option.evidenceUrls.length > 0 &&
-          Boolean(option.observedAt)
-      )
+    ? (course.pricingOptions ?? []).filter(isActionablePricingOption)
     : [];
 
+export const hasStartingAtPricing = (course: Course) =>
+  getActionablePricingOptions(course).some(isQualifiedPricingOption);
+
 export const isExactPricePending = (course: Course) =>
-  getActionablePricingOptions(course).length === 0 &&
-  (!isFieldVerified(course, "price") ||
-    course.priceModel === "unknown" ||
-    (course.priceModel !== "free" &&
-      (course.priceAmount == null ||
-        !course.currency ||
-        (course.priceModel === "subscription" && course.priceInterval == null))));
+  hasStartingAtPricing(course) ||
+  (getActionablePricingOptions(course).length === 0 &&
+    (!isFieldVerified(course, "price") ||
+      course.priceModel === "unknown" ||
+      (course.priceModel !== "free" &&
+        (course.priceAmount == null ||
+          !course.currency ||
+          (course.priceModel === "subscription" && course.priceInterval == null)))));
 
 const formatUsd = (amount: number) =>
   new Intl.NumberFormat("en-US", {
@@ -82,8 +83,17 @@ const formatUsd = (amount: number) =>
   }).format(amount);
 
 export const formatPricingOption = (option: PricingOption) => {
+  if (option.model === "free") {
+    return `Free — ${option.scope}`;
+  }
+
+  if (option.model === "free_audit") {
+    return `Free / audit — ${option.scope}`;
+  }
+
   const approximation =
     option.normalizationBasis === "currency_converted" ? "≈ " : "";
+  const qualifier = option.qualifier === "starting_at" ? "Starting at " : "";
   const cadence = {
     one_time: " total",
     month: "/month",
@@ -91,7 +101,20 @@ export const formatPricingOption = (option: PricingOption) => {
     other: ""
   }[option.cadence];
 
-  return `${approximation}${formatUsd(option.normalizedUsdAmount)}${cadence} — ${option.scope}`;
+  return `${qualifier}${approximation}${formatUsd(option.normalizedUsdAmount)}${cadence} — ${option.scope}`;
+};
+
+export const formatSourcePricingAmount = (option: PricingOption) => {
+  if (option.model === "free") {
+    return "Free ($0 USD)";
+  }
+
+  if (option.model === "free_audit") {
+    return "Free / audit ($0 USD)";
+  }
+
+  const qualifier = option.qualifier === "starting_at" ? "Starting at " : "";
+  return `${qualifier}${option.amount} ${option.currency}`;
 };
 
 export const formatCoursePricing = (course: Course) => {
@@ -110,6 +133,7 @@ const equalPricingOptions = (left: PricingOption[], right: PricingOption[]) =>
     return (
       rightOption != null &&
       leftOption.normalizedUsdAmount === rightOption.normalizedUsdAmount &&
+      leftOption.qualifier === rightOption.qualifier &&
       leftOption.cadence === rightOption.cadence &&
       leftOption.model === rightOption.model &&
       normalize(leftOption.scope) === normalize(rightOption.scope)
@@ -263,6 +287,7 @@ export const getPairDecisionReadiness = (left: Course, right: Course) => {
 };
 
 export const getCourseFitBullets = (course: Course) => {
+  const pricingOptions = getActionablePricingOptions(course);
   const bullets = [
     course.level === "Unknown"
       ? "You are comfortable verifying the intended learner level."
@@ -275,9 +300,11 @@ export const getCourseFitBullets = (course: Course) => {
     isDurationPending(course)
       ? "You are comfortable verifying duration and workload before committing."
       : `You can assess the provider-described workload: ${course.durationText}.`,
-    isExactPricePending(course)
+    pricingOptions.length === 0
       ? "You are comfortable confirming final price or subscription terms on the provider page."
-      : `You can evaluate the verified commitment: ${formatCoursePricing(course)}.`,
+      : hasStartingAtPricing(course)
+        ? `You can evaluate the provider-published qualified price: ${formatCoursePricing(course)}, then confirm the final checkout amount.`
+        : `You can evaluate the verified commitment: ${formatCoursePricing(course)}.`,
     course.prerequisitesBullets.length > 0
       ? `The listed prerequisites fit your background: ${summarizeBullets(course.prerequisitesBullets, "prerequisites available")}.`
       : "You can verify prerequisites directly on the provider page."
@@ -293,6 +320,8 @@ export const getCourseFitBullets = (course: Course) => {
 };
 
 export const getCourseDecisionSummary = (course: Course) => {
+  const pricingOptions = getActionablePricingOptions(course);
+  const hasQualifiedPrice = hasStartingAtPricing(course);
   const known = [
     `Platform: ${course.platform}.`,
     course.level === "Unknown" || !isFieldVerified(course, "level")
@@ -305,16 +334,20 @@ export const getCourseDecisionSummary = (course: Course) => {
     isDurationPending(course)
       ? "Workload is pending verification."
       : `Provider-described workload: ${course.durationText}.`,
-    isExactPricePending(course)
-      ? "Exact actionable pricing is pending verification."
-      : `Verified pricing: ${formatCoursePricing(course)}.`
+    pricingOptions.length === 0
+      ? "Actionable pricing is pending verification."
+      : hasQualifiedPrice
+        ? `Provider-published qualified pricing: ${formatCoursePricing(course)}.`
+        : `Verified pricing: ${formatCoursePricing(course)}.`
   ];
 
   const pending = [
     course.rating == null ? "Rating/review count is not available in Skills Compare." : null,
-    isExactPricePending(course)
+    pricingOptions.length === 0
       ? "Exact price or subscription terms must be verified on the provider page."
-      : null,
+      : hasQualifiedPrice
+        ? "The published starting price is not an exact checkout amount; confirm final provider terms."
+        : null,
     isDurationPending(course) ? "Workload must be checked before committing time." : null,
     course.prerequisitesBullets.length === 0 ? "Prerequisites should be verified on the provider page." : null,
     course.syllabusBullets.length === 0 ? "Current syllabus should be verified on the provider page." : null
@@ -326,13 +359,16 @@ export const getCourseDecisionSummary = (course: Course) => {
 };
 
 export const getPendingDataImpact = (course: Course) => {
+  const pricingOptions = getActionablePricingOptions(course);
   const impacts = [
     course.rating == null
       ? "Rating/review count unavailable: Skills Compare cannot show social proof for this course yet."
       : null,
-    isExactPricePending(course)
+    pricingOptions.length === 0
       ? "Exact price pending: confirm total cost, trial terms, and subscription renewal before enrolling."
-      : null,
+      : hasStartingAtPricing(course)
+        ? "Starting price published: confirm the final market and checkout amount before enrolling."
+        : null,
     isDurationPending(course)
       ? "Workload pending: check weekly workload and total time commitment on the provider page."
       : null,
@@ -447,12 +483,17 @@ export const buildComparisonRows = (left: Course, right: Course): ComparisonRow[
 
   const leftPricingOptions = getActionablePricingOptions(left);
   const rightPricingOptions = getActionablePricingOptions(right);
+  const pricingHasQualifiedAmount =
+    leftPricingOptions.some(isQualifiedPricingOption) ||
+    rightPricingOptions.some(isQualifiedPricingOption);
   const pricingRow: RawComparisonRow = {
     label: "Verified pricing",
     left: formatCoursePricing(left),
     right: formatCoursePricing(right),
     comparable:
-      (leftPricingOptions.length > 0 && rightPricingOptions.length > 0) ||
+      (leftPricingOptions.length > 0 &&
+        rightPricingOptions.length > 0 &&
+        !pricingHasQualifiedAmount) ||
       (!isExactPricePending(left) && !isExactPricePending(right)),
     equal:
       leftPricingOptions.length > 0 && rightPricingOptions.length > 0
@@ -465,8 +506,9 @@ export const buildComparisonRows = (left: Course, right: Course): ComparisonRow[
       "Verified amount, cadence, payment model, and scope match for the displayed paths.",
     differentInterpretation:
       "The verified commitments differ in amount, cadence, payment model, scope, or available paths.",
-    uncertainInterpretation:
-      "Actionable source-backed pricing is unavailable for one or both options."
+    uncertainInterpretation: pricingHasQualifiedAmount
+      ? "A provider-published starting price is available, but exact-price sameness or difference is not verified."
+      : "Actionable source-backed pricing is unavailable for one or both options."
   };
 
   const rows: RawComparisonRow[] = bothHaveDecisionDataV2
@@ -713,8 +755,11 @@ export const getPendingDataRisks = (items: Course[]) => {
     )
   ).sort();
   const risks = [
-    items.some(isExactPricePending)
-      ? "Exact price: current amount or subscription terms are not verified for one or both courses."
+    items.some((course) => getActionablePricingOptions(course).length === 0)
+      ? "Pricing: an actionable current amount or access path is not verified for one or both courses."
+      : null,
+    items.some(hasStartingAtPricing)
+      ? "Exact price: a provider-published starting price is not a verified final checkout amount."
       : null,
     items.some(isDurationPending)
       ? "Workload: provider-described time commitment is unavailable for one or both courses."
@@ -734,7 +779,8 @@ export const getPendingDataRisks = (items: Course[]) => {
     )
       ? "Course details: verify any incomplete prerequisites or learning topics on the provider pages."
       : null,
-    items.every((course) => !isExactPricePending(course)) && observedDates.length > 0
+    items.every((course) => getActionablePricingOptions(course).length > 0) &&
+    observedDates.length > 0
       ? `Pricing was checked ${observedDates.join(" and ")}; region, taxes, eligibility, and checkout terms may vary.`
       : null,
     "Provider details can change; confirm final checkout terms and availability before enrolling."
@@ -744,9 +790,11 @@ export const getPendingDataRisks = (items: Course[]) => {
 };
 
 export const getVerifyBeforeEnrollingItems = (course: Course) => [
-  isExactPricePending(course)
+  getActionablePricingOptions(course).length === 0
     ? "Confirm exact price, trial terms, and subscription renewal before enrolling."
-    : `Confirm the final checkout amount; pricing was observed ${getActionablePricingOptions(course)[0]?.observedAt ?? "on the provider page"}.`,
+    : hasStartingAtPricing(course)
+      ? `Confirm the final checkout amount; ${formatCoursePricing(course)} was observed ${getActionablePricingOptions(course)[0]?.observedAt ?? "on the provider page"}.`
+      : `Confirm the final checkout amount; pricing was observed ${getActionablePricingOptions(course)[0]?.observedAt ?? "on the provider page"}.`,
   course.certificate
     ? "Check certificate terms, eligibility, and whether payment is required."
     : "Verify whether a certificate is available and under what terms.",

--- a/src/lib/pricing-contract.ts
+++ b/src/lib/pricing-contract.ts
@@ -1,0 +1,35 @@
+export type PricingContractOption = {
+  model:
+    | "one_time"
+    | "subscription"
+    | "platform_subscription"
+    | "free_audit"
+    | "free";
+  amount: number;
+  normalizedUsdAmount: number;
+  qualifier: "exact" | "starting_at";
+  actionUrl: string;
+  evidenceUrls: string[];
+  observedAt: string;
+};
+
+export const isGenuinelyFreePricingOption = (option: PricingContractOption) =>
+  option.model === "free" &&
+  option.amount === 0 &&
+  option.normalizedUsdAmount === 0 &&
+  option.qualifier === "exact";
+
+export const isPaidPricingOption = (option: PricingContractOption) =>
+  option.model !== "free" &&
+  option.model !== "free_audit" &&
+  option.amount > 0 &&
+  option.normalizedUsdAmount > 0;
+
+export const isActionablePricingOption = (option: PricingContractOption) =>
+  (isPaidPricingOption(option) || isGenuinelyFreePricingOption(option)) &&
+  Boolean(option.actionUrl) &&
+  option.evidenceUrls.length > 0 &&
+  Boolean(option.observedAt);
+
+export const isQualifiedPricingOption = (option: PricingContractOption) =>
+  option.qualifier === "starting_at";

--- a/src/lib/schema/course.ts
+++ b/src/lib/schema/course.ts
@@ -24,10 +24,17 @@ const CostModelSchema = z.object({
 
 const PricingOptionSchema = z.object({
   id: z.string().min(1),
-  model: z.enum(["one_time", "subscription", "platform_subscription", "free_audit"]),
+  model: z.enum([
+    "one_time",
+    "subscription",
+    "platform_subscription",
+    "free_audit",
+    "free"
+  ]),
   amount: z.number().nonnegative(),
   currency: z.string().length(3),
   normalizedUsdAmount: z.number().nonnegative(),
+  qualifier: z.enum(["exact", "starting_at"]).default("exact"),
   cadence: z.enum(["one_time", "month", "year", "other"]),
   scope: z.string().min(1),
   normalizationBasis: z.enum(["provider_published_usd", "currency_converted"]),
@@ -41,6 +48,47 @@ const PricingOptionSchema = z.object({
     "account_visible_enrollment"
   ]),
   conditions: z.string().min(1).nullable()
+}).superRefine((option, context) => {
+  const isFree = option.model === "free";
+  const isFreeAudit = option.model === "free_audit";
+
+  if (isFree || isFreeAudit) {
+    if (option.amount !== 0 || option.normalizedUsdAmount !== 0) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `${option.model} pricing must use zero source and normalized amounts`,
+        path: ["amount"]
+      });
+    }
+
+    if (option.qualifier !== "exact") {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `${option.model} pricing cannot use a starting-at qualifier`,
+        path: ["qualifier"]
+      });
+    }
+  } else if (option.amount <= 0 || option.normalizedUsdAmount <= 0) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Paid pricing must use positive source and normalized amounts",
+      path: ["amount"]
+    });
+  }
+
+  if (
+    isFree &&
+    (option.currency !== "USD" ||
+      option.cadence !== "other" ||
+      option.normalizationBasis !== "provider_published_usd")
+  ) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        "Genuinely free pricing must use USD, other cadence, and provider-published basis",
+      path: ["model"]
+    });
+  }
 });
 
 export const CourseSchema = z.object({

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -41,10 +41,16 @@ export type Course = {
   } | null;
   pricingOptions?: Array<{
     id: string;
-    model: "one_time" | "subscription" | "platform_subscription" | "free_audit";
+    model:
+      | "one_time"
+      | "subscription"
+      | "platform_subscription"
+      | "free_audit"
+      | "free";
     amount: number;
     currency: string;
     normalizedUsdAmount: number;
+    qualifier: "exact" | "starting_at";
     cadence: "one_time" | "month" | "year" | "other";
     scope: string;
     normalizationBasis: "provider_published_usd" | "currency_converted";


### PR DESCRIPTION
## Summary

- evolve the provider-neutral pricing contract with backward-compatible `exact` defaults and explicit `starting_at` qualifiers
- add a distinct genuinely free `$0` path while rejecting zero paid/subscription and contradictory qualified-free combinations
- preserve qualifiers across course cards/details, Compare pricing evidence, snapshots, and decision summaries
- keep exact-price Same/Different conservative whenever either side uses qualified pricing
- add focused pricing-contract regressions and update durable product documentation

No provider/course ingestion, catalog/manifest changes, provider-specific UI, monetization, analytics, SEO-route, dependency, database, or infrastructure work.

## Validation

- `corepack pnpm check:pricing-contract` — pass
- `corepack pnpm validate:data` — pass; all seven approved pairs retain pricing and 5/7+ gates
- `corepack pnpm report:data-quality` — pass; no structural regression
- `corepack pnpm exec tsc --noEmit` — Windows launcher-resolution failure only (`tsc` not found)
- `node node_modules/typescript/bin/tsc --noEmit` — pass using the documented repository-local fallback
- `corepack pnpm build` — pass

Changed files: 15.

Closes #121